### PR TITLE
Simplify EventTask. Add Continuation parameter support.

### DIFF
--- a/annotation-processor/src/main/java/com/velocitypowered/annotationprocessor/ApiAnnotationProcessor.java
+++ b/annotation-processor/src/main/java/com/velocitypowered/annotationprocessor/ApiAnnotationProcessor.java
@@ -17,7 +17,6 @@
 
 package com.velocitypowered.annotationprocessor;
 
-import static com.velocitypowered.annotationprocessor.AnnotationProcessorConstants.EVENTTASK_CLASS;
 import static com.velocitypowered.annotationprocessor.AnnotationProcessorConstants.EVENT_INTERFACE;
 import static com.velocitypowered.annotationprocessor.AnnotationProcessorConstants.PLUGIN_ANNOTATION_CLASS;
 import static com.velocitypowered.annotationprocessor.AnnotationProcessorConstants.SUBSCRIBE_ANNOTATION_CLASS;
@@ -30,9 +29,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
-import javax.annotation.Nullable;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.RoundEnvironment;
@@ -45,7 +42,6 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
-import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -90,10 +86,6 @@ public class ApiAnnotationProcessor extends AbstractProcessor {
         if (enclosing != null && enclosing.getKind().isInterface()) {
           msg.printMessage(Diagnostic.Kind.ERROR,
               "interfaces cannot declare listeners", method);
-        }
-        if (method.getReturnType().getKind() != TypeKind.VOID
-            && !this.isTypeSubclass(method.getReturnType(), EVENTTASK_CLASS)) {
-          msg.printMessage(Kind.ERROR, "method must return void or EventTask", method);
         }
         final List<? extends VariableElement> parameters = method.getParameters();
         if (parameters.isEmpty()

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -87,7 +87,7 @@ dependencies {
 
     implementation 'com.electronwill.night-config:toml:3.6.3'
     implementation 'org.bstats:bstats-base:2.2.0'
-    implementation 'org.lanternpowered:lmbda:2.0.0-SNAPSHOT'
+    implementation 'org.lanternpowered:lmbda:2.0.0'
 
     implementation 'com.github.ben-manes.caffeine:caffeine:2.8.8'
     implementation 'com.vdurmont:semver4j:3.1.0'

--- a/proxy/src/main/java/com/velocitypowered/proxy/event/CustomHandlerAdapter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/event/CustomHandlerAdapter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.event;
+
+import com.google.common.reflect.TypeToken;
+import com.velocitypowered.api.event.Event;
+import com.velocitypowered.api.event.EventHandler;
+import com.velocitypowered.api.event.EventTask;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.lanternpowered.lmbda.LambdaFactory;
+import org.lanternpowered.lmbda.LambdaType;
+
+final class CustomHandlerAdapter<F> {
+
+  final String name;
+  private final Function<F, BiFunction<Object, Event, EventTask>> handlerBuilder;
+  final Predicate<Method> filter;
+  final BiConsumer<Method, List<String>> validator;
+  private final LambdaType<F> functionType;
+  private final MethodHandles.Lookup methodHandlesLookup;
+
+  @SuppressWarnings("unchecked")
+  CustomHandlerAdapter(
+      final String name,
+      final Predicate<Method> filter,
+      final BiConsumer<Method, List<String>> validator,
+      final TypeToken<F> invokeFunctionType,
+      final Function<F, BiFunction<Object, Event, EventTask>> handlerBuilder,
+      final MethodHandles.Lookup methodHandlesLookup) {
+    this.name = name;
+    this.filter = filter;
+    this.validator = validator;
+    this.functionType = (LambdaType<F>) LambdaType.of(invokeFunctionType.getRawType());
+    this.handlerBuilder = handlerBuilder;
+    this.methodHandlesLookup = methodHandlesLookup;
+  }
+
+  UntargetedEventHandler buildUntargetedHandler(final Method method)
+      throws IllegalAccessException {
+    final MethodHandle methodHandle = methodHandlesLookup.unreflect(method);
+    final MethodHandles.Lookup defineLookup = MethodHandles.privateLookupIn(
+        method.getDeclaringClass(), methodHandlesLookup);
+    final LambdaType<F> lambdaType = functionType.defineClassesWith(defineLookup);
+    final F invokeFunction = LambdaFactory.create(lambdaType, methodHandle);
+    final BiFunction<Object, Event, EventTask> handlerFunction =
+        handlerBuilder.apply(invokeFunction);
+    return targetInstance -> new EventHandler<>() {
+
+      @Override
+      public @Nullable EventTask execute(Event event) {
+        return handlerFunction.apply(targetInstance, event);
+      }
+    };
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/plugin/PluginClassLoader.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/plugin/PluginClassLoader.java
@@ -64,9 +64,13 @@ public class PluginClassLoader extends URLClassLoader {
     return findClass0(name, true);
   }
 
+  private boolean isKtLanguagePlugin() {
+    return description.id().equals("velocity-language-kotlin");
+  }
+
   private Class<?> findClass0(String name, boolean checkOther)
       throws ClassNotFoundException {
-    if (name.startsWith("com.velocitypowered")) {
+    if (name.startsWith("com.velocitypowered") && !isKtLanguagePlugin()) {
       throw new ClassNotFoundException();
     }
 


### PR DESCRIPTION
- Simplify EventTask. No more subtypes and is now an interface. No default methods though to prevent it being implemented as a lambda. Renamed `run` -> `execute` to be consistent with `EventHandler`.  Deleted `EventTask.asyncWithContinuation` and `EventTask.of`.
- Add support for `Continuation` as a second subscribe method parameter, instead of having to use `EventTask` as return type.
```java
@Subscribe
public void onEvent(MyEvent event, Continuation continuation) { 
  // do things
  continuation.resume();
}
```
- Preparations to support `suspend fun` for kotlin event handling.