### PR TITLE
WIP: Unix domain socket binding support

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -13,6 +13,7 @@ import com.velocitypowered.api.util.Favicon;
 import com.velocitypowered.proxy.util.AddressUtil;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.netty.channel.unix.DomainSocketAddress;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -337,6 +338,13 @@ public class VelocityConfiguration implements ProxyConfig {
     return advanced.isProxyProtocol();
   }
 
+  public @Nullable DomainSocketAddress getUnixSocket() {
+    if (advanced.unixSocket == null) {
+      return null;
+    }
+    return new DomainSocketAddress(advanced.unixSocket);
+  }
+
   public boolean useTcpFastOpen() {
     return advanced.tcpFastOpen;
   }
@@ -629,6 +637,7 @@ public class VelocityConfiguration implements ProxyConfig {
     @Expose private int connectionTimeout = 5000;
     @Expose private int readTimeout = 30000;
     @Expose private boolean proxyProtocol = false;
+    @Expose private @Nullable String unixSocket = null;
     @Expose private boolean tcpFastOpen = false;
     @Expose private boolean bungeePluginMessageChannel = true;
     @Expose private boolean showPingRequests = false;
@@ -651,6 +660,7 @@ public class VelocityConfiguration implements ProxyConfig {
         } else {
           this.proxyProtocol = config.getOrElse("proxy-protocol", false);
         }
+        this.unixSocket = config.get("unix-socket");
         this.tcpFastOpen = config.getOrElse("tcp-fast-open", false);
         this.bungeePluginMessageChannel = config.getOrElse("bungee-plugin-message-channel", true);
         this.showPingRequests = config.getOrElse("show-ping-requests", false);
@@ -718,6 +728,7 @@ public class VelocityConfiguration implements ProxyConfig {
           + ", connectionTimeout=" + connectionTimeout
           + ", readTimeout=" + readTimeout
           + ", proxyProtocol=" + proxyProtocol
+          + ", unixSocket=" + unixSocket
           + ", tcpFastOpen=" + tcpFastOpen
           + ", bungeePluginMessageChannel=" + bungeePluginMessageChannel
           + ", showPingRequests=" + showPingRequests

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -338,6 +338,11 @@ public class VelocityConfiguration implements ProxyConfig {
     return advanced.isProxyProtocol();
   }
 
+  /**
+   * Returns the Unix domain socket address to bind on.
+   *
+   * @return the domain socket address, or {@code null} if not specified
+   */
   public @Nullable DomainSocketAddress getUnixSocket() {
     if (advanced.unixSocket == null) {
       return null;

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -109,6 +109,11 @@ read-timeout = 30000
 # don't enable it.
 haproxy-protocol = false
 
+# What file-system path should the proxy be bound to? Specifying this option will disable
+# the default IP address binding. Unix domain sockets are only supported if the epoll transport
+# is available.
+#unix-socket = "/tmp/velocity.sock"
+
 # Enables TCP fast open support on the proxy. Requires the proxy to run on Linux.
 tcp-fast-open = false
 


### PR DESCRIPTION
A niche feature, but useful for upper-level proxies running on the same host, e.g. HAProxy (which Velocity already supports). I followed the Redis configuration convention, where the binding address and Unix domain socket address are different options. Mixing both types of sockets under the `bind` config would complicate determining if the given address is a hostname or a filename.