### PR TITLE
Add Duration-accepting methods to TaskBuilder

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/scheduler/Scheduler.java
+++ b/api/src/main/java/com/velocitypowered/api/scheduler/Scheduler.java
@@ -1,5 +1,6 @@
 package com.velocitypowered.api.scheduler;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.checkerframework.common.value.qual.IntRange;
 
@@ -32,6 +33,16 @@ public interface Scheduler {
     TaskBuilder delay(@IntRange(from = 0) long time, TimeUnit unit);
 
     /**
+     * Specifies that the task should delay its execution by the specified amount of time.
+     *
+     * @param duration the duration of the delay
+     * @return this builder, for chaining
+     */
+    default TaskBuilder delay(Duration duration) {
+      return delay(duration.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    /**
      * Specifies that the task should continue running after waiting for the specified amount, until
      * it is cancelled.
      *
@@ -40,6 +51,17 @@ public interface Scheduler {
      * @return this builder, for chaining
      */
     TaskBuilder repeat(@IntRange(from = 0) long time, TimeUnit unit);
+
+    /**
+     * Specifies that the task should continue running after waiting for the specified amount, until
+     * it is cancelled.
+     *
+     * @param duration the duration of the delay
+     * @return this builder, for chaining
+     */
+    default TaskBuilder repeat(Duration duration) {
+      return repeat(duration.toMillis(), TimeUnit.MILLISECONDS);
+    }
 
     /**
      * Clears the delay on this task.


### PR DESCRIPTION
Using Duration is slightly more readable than a long + TimeUnit as it co-locates the time interval and the unit.

```java
scheduler.buildTask(plugin, () -> {}).repeat(Duration.ofMinutes(1L)).delay(Duration.ofSeconds(10L)).schedule();
```

This API addition would require a minor version bump.