### PR TITLE
Suggestion Permissions

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/command/CommandNodeFactory.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/CommandNodeFactory.java
@@ -46,6 +46,10 @@ public interface CommandNodeFactory<T extends Command> {
         },
         (context, builder) -> {
           String[] args = BrigadierUtils.getSplitArguments(context);
+          if (!command.hasPermission(context.getSource(), args)) {
+              return builder.buildFuture();
+          }
+
           return command.suggestAsync(context.getSource(), args).thenApply(values -> {
             for (String value : values) {
               builder.suggest(value);

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/CommandNodeFactory.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/CommandNodeFactory.java
@@ -82,6 +82,9 @@ public interface CommandNodeFactory<T extends Command> {
           (context, builder) -> {
             I invocation = createInvocation(context);
 
+            if (!command.hasPermission(invocation)) {
+                return builder.buildFuture();
+            }
             return command.suggestAsync(invocation).thenApply(values -> {
               for (String value : values) {
                 builder.suggest(value);


### PR DESCRIPTION
When using Velocity on my Network my players could see all the backend servers. They could not connect, but they could just tab the /server command and get them suggested. Back then this hasn't really bothered me... But now I have private servers no normal player should know about.

I added a basic check for permissions when autocompleting commands. They command will show up, but they won't be able to autocomplete. I tried to remove the command too, but that would require some API changes since I cannot get a CommandContext in the predicate that will be provided in the `ArgumentBuilder#requires(Predicate<S>)` method. Without the CommandContext I cannot create an Invocation which is required by the InvocableCommand to check for permissions.
