### PR TITLE
Lessen restriction that EventHandler's event type extend Event

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/EventHandler.java
+++ b/api/src/main/java/com/velocitypowered/api/event/EventHandler.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * similar), or pass events through to an external system to be handled.
  */
 @FunctionalInterface
-public interface EventHandler<E extends Event> {
+public interface EventHandler<E> {
 
   @Nullable EventTask execute(E event);
 }

--- a/api/src/main/java/com/velocitypowered/api/event/EventManager.java
+++ b/api/src/main/java/com/velocitypowered/api/event/EventManager.java
@@ -32,8 +32,7 @@ public interface EventManager {
    * @param handler the handler to register
    * @param <E> the event type to handle
    */
-  default <E extends Event> void register(Object plugin, Class<E> eventClass,
-      EventHandler<E> handler) {
+  default <E> void register(Object plugin, Class<E> eventClass, EventHandler<E> handler) {
     register(plugin, eventClass, PostOrder.NORMAL, handler);
   }
 
@@ -47,8 +46,7 @@ public interface EventManager {
    * @param handler the handler to register
    * @param <E> the event type to handle
    */
-  <E extends Event> void register(Object plugin, Class<E> eventClass, short postOrder,
-      EventHandler<E> handler);
+  <E> void register(Object plugin, Class<E> eventClass, short postOrder, EventHandler<E> handler);
 
   /**
    * Fires the specified event to the event bus asynchronously. This allows Velocity to continue
@@ -93,5 +91,5 @@ public interface EventManager {
    * @param handler the handler to register
    * @param <E> the event type to handle
    */
-  <E extends Event> void unregister(Object plugin, EventHandler<E> handler);
+  <E> void unregister(Object plugin, EventHandler<E> handler);
 }


### PR DESCRIPTION
In Velocity 1.x, events only had to be `Object`s. I presume that the reason `Event` was introduced is to increase type-safety of the event manager, which is reasonable. For that reason, `fire(E)` still uses `Event`.

For `EventHandler`s, the restriction that the event type be an `Event` has been lifted. This generally allows more flexibility for users defining platform-independent APIs, restoring a feature of EventManager which was possible in 1.x.

Here's one example where this is useful: a platform-independent API defines an event interface which can be listened to through platform-specific means, including `EventHandler`. The platform-independent event interface does *not* need to extend Event.