### PR TITLE
Initial implementation of raw registered server creation.

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
@@ -106,6 +106,14 @@ public interface ProxyServer extends Audience {
   Collection<RegisteredServer> matchServer(String partialName);
 
   /**
+   * Creates a raw {@link RegisteredServer} without tying it into the internal server map.
+   *
+   * @param server the server to register
+   * @return the {@link RegisteredServer} implementation created by the provided {@link ServerInfo}.
+   */
+  RegisteredServer createRawRegisteredServer(ServerInfo server);
+
+  /**
    * Registers a server with this proxy. A server with this name should not already exist.
    *
    * @param server the server to register

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -601,6 +601,11 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
   }
 
   @Override
+  public RegisteredServer createRawRegisteredServer(ServerInfo server) {
+    return servers.createRawRegisteredServer(server);
+  }
+
+  @Override
   public RegisteredServer registerServer(ServerInfo server) {
     return servers.register(server);
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/server/ServerMap.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/server/ServerMap.java
@@ -55,6 +55,17 @@ public class ServerMap {
   }
 
   /**
+   * Creates a raw implementation of a {@link RegisteredServer} without
+   *  tying it to the internal server map.
+   *
+   * @param serverInfo the server to create a registered server with
+   * @return the {@link RegisteredServer} built from the {@link ServerInfo}
+   */
+  public RegisteredServer createRawRegisteredServer(ServerInfo serverInfo) {
+    return new VelocityRegisteredServer(server, serverInfo);
+  }
+
+  /**
    * Registers a server with the proxy.
    *
    * @param serverInfo the server to register
@@ -63,7 +74,7 @@ public class ServerMap {
   public RegisteredServer register(ServerInfo serverInfo) {
     Preconditions.checkNotNull(serverInfo, "serverInfo");
     String lowerName = serverInfo.getName().toLowerCase(Locale.US);
-    VelocityRegisteredServer rs = new VelocityRegisteredServer(server, serverInfo);
+    RegisteredServer rs = createRawRegisteredServer(serverInfo);
 
     RegisteredServer existing = servers.putIfAbsent(lowerName, rs);
     if (existing != null && !existing.getServerInfo().equals(serverInfo)) {


### PR DESCRIPTION
This PR allows plugin creators or server owners to create their own RegisteredServer which players in velocity can connect to without necessarily tying it into the server map or forcing it to be recognized by the backend.

This change allows for dynamic server types which often change IPs but may keep the same name.

For instance:
```
Server A => Name: ServerA, IP: 129.0.0.3:25500
=> player connects to Server A
=> server A drops connection and unties from the network unexpectedly
=> player disconnects from Server A
=> server A comes back up with new information => Name: ServerA, IP: 128.0.0.3:25500
=> player cannot connect to Server A since it cannot be re-registered within the server map
```

This issue comes into play with kubernetes style networks which have fairly complex IP topology, wherein a server may change IP but may have the same underlying information.

There are some workarounds such as reflection to fudge the underlying map to allow for multiple server registrations, along with watching for servers disconnecting or dropping and sending an event to do such things.

These workarounds aren't viable in a production network for the following reasons:
* Reflection can be spotty and is not a necessarily supported feature within Java (hence the warnings when you do it)
* Events drop, they can be missed and unfortunately cannot be relied on for network consistency, if one of these events drop it puts a level of issue into the network since it cannot guarantee a consistent level of connection

This PR brings in a new concept, being untied `RegisteredServer`, this probably gives a different idea to the name and should probably urge for a renaming of such structure, but I think that's due in another PR or some other API-breaking overhaul of this typing. Since it's not necessarily registered but is absolutely required for connection.

Unfortunately all that's needed for a player to connect is the `ServerInfo` there's a preconditions check to make sure it's of a `VelocityRegisteredServer` instead, also completely removing the ability to spoof such type. This probably brings on a bigger issue with how the system is designed internally and should probably be looked into eventually, but this should allow a quick fix for server owners who require such dynamic typing.