### PR TITLE
Make the logging of server connections configurable

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -368,6 +368,10 @@ public class VelocityConfiguration implements ProxyConfig {
     return advanced.isLogCommandExecutions();
   }
 
+  public boolean isLogServerConnections() {
+    return advanced.isLogServerConnections();
+  }
+
   public Messages getMessages() {
     return messages;
   }
@@ -629,6 +633,7 @@ public class VelocityConfiguration implements ProxyConfig {
     @Expose private boolean failoverOnUnexpectedServerDisconnect = true;
     @Expose private boolean announceProxyCommands = true;
     @Expose private boolean logCommandExecutions = false;
+    @Expose private boolean logServerConnections = true;
 
     private Advanced() {
     }
@@ -652,6 +657,7 @@ public class VelocityConfiguration implements ProxyConfig {
             .getOrElse("failover-on-unexpected-server-disconnect", true);
         this.announceProxyCommands = config.getOrElse("announce-proxy-commands", true);
         this.logCommandExecutions = config.getOrElse("log-command-executions", false);
+        this.logServerConnections = config.getOrElse("log-server-connections", true);
       }
     }
 
@@ -703,6 +709,10 @@ public class VelocityConfiguration implements ProxyConfig {
       return logCommandExecutions;
     }
 
+    public boolean isLogServerConnections() {
+      return logServerConnections;
+    }
+
     @Override
     public String toString() {
       return "Advanced{"
@@ -718,6 +728,7 @@ public class VelocityConfiguration implements ProxyConfig {
           + ", failoverOnUnexpectedServerDisconnect=" + failoverOnUnexpectedServerDisconnect
           + ", announceProxyCommands=" + announceProxyCommands
           + ", logCommandExecutions=" + logCommandExecutions
+          + ", logServerConnections=" + logServerConnections
           + '}';
     }
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -16,6 +16,7 @@ import com.velocitypowered.natives.encryption.VelocityCipher;
 import com.velocitypowered.natives.encryption.VelocityCipherFactory;
 import com.velocitypowered.natives.util.Natives;
 import com.velocitypowered.proxy.VelocityServer;
+import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
 import com.velocitypowered.proxy.connection.client.HandshakeSessionHandler;
 import com.velocitypowered.proxy.connection.client.LoginSessionHandler;
 import com.velocitypowered.proxy.connection.client.StatusSessionHandler;
@@ -84,6 +85,11 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
     }
 
     if (association != null) {
+      // Check if server connections can be logged
+      if (association instanceof VelocityServerConnection
+              && !server.getConfiguration().isLogServerConnections()) {
+        return;
+      }
       logger.info("{} has connected", association);
     }
   }
@@ -96,6 +102,11 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
 
     if (association != null && !knownDisconnect
         && !(sessionHandler instanceof StatusSessionHandler)) {
+      // Check if server connections can be logged
+      if (association instanceof VelocityServerConnection
+              && !server.getConfiguration().isLogServerConnections()) {
+        return;
+      }
       logger.info("{} has disconnected", association);
     }
   }

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -130,6 +130,10 @@ announce-proxy-commands = true
 # Enables the logging of commands
 log-command-executions = false
 
+# Enables the logging of server connections. By default, Velocity will log clients attempting to switch between servers.
+# Disable this if you think it clutters your logs too much.
+log-server-connections = true
+
 [query]
 # Whether to enable responding to GameSpy 4 query responses or not.
 enabled = false


### PR DESCRIPTION
Makes the logging of server connections (`[server connection] Player -> SERVER has (dis)connected`) configurable.

I think `MinecraftConnection` can only handle `VelocityServerConnection`s, but I added an instance check anyway.