### PR TITLE
Guarantee the presence of snakeyaml

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     api "org.spongepowered:configurate-hocon:${configurateVersion}"
     api "org.spongepowered:configurate-yaml:${configurateVersion}"
     api "org.spongepowered:configurate-gson:${configurateVersion}"
+    api "org.yaml:snakeyaml:1.28"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"


### PR DESCRIPTION
In Velocity 1.x, snakeyaml is a visible transitive API dependency. With Configurate 4, it becomes an "implementation" dependency.

SnakeYaml is essentially a cornerstone of the plugin ecosystem, with many things - not just Configurate - relying on it. Velocity should guarantee its presence just as other platforms do.

This will also ease source code migration from 1.x to 3.x for codebases directly using snakeyaml (though I don't recommend such things)