### PR TITLE
Add 1.16.5

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -42,7 +42,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_2(751, "1.16.2"),
   MINECRAFT_1_16_3(753, "1.16.3"),
   MINECRAFT_1_16_4(754, "1.16.4"),
-  MINECRAFT_1_16_4(754, "1.16.5");
+  MINECRAFT_1_16_5(754, "1.16.5");
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -41,7 +41,8 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_1(736, "1.16.1"),
   MINECRAFT_1_16_2(751, "1.16.2"),
   MINECRAFT_1_16_3(753, "1.16.3"),
-  MINECRAFT_1_16_4(754, "1.16.4");
+  MINECRAFT_1_16_4(754, "1.16.4"),
+  MINECRAFT_1_16_4(754, "1.16.5");
 
   private static final int SNAPSHOT_BIT = 30;
 


### PR DESCRIPTION
This is frankly not a major update, and is even unnecessary, but at least showing server status through minecraft or whatever, showing that 1.16.5 is supported won't hurt. Especially since not everyone knows that 1.16.4 and 1.16.5 are identical in terms of the connection protocol.