### PR TITLE
Further packet handling performance improvements

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -36,12 +36,13 @@ import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.client.HandshakeSessionHandler;
 import com.velocitypowered.proxy.connection.client.LoginSessionHandler;
 import com.velocitypowered.proxy.connection.client.StatusSessionHandler;
+import com.velocitypowered.proxy.network.Connections;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.netty.MinecraftCipherDecoder;
 import com.velocitypowered.proxy.protocol.netty.MinecraftCipherEncoder;
 import com.velocitypowered.proxy.protocol.netty.MinecraftCompressDecoder;
-import com.velocitypowered.proxy.protocol.netty.MinecraftCompressEncoder;
+import com.velocitypowered.proxy.protocol.netty.MinecraftCompressorAndLengthEncoder;
 import com.velocitypowered.proxy.protocol.netty.MinecraftDecoder;
 import com.velocitypowered.proxy.protocol.netty.MinecraftEncoder;
 import com.velocitypowered.proxy.util.except.QuietDecoderException;
@@ -402,8 +403,8 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
     } else {
       MinecraftCompressDecoder decoder = (MinecraftCompressDecoder) channel.pipeline()
           .get(COMPRESSION_DECODER);
-      MinecraftCompressEncoder encoder = (MinecraftCompressEncoder) channel.pipeline()
-          .get(COMPRESSION_ENCODER);
+      MinecraftCompressorAndLengthEncoder encoder =
+          (MinecraftCompressorAndLengthEncoder) channel.pipeline().get(COMPRESSION_ENCODER);
       if (decoder != null && encoder != null) {
         decoder.setThreshold(threshold);
         encoder.setThreshold(threshold);
@@ -411,9 +412,10 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
         int level = server.getConfiguration().getCompressionLevel();
         VelocityCompressor compressor = Natives.compress.get().create(level);
 
-        encoder = new MinecraftCompressEncoder(threshold, compressor);
+        encoder = new MinecraftCompressorAndLengthEncoder(threshold, compressor);
         decoder = new MinecraftCompressDecoder(threshold, compressor);
 
+        channel.pipeline().remove(FRAME_ENCODER);
         channel.pipeline().addBefore(MINECRAFT_DECODER, COMPRESSION_DECODER, decoder);
         channel.pipeline().addBefore(MINECRAFT_ENCODER, COMPRESSION_ENCODER, encoder);
       }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
@@ -147,6 +147,16 @@ public enum ProtocolUtils {
     }
   }
 
+  /**
+   * Writes all integers as 3 bytes Minecraft-style VarInt to the specified {@code buf}.
+   * @param buf the buffer to read from
+   * @param value the integer to write
+   */
+  public static void writeVarIntAs3Bytes(ByteBuf buf, int value) {
+    int w = (value & 0x7F | 0x80) << 16 | ((value >>> 7) & 0x7F | 0x80) << 8 | (value >>> 14);
+    buf.writeMedium(w);
+  }
+
   public static String readString(ByteBuf buf) {
     return readString(buf, DEFAULT_MAX_STRING_SIZE);
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
@@ -148,7 +148,7 @@ public enum ProtocolUtils {
       buf.writeInt(w);
     } else {
       int w = (value & 0x7F | 0x80) << 24 | ((value >>> 7) & 0x7F | 0x80) << 16
-          | ((value >>> 14) & 0x7F | 0x80) | ((value >>> 21) & 0x7F | 0x80);
+          | ((value >>> 14) & 0x7F | 0x80) << 8 | ((value >>> 21) & 0x7F | 0x80);
       buf.writeInt(w);
       buf.writeByte(value >>> 28);
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressorAndLengthEncoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressorAndLengthEncoder.java
@@ -29,6 +29,9 @@ import java.util.zip.DataFormatException;
 
 public class MinecraftCompressorAndLengthEncoder extends MessageToByteEncoder<ByteBuf> {
 
+  private static final boolean MUST_USE_SAFE_AND_SLOW_COMPRESSION_HANDLING =
+      Boolean.getBoolean("velocity.increased-compression-cap");
+
   private int threshold;
   private final VelocityCompressor compressor;
 
@@ -46,27 +49,60 @@ public class MinecraftCompressorAndLengthEncoder extends MessageToByteEncoder<By
       ProtocolUtils.writeVarInt(out, 0);
       out.writeBytes(msg);
     } else {
-      handleCompressed(ctx, msg, out);
+      if (MUST_USE_SAFE_AND_SLOW_COMPRESSION_HANDLING) {
+        handleCompressedSafe(ctx, msg, out);
+      } else {
+        handleCompressedFast(ctx, msg, out);
+      }
     }
   }
 
-  private void handleCompressed(ChannelHandlerContext ctx, ByteBuf msg, ByteBuf out)
+  private void handleCompressedFast(ChannelHandlerContext ctx, ByteBuf msg, ByteBuf out)
       throws DataFormatException {
-    ProtocolUtils.writeVarIntAs3Bytes(out, 0); //Dummy packet length
     int uncompressed = msg.readableBytes();
+
+    ProtocolUtils.writeVarIntAs3Bytes(out, 0); // Dummy packet length
     ProtocolUtils.writeVarInt(out, uncompressed);
     ByteBuf compatibleIn = MoreByteBufUtils.ensureCompatible(ctx.alloc(), compressor, msg);
+
+    int startCompressed = out.writerIndex();
     try {
       compressor.deflate(compatibleIn, out);
     } finally {
       compatibleIn.release();
     }
+    int compressedLength = out.writerIndex() - startCompressed;
+    if (compressedLength >= 1 << 21) {
+      throw new DataFormatException("The server sent a very large (over 2MiB compressed) packet. "
+          + "Please restart Velocity with the JVM flag -Dvelocity.increased-compression-cap=true "
+          + "to fix this issue.");
+    }
 
     int writerIndex = out.writerIndex();
     int packetLength = out.readableBytes() - 3;
     out.writerIndex(0);
-    ProtocolUtils.writeVarIntAs3Bytes(out, packetLength); //Rewrite packet length
+    ProtocolUtils.writeVarIntAs3Bytes(out, packetLength); // Rewrite packet length
     out.writerIndex(writerIndex);
+  }
+
+  private void handleCompressedSafe(ChannelHandlerContext ctx, ByteBuf msg, ByteBuf out)
+      throws DataFormatException {
+    int uncompressed = msg.readableBytes();
+    ByteBuf tmpBuf = MoreByteBufUtils.preferredBuffer(ctx.alloc(), compressor, uncompressed - 1);
+    try {
+      ProtocolUtils.writeVarInt(tmpBuf, uncompressed);
+      ByteBuf compatibleIn = MoreByteBufUtils.ensureCompatible(ctx.alloc(), compressor, msg);
+      try {
+        compressor.deflate(compatibleIn, tmpBuf);
+      } finally {
+        compatibleIn.release();
+      }
+
+      ProtocolUtils.writeVarInt(out, tmpBuf.readableBytes());
+      out.writeBytes(tmpBuf);
+    } finally {
+      tmpBuf.release();
+    }
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressorAndLengthEncoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressorAndLengthEncoder.java
@@ -61,7 +61,7 @@ public class MinecraftCompressorAndLengthEncoder extends MessageToByteEncoder<By
       throws DataFormatException {
     int uncompressed = msg.readableBytes();
 
-    ProtocolUtils.writeVarIntAs3Bytes(out, 0); // Dummy packet length
+    ProtocolUtils.write21BitVarInt(out, 0); // Dummy packet length
     ProtocolUtils.writeVarInt(out, uncompressed);
     ByteBuf compatibleIn = MoreByteBufUtils.ensureCompatible(ctx.alloc(), compressor, msg);
 
@@ -81,7 +81,7 @@ public class MinecraftCompressorAndLengthEncoder extends MessageToByteEncoder<By
     int writerIndex = out.writerIndex();
     int packetLength = out.readableBytes() - 3;
     out.writerIndex(0);
-    ProtocolUtils.writeVarIntAs3Bytes(out, packetLength); // Rewrite packet length
+    ProtocolUtils.write21BitVarInt(out, packetLength); // Rewrite packet length
     out.writerIndex(writerIndex);
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftVarintLengthEncoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftVarintLengthEncoder.java
@@ -29,7 +29,7 @@ import io.netty.handler.codec.MessageToByteEncoder;
 public class MinecraftVarintLengthEncoder extends MessageToByteEncoder<ByteBuf> {
 
   public static final MinecraftVarintLengthEncoder INSTANCE = new MinecraftVarintLengthEncoder();
-  private static final boolean IS_JAVA_CIPHER = Natives.cipher.get() == JavaVelocityCipher.FACTORY;
+  public static final boolean IS_JAVA_CIPHER = Natives.cipher.get() == JavaVelocityCipher.FACTORY;
 
   private MinecraftVarintLengthEncoder() {
   }

--- a/proxy/src/test/java/com/velocitypowered/proxy/protocol/ProtocolUtilsTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/protocol/ProtocolUtilsTest.java
@@ -81,7 +81,7 @@ public class ProtocolUtilsTest {
 
   private void writeReadTest3Bytes(ByteBuf buf, int test) {
     buf.clear();
-    ProtocolUtils.writeVarIntAs3Bytes(buf, test);
+    ProtocolUtils.write21BitVarInt(buf, test);
     assertEquals(test, ProtocolUtils.readVarInt(buf));
   }
 

--- a/proxy/src/test/java/com/velocitypowered/proxy/protocol/ProtocolUtilsTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/protocol/ProtocolUtilsTest.java
@@ -72,6 +72,20 @@ public class ProtocolUtilsTest {
   }
 
   @Test
+  void test3Bytes() {
+    ByteBuf buf = Unpooled.buffer(5);
+    for (int i = 0; i < 2097152; i += 31) {
+      writeReadTest3Bytes(buf, i);
+    }
+  }
+
+  private void writeReadTest3Bytes(ByteBuf buf, int test) {
+    buf.clear();
+    ProtocolUtils.writeVarIntAs3Bytes(buf, test);
+    assertEquals(test, ProtocolUtils.readVarInt(buf));
+  }
+
+  @Test
   void testBytesWrittenAtBitBoundaries() {
     ByteBuf varintNew = Unpooled.buffer(5);
     ByteBuf varintOld = Unpooled.buffer(5);


### PR DESCRIPTION
This PR containing work from @Leymooo and I includes two important optimizations:

1. VarInt writing is now fuily optimized, based mostly on my work iterating on speeding them up. (I started on this, @Leymooo pointed out some issues with the first approach I tried, and I iterated for several days until coming up with this solution. Make sure to [read my post about it](https://steinborn.me/posts/performance/how-fast-can-you-write-a-varint/), as the work in there enables the next optimization)
2. Packet compression and encoding is now combined into one generic handler to save on at least two memory copies. This was trivial to implement for uncompressed packets, but for compressed packets a specially optimized VarInt writer that always emits 21-bit numbers was required.