### PR TITLE
Extend ConnectionHandshakeEvent

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/connection/ConnectionHandshakeEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/connection/ConnectionHandshakeEvent.java
@@ -3,28 +3,40 @@ package com.velocitypowered.api.event.connection;
 import com.google.common.base.Preconditions;
 import com.velocitypowered.api.event.ResultedEvent;
 import com.velocitypowered.api.proxy.InboundConnection;
+import java.util.Optional;
+import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import javax.annotation.Nullable;
-import java.util.Optional;
-
 /**
  * This event is fired when a handshake is established between a client and the proxy.
  */
-public final class ConnectionHandshakeEvent implements ResultedEvent<ConnectionHandshakeEvent.ConnectionHandshakeComponentResult> {
+public final class ConnectionHandshakeEvent
+        implements ResultedEvent<ConnectionHandshakeEvent.ConnectionHandshakeComponentResult> {
 
   private final InboundConnection connection;
   private ConnectionHandshakeComponentResult result;
   private String newSocketAddressHostname;
   private String hostname;
 
+  /**
+   * Constructs a {@code ConnectionHandshakeEvent}.
+   *
+   * @param connection the connection
+   * @deprecated in favor of {@link #ConnectionHandshakeEvent(InboundConnection, String)}
+   */
   @Deprecated
   public ConnectionHandshakeEvent(InboundConnection connection) {
     this(connection, "127.0.0.1");
   }
 
+  /**
+   * Constructs a {@code ConnectionHandshakeEvent}.
+   *
+   * @param connection the connection
+   * @param hostname the handshake hostname
+   */
   public ConnectionHandshakeEvent(InboundConnection connection, @NonNull String hostname) {
     this.connection = Preconditions.checkNotNull(connection, "connection");
     this.hostname = Preconditions.checkNotNull(hostname, "serverHostname");
@@ -122,12 +134,15 @@ public final class ConnectionHandshakeEvent implements ResultedEvent<ConnectionH
   }
 
   /**
+   * Represents an "allowed/denied" result with a (nullable) reason for denial.
+   *
    * @implNote We don't use {@link com.velocitypowered.api.event.ResultedEvent.ComponentResult} as
    *     it doesn't allow for a {@code null} component result on deny.
    */
   public static final class ConnectionHandshakeComponentResult implements ResultedEvent.Result {
 
-    private static final ConnectionHandshakeComponentResult ALLOWED = new ConnectionHandshakeComponentResult(true, null);
+    private static final ConnectionHandshakeComponentResult ALLOWED
+            = new ConnectionHandshakeComponentResult(true, null);
 
     private final boolean status;
     private final @Nullable Component reason;

--- a/api/src/main/java/com/velocitypowered/api/event/connection/ConnectionHandshakeEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/connection/ConnectionHandshakeEvent.java
@@ -1,27 +1,190 @@
 package com.velocitypowered.api.event.connection;
 
 import com.google.common.base.Preconditions;
+import com.velocitypowered.api.event.ResultedEvent;
 import com.velocitypowered.api.proxy.InboundConnection;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
 
 /**
  * This event is fired when a handshake is established between a client and the proxy.
  */
-public final class ConnectionHandshakeEvent {
+public final class ConnectionHandshakeEvent implements ResultedEvent<ConnectionHandshakeEvent.ConnectionHandshakeComponentResult> {
 
   private final InboundConnection connection;
+  private ConnectionHandshakeComponentResult result;
+  private String newSocketAddressHostname;
+  private String hostname;
 
+  @Deprecated
   public ConnectionHandshakeEvent(InboundConnection connection) {
+    this(connection, "127.0.0.1");
+  }
+
+  public ConnectionHandshakeEvent(InboundConnection connection, @NonNull String hostname) {
     this.connection = Preconditions.checkNotNull(connection, "connection");
+    this.hostname = Preconditions.checkNotNull(hostname, "serverHostname");
+    this.result = ConnectionHandshakeComponentResult.allowed();
   }
 
   public InboundConnection getConnection() {
     return connection;
   }
 
+  /**
+   * Sets the new handshake hostname. Keep in mind we will run a cleanup of the specified hostname
+   * after it (removing SRV record points, removing everything after {@code \0}, ...)
+   *
+   * @param hostname the new handshake hostname
+   * @see #getHostname()
+   */
+  public void setHostname(@NonNull String hostname) {
+    this.hostname = hostname;
+  }
+
+  /**
+   * Returns the handshake hostname.
+   *
+   * @return the handshake hostname
+   * @see #setHostname(String)
+   */
+  @NonNull
+  public String getHostname() {
+    return hostname;
+  }
+
+  /**
+   * Sets the socket address hostname (without the port) of the player.
+   *
+   * <p>This essentially changes the IP to the one specified.
+   *
+   * <p>We expect you to provide a *resolved* IP address!
+   *
+   * @param newSocketAddressHostname the new hostname of the socket address
+   * @see #getNewSocketAddressHostname()
+   */
+  public void setNewSocketAddressHostname(String newSocketAddressHostname) {
+    this.newSocketAddressHostname = newSocketAddressHostname;
+  }
+
+  /**
+   * Returns the set hostname of the player's socket address.
+   *
+   * <p>This returns {@code null} if the socket address wasn't previously set by {@link
+   * #setNewSocketAddressHostname(String)}.
+   *
+   * @return the hostname of the set socket address
+   * @see #setNewSocketAddressHostname(String)
+   */
+  @Nullable
+  public String getNewSocketAddressHostname() {
+    return newSocketAddressHostname;
+  }
+
+  /**
+   * Returns the result of the event.
+   *
+   * @return the result
+   * @see #setResult(ConnectionHandshakeComponentResult)
+   */
+  @Override
+  public ConnectionHandshakeComponentResult getResult() {
+    return result;
+  }
+
+  /**
+   * Sets the result of the event. If the {@code result} is denied, the player will disconnect with
+   * the specified reason.
+   *
+   * <p>If the specified reason is {@code null}, the socket will be closed without a disconnect
+   * message.
+   *
+   * @param result the new result
+   * @see #getResult()
+   */
+  @Override
+  public void setResult(ConnectionHandshakeComponentResult result) {
+    this.result = result;
+  }
+
   @Override
   public String toString() {
     return "ConnectionHandshakeEvent{"
         + "connection=" + connection
+        + ", result=" + result
+        + ", newSocketAddressHostname='" + newSocketAddressHostname + '\''
+        + ", hostname='" + hostname + '\''
         + '}';
+  }
+
+  /**
+   * @implNote We don't use {@link com.velocitypowered.api.event.ResultedEvent.ComponentResult} as
+   *     it doesn't allow for a {@code null} component result on deny.
+   */
+  public static final class ConnectionHandshakeComponentResult implements ResultedEvent.Result {
+
+    private static final ConnectionHandshakeComponentResult ALLOWED = new ConnectionHandshakeComponentResult(true, null);
+
+    private final boolean status;
+    private final @Nullable Component reason;
+
+    private ConnectionHandshakeComponentResult(boolean status, @Nullable Component reason) {
+      this.status = status;
+      this.reason = reason;
+    }
+
+    @Override
+    public boolean isAllowed() {
+      return status;
+    }
+
+    public Optional<Component> getReason() {
+      return Optional.ofNullable(reason);
+    }
+
+    @Override
+    public String toString() {
+      if (status) {
+        return "allowed";
+      }
+      if (reason != null) {
+        return "denied: " + PlainComponentSerializer.plain().serialize(reason);
+      }
+      return "denied";
+    }
+
+    /**
+     * Returns a result indicating the connection will be allowed.
+     *
+     * @return the allowed result
+     */
+    public static ConnectionHandshakeComponentResult allowed() {
+      return ALLOWED;
+    }
+
+    /**
+     * Returns a result indicating the connection will be denied with no kick reason provided.
+     *
+     * @return the denied result
+     * @see #denied(Component)
+     */
+    public static ConnectionHandshakeComponentResult denied() {
+      return denied(null);
+    }
+
+    /**
+     * Returns a result indicating the connection will be denied with the specified kick reason.
+     *
+     * @param reason the reason for disallowing the connection, can be {@code null}
+     * @return the denied result
+     * @see #denied()
+     */
+    public static ConnectionHandshakeComponentResult denied(@Nullable Component reason) {
+      return new ConnectionHandshakeComponentResult(false, reason);
+    }
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -280,6 +280,10 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
     return !channel.isActive();
   }
 
+  public void setRemoteAddress(SocketAddress remoteAddress) {
+    this.remoteAddress = remoteAddress;
+  }
+
   public SocketAddress getRemoteAddress() {
     return remoteAddress;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -154,9 +154,11 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
               }
 
               // if the socket address is changed, propagate the change
-              if (handshakeEvent.getNewSocketAddressHostname() != null) {
+              String newSocketAddress = handshakeEvent.getNewSocketAddressHostname();
+              if (newSocketAddress != null) {
                 // Using #createUnresolved is important as a reverse lookup is expensive
-                InetSocketAddress newAddress = InetSocketAddress.createUnresolved(handshakeEvent.getNewSocketAddressHostname(), handshake.getPort());
+                InetSocketAddress newAddress
+                        = InetSocketAddress.createUnresolved(newSocketAddress, handshake.getPort());
                 ic.getConnection().setRemoteAddress(newAddress);
               }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialInboundConnection.java
@@ -19,8 +19,8 @@ public final class InitialInboundConnection implements InboundConnection,
   private static final Logger logger = LogManager.getLogger(InitialInboundConnection.class);
 
   private final MinecraftConnection connection;
-  private final String cleanedAddress;
   private final Handshake handshake;
+  private String cleanedAddress;
 
   InitialInboundConnection(MinecraftConnection connection, String cleanedAddress,
       Handshake handshake) {
@@ -52,6 +52,14 @@ public final class InitialInboundConnection implements InboundConnection,
   @Override
   public String toString() {
     return "[initial connection] " + connection.getRemoteAddress().toString();
+  }
+
+  public MinecraftConnection getConnection() {
+    return connection;
+  }
+
+  public void setCleanedAddress(String cleanedAddress) {
+    this.cleanedAddress = cleanedAddress;
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR extends the `ConnectionHandshakeEvent` for it to include methods to set the hostname of the handshake and to set the remote address (the IP). It also allows denying the event.

## Motivation
Currently, there's no way to access this information without at least some kind of Reflection. This is not only hard-to-write and hard-to-read code but also code which is not future-proof at all. Internal changes in Velocity might affect the functionality of some plugins which **depend** on modifying internal fields.

There are several use-cases for this kind of extension:
* IP bans / blocks in an earlier state of connection
* DDoS mitigation solutions like TCPShield 
* Other services which inject data into the `hostname` field of the packet (e.g. Geyser although they've changed their procedure for Floodgate 2.0 so this PR probably wouldn't affect them)

## Prior art
From a proxy side of things, there is currently no proxy software supporting an equal use-case. From a Minecraft server side of things though, there is Paper's [`PlayerHandshakeEvent`](https://papermc.io/javadocs/paper/1.16/com/destroystokyo/paper/event/player/PlayerHandshakeEvent.html) which includes everything added by this PR.

## Drawbacks
Previously, `ConnectionHandshakeEvent` would not block the connection flow. After this change, `connection#setSessionHandler()` will only be invoked **after** the event is handled. This could lead, depending on the listeners, to unexpected behavior. 

## Alternatives
1. keep on using Reflection
2. using a more specialized event for this kind of usage (e.g. `ExtendedConnectionHandshakeEvent`) so we don't change the current behavior