### PR TITLE
Remove Add-Opens from manifest

### DIFF
--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -28,7 +28,6 @@ jar {
         attributes 'Implementation-Version': version
         attributes 'Implementation-Vendor': "Velocity Contributors"
         attributes 'Multi-Release': 'true'
-        attributes 'Add-Opens': 'java.base/java.lang'
     }
 }
 


### PR DESCRIPTION
This will help with detecting other libraries, such as those bundled in plugins, performing illegal access.

With the add-opens present, it is possible for users testing Velocity 3.x to miss these issues.