### PR TITLE
Ignore empty server packets

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
@@ -19,6 +19,8 @@ package com.velocitypowered.proxy.protocol.netty;
 
 import com.google.common.base.Preconditions;
 import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.connection.MinecraftConnection;
+import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.StateRegistry;
@@ -62,7 +64,8 @@ public class MinecraftDecoder extends ChannelInboundHandlerAdapter {
   }
 
   private void tryDecode(ChannelHandlerContext ctx, ByteBuf buf) throws Exception {
-    if (!ctx.channel().isActive()) {
+    if (!ctx.channel().isActive() || buf.readableBytes() == 0 && ctx.pipeline().get(MinecraftConnection.class) != null
+            && ctx.pipeline().get(MinecraftConnection.class).getAssociation() instanceof VelocityServerConnection) {
       buf.release();
       return;
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
@@ -64,8 +64,8 @@ public class MinecraftDecoder extends ChannelInboundHandlerAdapter {
   }
 
   private void tryDecode(ChannelHandlerContext ctx, ByteBuf buf) throws Exception {
-    if (!ctx.channel().isActive() || buf.readableBytes() == 0 && ctx.pipeline().get(MinecraftConnection.class) != null
-            && ctx.pipeline().get(MinecraftConnection.class).getAssociation() instanceof VelocityServerConnection) {
+    if (!ctx.channel().isActive() || (buf.readableBytes() == 0 && ctx.pipeline().get(MinecraftConnection.class) != null
+            && ctx.pipeline().get(MinecraftConnection.class).getAssociation() instanceof VelocityServerConnection)) {
       buf.release();
       return;
     }


### PR DESCRIPTION
A fix similar to [this](https://github.com/PaperMC/Waterfall/commit/c19c4771deb96ad88e01781674d7d716dd10d3c0). 1.12 players are sometimes receiving empty packets from the server, these should be discarded, but empty packets from the client will still throw an exception.