### PR TITLE
Fix ambiguous newFileSystem method when using Java 13.

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/util/FileSystemUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/FileSystemUtils.java
@@ -48,7 +48,7 @@ public class FileSystemUtils {
         .getProtectionDomain().getCodeSource().getLocation().getPath());
 
     if (file.isFile()) { // jar
-      try (FileSystem fileSystem = FileSystems.newFileSystem(file.toPath(), null)) {
+      try (FileSystem fileSystem = FileSystems.newFileSystem(file.toPath(), (ClassLoader) null)) {
         Path toVisit = fileSystem.getPath(path.toString());
         if (Files.exists(toVisit)) {
           consumer.accept(toVisit);


### PR DESCRIPTION
"both method newFileSystem(Path,ClassLoader) in FileSystems and method newFileSystem(Path,Map<String,?>) in FileSystems match"

when compiling in IntelliJ using JDK 13