### PR TITLE
Fix bStats error when starting in dev.

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/Metrics.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/Metrics.java
@@ -52,6 +52,11 @@ public class Metrics {
       return;
     }
 
+    // Disable the relocate check if velocity doesn't have bStats relocated, this happens in dev
+    if (!MetricsBase.class.getPackageName().startsWith(getClass().getPackageName())) {
+      System.setProperty("bstats.relocatecheck", "false");
+    }
+
     metricsBase = new MetricsBase(
         "server-implementation",
         config.getServerUUID(),


### PR DESCRIPTION
Adding this check prevents velocity from crashing in dev. Velocity should work without having to provide a system property for bStats.