### PR TITLE
Handle unknown commands properly

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -155,8 +155,7 @@ public class VelocityCommandManager implements CommandManager {
     Preconditions.checkNotNull(cmdLine, "cmdLine");
 
     String normalizedInput = BrigadierUtils.normalizeInput(cmdLine, true);
-    String[] args = normalizedInput.split(" ");
-    if (dispatcher.getRoot().getChild(args[0]) == null) {
+    if (dispatcher.getRoot().getChild(BrigadierUtils.getCommandName(normalizedInput)) == null) {
       return false;
     }
     ParseResults<CommandSource> results = dispatcher.parse(normalizedInput, source);
@@ -209,8 +208,7 @@ public class VelocityCommandManager implements CommandManager {
     Preconditions.checkNotNull(source, "source");
     Preconditions.checkNotNull(cmdLine, "cmdLine");
 
-    ParseResults<CommandSource> parse =
-        dispatcher.parse(BrigadierUtils.normalizeInput(cmdLine, false), source);
+    ParseResults<CommandSource> parse = dispatcher.parse(cmdLine, source);
     return dispatcher.getCompletionSuggestions(parse)
             .thenApply(suggestions -> Lists.transform(suggestions.getList(), Suggestion::getText));
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -208,7 +208,8 @@ public class VelocityCommandManager implements CommandManager {
     Preconditions.checkNotNull(source, "source");
     Preconditions.checkNotNull(cmdLine, "cmdLine");
 
-    ParseResults<CommandSource> parse = dispatcher.parse(cmdLine, source);
+    ParseResults<CommandSource> parse =
+        dispatcher.parse(BrigadierUtils.normalizeInput(cmdLine, false), source);
     return dispatcher.getCompletionSuggestions(parse)
             .thenApply(suggestions -> Lists.transform(suggestions.getList(), Suggestion::getText));
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/BrigadierUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/BrigadierUtils.java
@@ -100,9 +100,9 @@ public final class BrigadierUtils {
   public static String getCommandName(final String input) {
     int firstSpace = input.indexOf(' ');
     if (firstSpace == -1) {
-      return input;
+      return input.toLowerCase(Locale.ENGLISH);
     }
-    return input.substring(0, firstSpace);
+    return input.substring(0, firstSpace).toLowerCase(Locale.ENGLISH);
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/BrigadierUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/BrigadierUtils.java
@@ -92,6 +92,20 @@ public final class BrigadierUtils {
   }
 
   /**
+   * Returns the command name from the specified input.
+   *
+   * @param input command input
+   * @return command name from the specified input
+   */
+  public static String getCommandName(final String input) {
+    int firstSpace = input.indexOf(' ');
+    if (firstSpace == -1) {
+      return input;
+    }
+    return input.substring(0, firstSpace);
+  }
+
+  /**
    * Returns the splitted arguments of a command node built with
    * {@link #buildRawArgumentsLiteral(String, Command, SuggestionProvider)}.
    *


### PR DESCRIPTION
Previously, the check for unknown commands was done if a CommandSyntaxException with dispatcherUnknownCommand was thrown, which as expected, forwarded the command to the backend. This is a hacky way to handle unknown commands (and CommandSyntaxExceptions). My changes did it so it checks for a child first, so every CommandSyntaxException is sent as a message to the sender and only unknown commands to be forwarded to the server.