### PR TITLE
Change version-name logic

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -1,9 +1,11 @@
 package com.velocitypowered.api.network;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -13,16 +15,19 @@ import java.util.Set;
 public enum ProtocolVersion {
   UNKNOWN(-1, "Unknown"),
   LEGACY(-2, "Legacy"),
-  MINECRAFT_1_7_2(4, "1.7.2"),
-  MINECRAFT_1_7_6(5, "1.7.6"),
-  MINECRAFT_1_8(47, "1.8"),
+  MINECRAFT_1_7_2(4,
+          "1.7.2", "1.7.3", "1.7.4", "1.7.5"),
+  MINECRAFT_1_7_6(5,
+          "1.7.6", "1.7.7", "1.7.8", "1.7.9", "1.7.10"),
+  MINECRAFT_1_8(47,
+          "1.8", "1.8.1", "1.8.2", "1.8.3", "1.8.4", "1.8.5", "1.8.6", "1.8.7", "1.8.8", "1.8.9"),
   MINECRAFT_1_9(107, "1.9"),
   MINECRAFT_1_9_1(108, "1.9.1"),
   MINECRAFT_1_9_2(109, "1.9.2"),
-  MINECRAFT_1_9_4(110, "1.9.4"),
-  MINECRAFT_1_10(210, "1.10"),
+  MINECRAFT_1_9_4(110, "1.9.3", "1.9.4"),
+  MINECRAFT_1_10(210, "1.10", "1.10.1", "1.10.2"),
   MINECRAFT_1_11(315, "1.11"),
-  MINECRAFT_1_11_1(316, "1.11.1"),
+  MINECRAFT_1_11_1(316, "1.11.1", "1.11.2"),
   MINECRAFT_1_12(335, "1.12"),
   MINECRAFT_1_12_1(338, "1.12.1"),
   MINECRAFT_1_12_2(340, "1.12.2"),
@@ -41,13 +46,13 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_1(736, "1.16.1"),
   MINECRAFT_1_16_2(751, "1.16.2"),
   MINECRAFT_1_16_3(753, "1.16.3"),
-  MINECRAFT_1_16_4(754, "1.16.4");
+  MINECRAFT_1_16_4(754, "1.16.4", "1.16.5");
 
   private static final int SNAPSHOT_BIT = 30;
 
   private final int protocol;
   private final int snapshotProtocol;
-  private final String name;
+  private final String[] name;
 
   /**
    * Represents the lowest supported version.
@@ -62,7 +67,8 @@ public enum ProtocolVersion {
    * The user-friendly representation of the lowest and highest supported versions.
    */
   public static final String SUPPORTED_VERSION_STRING = String
-      .format("%s-%s", MINIMUM_VERSION, MAXIMUM_VERSION);
+          .format("%s-%s", MINIMUM_VERSION.getVersionIntroducedIn(),
+                  MAXIMUM_VERSION.getVersionDiscontinuedIn());
 
   /**
    * A map linking the protocol version number to its {@link ProtocolVersion} representation.
@@ -101,11 +107,11 @@ public enum ProtocolVersion {
     SUPPORTED_VERSIONS = Sets.immutableEnumSet(versions);
   }
 
-  ProtocolVersion(int protocol, String name) {
+  ProtocolVersion(int protocol, String... name) {
     this(protocol, -1, name);
   }
 
-  ProtocolVersion(int protocol, int snapshotProtocol, String name) {
+  ProtocolVersion(int protocol, int snapshotProtocol, String... name) {
     if (snapshotProtocol != -1) {
       this.snapshotProtocol = (1 << SNAPSHOT_BIT) | snapshotProtocol;
     } else {
@@ -129,9 +135,41 @@ public enum ProtocolVersion {
    * Returns the user-friendly name for this protocol.
    *
    * @return the protocol name
+   * @deprecated A protocol may be shared by multiple versions. Use @link{#getVersionIntroducedIn()}
+   *     or @link{#getVersionsSupportedBy()} to get more accurate version names.
    */
+  @Deprecated
   public String getName() {
-    return name;
+    return getVersionIntroducedIn();
+  }
+
+  /**
+   * Returns the user-friendly name of the version
+   * this protocol was introduced in.
+   *
+   * @return the version name
+   */
+  public String getVersionIntroducedIn() {
+    return name[0];
+  }
+
+  /**
+   * Returns the user-friendly name of the last
+   * version this protocol is valid for.
+   *
+   * @return the version name
+   */
+  public String getVersionDiscontinuedIn() {
+    return name[name.length - 1];
+  }
+
+  /**
+   * Returns all versions this protocol is valid for.
+   *
+   * @return the version names
+   */
+  public List<String> getVersionsSupportedBy() {
+    return ImmutableList.copyOf(name);
   }
 
   /**
@@ -186,6 +224,6 @@ public enum ProtocolVersion {
 
   @Override
   public String toString() {
-    return name;
+    return name[name.length - 1];
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -52,7 +52,7 @@ public enum ProtocolVersion {
 
   private final int protocol;
   private final int snapshotProtocol;
-  private final String[] name;
+  private final String[] names;
 
   /**
    * Represents the lowest supported version.
@@ -107,11 +107,11 @@ public enum ProtocolVersion {
     SUPPORTED_VERSIONS = Sets.immutableEnumSet(versions);
   }
 
-  ProtocolVersion(int protocol, String... name) {
-    this(protocol, -1, name);
+  ProtocolVersion(int protocol, String... names) {
+    this(protocol, -1, names);
   }
 
-  ProtocolVersion(int protocol, int snapshotProtocol, String... name) {
+  ProtocolVersion(int protocol, int snapshotProtocol, String... names) {
     if (snapshotProtocol != -1) {
       this.snapshotProtocol = (1 << SNAPSHOT_BIT) | snapshotProtocol;
     } else {
@@ -119,7 +119,7 @@ public enum ProtocolVersion {
     }
 
     this.protocol = protocol;
-    this.name = name;
+    this.names = names;
   }
 
   /**
@@ -150,7 +150,7 @@ public enum ProtocolVersion {
    * @return the version name
    */
   public String getVersionIntroducedIn() {
-    return name[0];
+    return names[0];
   }
 
   /**
@@ -160,7 +160,7 @@ public enum ProtocolVersion {
    * @return the version name
    */
   public String getMostRecentSupportedVersion() {
-    return name[name.length - 1];
+    return names[names.length - 1];
   }
 
   /**
@@ -169,7 +169,7 @@ public enum ProtocolVersion {
    * @return the version names
    */
   public List<String> getVersionsSupportedBy() {
-    return ImmutableList.copyOf(name);
+    return ImmutableList.copyOf(names);
   }
 
   /**
@@ -224,6 +224,6 @@ public enum ProtocolVersion {
 
   @Override
   public String toString() {
-    return name[name.length - 1];
+    return getVersionIntroducedIn();
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -68,7 +68,7 @@ public enum ProtocolVersion {
    */
   public static final String SUPPORTED_VERSION_STRING = String
           .format("%s-%s", MINIMUM_VERSION.getVersionIntroducedIn(),
-                  MAXIMUM_VERSION.getVersionDiscontinuedIn());
+                  MAXIMUM_VERSION.getMostRecentSupportedVersion());
 
   /**
    * A map linking the protocol version number to its {@link ProtocolVersion} representation.
@@ -159,7 +159,7 @@ public enum ProtocolVersion {
    *
    * @return the version name
    */
-  public String getVersionDiscontinuedIn() {
+  public String getMostRecentSupportedVersion() {
     return name[name.length - 1];
   }
 


### PR DESCRIPTION
These changes are to more accurately reflect the Minecraft protocol and the versions associated with them.
Amends #437