### PR TITLE
Add a display name attribute for Player

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -31,6 +31,19 @@ public interface Player extends CommandSource, Identified, InboundConnection,
    */
   String getUsername();
 
+  /**
+   * Sets the player's display name.
+   *
+   * @param displayName the display name as a {@link Component}
+   */
+  void setDisplayNameComponent(Component displayName);
+
+  /**
+   * Returns the player's current display name as a {@link Component}.
+   *
+   * @return the display name
+   */
+  Component getDisplayNameComponent();
 
   /**
    * Returns the player's UUID.

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -36,14 +36,14 @@ public interface Player extends CommandSource, Identified, InboundConnection,
    *
    * @param displayName the display name as a {@link Component}
    */
-  void setDisplayNameComponent(Component displayName);
+  void setDisplayName(Component displayName);
 
   /**
    * Returns the player's current display name as a {@link Component}.
    *
    * @return the display name
    */
-  Component getDisplayNameComponent();
+  Component getDisplayName();
 
   /**
    * Returns the player's UUID.

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -99,6 +99,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   private final MinecraftConnection connection;
   private final @Nullable InetSocketAddress virtualHost;
   private GameProfile profile;
+  private Component displayName;
   private PermissionFunction permissionFunction;
   private int tryIndex = 0;
   private long ping = -1;
@@ -120,6 +121,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
       @Nullable InetSocketAddress virtualHost, boolean onlineMode) {
     this.server = server;
     this.profile = profile;
+    this.displayName = Component.text(profile.getName());
     this.connection = connection;
     this.virtualHost = virtualHost;
     this.permissionFunction = PermissionFunction.ALWAYS_UNDEFINED;
@@ -142,6 +144,16 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   @Override
   public String getUsername() {
     return profile.getName();
+  }
+
+  @Override
+  public void setDisplayNameComponent(Component displayName) {
+    this.displayName = displayName;
+  }
+
+  @Override
+  public Component getDisplayNameComponent() {
+    return displayName;
   }
 
   @Override
@@ -405,6 +417,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   @Override
   public void setGameProfileProperties(List<GameProfile.Property> properties) {
     this.profile = profile.withProperties(Preconditions.checkNotNull(properties));
+    this.displayName = Component.text(profile.getName());
   }
 
   @Deprecated

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -417,7 +417,6 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   @Override
   public void setGameProfileProperties(List<GameProfile.Property> properties) {
     this.profile = profile.withProperties(Preconditions.checkNotNull(properties));
-    this.displayName = Component.text(profile.getName());
   }
 
   @Deprecated

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -147,12 +147,12 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   }
 
   @Override
-  public void setDisplayNameComponent(Component displayName) {
+  public void setDisplayName(Component displayName) {
     this.displayName = displayName;
   }
 
   @Override
-  public Component getDisplayNameComponent() {
+  public Component getDisplayName() {
     return displayName;
   }
 


### PR DESCRIPTION
This pr adds a display name attribute to the Player interface, much like what spigot and bungeecord have. Although not used from within velocity, this could be useful to standardize name customization across plugins. For example, a chat plugin might have a nickname feature, and a tablist plugin should respect that nickname.
Currently I have the display name as a Component, with no functions for legacy text serialization. My understanding is that legacy text is being phased out in favour of Components, so that shouldn't be a problem.