### PR TITLE
build: Fix search when generating Javadoc with broken java versions

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -93,9 +93,14 @@ javadoc {
 
     // Disable the crazy super-strict doclint tool in Java 8
     options.addStringOption('Xdoclint:none', '-quiet')
-    
+
     // Mark sources as Java 8 source compatible
     options.source = '8'
+
+    // Remove 'undefined' from seach paths when generating javadoc for a non-modular project (JDK-8215291)
+    if (JavaVersion.current() >= JavaVersion.VERSION_1_9 && JavaVersion.current() < JavaVersion.VERSION_12) {
+        options.addBooleanOption('-no-module-directories', true)
+    }
 }
 
 test {


### PR DESCRIPTION
This will fix Javadoc generated in the future. Existing Javadoc can be fixed manually, just replace:

```
var useModuleDirectories = true;
```
in each file's header with
```
var useModuleDirectories = false;
```

This bug was fixed for JDK 12 and the option was removed, so the application of the option is version-gated.