### PR TITLE
Relay more exceptions

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -86,7 +86,7 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
     server.getEventManager()
         .fire(new ServerConnectedEvent(player, serverConn.getServer(),
             existingConnection != null ? existingConnection.getServer() : null))
-        .whenCompleteAsync((x, error) -> {
+        .thenRunAsync(() -> {
           // Make sure we can still transition (player might have disconnected here).
           if (!serverConn.isActive()) {
             // Connection is obsolete.

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/GS4QueryHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/GS4QueryHandler.java
@@ -134,7 +134,7 @@ public class GS4QueryHandler extends SimpleChannelInboundHandler<DatagramPacket>
         // Call event and write response
         server.getEventManager()
             .fire(new ProxyQueryEvent(isBasic ? BASIC : FULL, senderAddress, response))
-            .whenCompleteAsync((event, exc) -> {
+            .thenAcceptAsync((event) -> {
               // Packet header
               ByteBuf queryResponse = ctx.alloc().buffer();
               queryResponse.writeByte(QUERY_TYPE_STAT);


### PR DESCRIPTION
I've found some minor places where it looks like exceptions are not carried through.

Using `whenCompleteAsync`, if an exception occurs, that exception is the `ex` parameter. Using `thenAcceptAsync` or `thenRunAsync`, if an exception occurs, it is relayed to the returned future and the callback is not invoked.

Note that these changes alter the behavior of the code in question when an exception occurs - where previously the exception would be ignored, now the exception is re-thrown (really, the equivalent of re-throwing for a CompletableFuture)

The only change I'm not entirely sure about is ConnectedPlayer.ConnectionRequestBuilderImpl#connect. I decided to log the exception instead of using `handleConnectionException`