### PR TITLE
Expose proxy protocol setting in ProxyConfig

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
@@ -150,4 +150,11 @@ public interface ProxyConfig {
    * @return read timeout (in milliseconds)
    */
   int getReadTimeout();
+
+  /**
+   * Get whether HAProxy compatibility is enabled.
+   *
+   * @return proxy protocol enabled
+   */
+  boolean isProxyProtocol();
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -333,6 +333,7 @@ public class VelocityConfiguration implements ProxyConfig {
     return advanced.getReadTimeout();
   }
 
+  @Override
   public boolean isProxyProtocol() {
     return advanced.isProxyProtocol();
   }


### PR DESCRIPTION
Turns out people see `use-proxy-protocol` in our Geyser configuration and think it's required for proxy usage. This way we can auto-toggle our proxy protocol setting based on Velocity's.