### PR TITLE
Initial change to allow for server info equality.

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -870,7 +870,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
           && !connectedServer.hasCompletedJoin())) {
         return Optional.of(ConnectionRequestBuilder.Status.CONNECTION_IN_PROGRESS);
       }
-      if (connectedServer != null && connectedServer.getServer().equals(server)) {
+      if (connectedServer != null
+              && connectedServer.getServer().getServerInfo().equals(server.getServerInfo())) {
         return Optional.of(ALREADY_CONNECTED);
       }
       return Optional.empty();


### PR DESCRIPTION
This change is linked directly to #513

With the changes in #513 we can no longer guarantee that a `VelocityRegisteredServer` can be equal to another. With this in mind connections to said dynamic servers can have issues guaranteeing that some `Player` is connected to some specific `VelocityRegisteredServer` since the new connection's destination will likely (when using dynamic registration) be non-equal. The fix is fairly simple, just checking the equality of `ServerInfo` of said server to check for address and name equality.

This fix gives us quite a few advantages when looking at dynamic server creation. Since `VelocityRegisteredServer` only has the default `equals` meaning the hashes have to line up and force static equality between the 2 objects, this instead checks the equality behind the connection information. If the underlying server implementation is cloned, copied or in some other way moved into another object to retry connection this will always catch it as long as the user is attempting to access the same server.