### PR TITLE
Add PlayerRegisterChannelEvent

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/player/PlayerChannelRegisterEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/PlayerChannelRegisterEvent.java
@@ -2,6 +2,7 @@ package com.velocitypowered.api.event.player;
 
 import com.google.common.base.Preconditions;
 import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 
 import java.util.List;
 
@@ -9,12 +10,12 @@ import java.util.List;
  * This event is fired when a client ({@link Player}) sends a plugin message through the
  * register channel.
  */
-public final class PlayerPluginMessageRegisterEvent {
+public final class PlayerChannelRegisterEvent {
 
   private final Player player;
-  private final List<String> channels;
+  private final List<ChannelIdentifier> channels;
 
-  public PlayerPluginMessageRegisterEvent(Player player, List<String> channels) {
+  public PlayerChannelRegisterEvent(Player player, List<ChannelIdentifier> channels) {
     this.player = Preconditions.checkNotNull(player, "player");
     this.channels = Preconditions.checkNotNull(channels, "channels");
   }
@@ -23,13 +24,13 @@ public final class PlayerPluginMessageRegisterEvent {
     return player;
   }
 
-  public List<String> getChannels() {
+  public List<ChannelIdentifier> getChannels() {
     return channels;
   }
 
   @Override
   public String toString() {
-    return "PlayerPluginMessageRegisterEvent{"
+    return "PlayerChannelRegisterEvent{"
             + "player=" + player
             + ", channels=" + channels
             + '}';

--- a/api/src/main/java/com/velocitypowered/api/event/player/PlayerPluginMessageRegisterEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/PlayerPluginMessageRegisterEvent.java
@@ -1,0 +1,37 @@
+package com.velocitypowered.api.event.player;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.proxy.Player;
+
+import java.util.List;
+
+/**
+ * This event is fired when a client ({@link Player}) sends a plugin message through the
+ * register channel.
+ */
+public final class PlayerPluginMessageRegisterEvent {
+
+  private final Player player;
+  private final List<String> channels;
+
+  public PlayerPluginMessageRegisterEvent(Player player, List<String> channels) {
+    this.player = Preconditions.checkNotNull(player, "player");
+    this.channels = Preconditions.checkNotNull(channels, "channels");
+  }
+
+  public Player getPlayer() {
+    return player;
+  }
+
+  public List<String> getChannels() {
+    return channels;
+  }
+
+  @Override
+  public String toString() {
+    return "PlayerPluginMessageRegisterEvent{"
+            + "player=" + player
+            + ", channels=" + channels
+            + '}';
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -8,6 +8,7 @@ import static com.velocitypowered.proxy.protocol.util.PluginMessageUtil.construc
 import com.velocitypowered.api.event.command.CommandExecuteEvent.CommandResult;
 import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.event.player.PlayerChatEvent;
+import com.velocitypowered.api.event.player.PlayerPluginMessageRegisterEvent;
 import com.velocitypowered.api.event.player.PlayerResourcePackStatusEvent;
 import com.velocitypowered.api.event.player.TabCompleteEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
@@ -190,7 +191,10 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
         logger.warn("A plugin message was received while the backend server was not "
             + "ready. Channel: {}. Packet discarded.", packet.getChannel());
       } else if (PluginMessageUtil.isRegister(packet)) {
-        player.getKnownChannels().addAll(PluginMessageUtil.getChannels(packet));
+        List<String> channels = PluginMessageUtil.getChannels(packet);
+        player.getKnownChannels().addAll(channels);
+        server.getEventManager().fireAndForget(new PlayerPluginMessageRegisterEvent(player,
+                channels));
         backendConn.write(packet.retain());
       } else if (PluginMessageUtil.isUnregister(packet)) {
         player.getKnownChannels().removeAll(PluginMessageUtil.getChannels(packet));


### PR DESCRIPTION
This event fires whenever a client sends a register plugin message, and provides plugins with the list of channels that the client has sent in that plugin message.