### PR TITLE
Bump guice to 5.0.1 to prevent issues with java 16

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     }
 
     api "org.slf4j:slf4j-api:${slf4jVersion}"
-    api 'com.google.inject:guice:4.2.3'
+    api 'com.google.inject:guice:5.0.1'
     api "org.checkerframework:checker-qual:${checkerFrameworkVersion}"
     api 'com.velocitypowered:velocity-brigadier:1.0.0-SNAPSHOT'
 


### PR DESCRIPTION
As java released the latest version 16 there was an issue introduced into velocity because of using an older version of guice the proxy was unable to create plugin instances failing with:
```
Caused by: com.google.inject.internal.cglib.core.$CodeGenerationException: java.lang.reflect.InaccessibleObjectException-->Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @73a1e9a9
```

Updating guice to the latest release 5.0.1 solves the issue.