### PR TITLE
Bump to Caffeine 3

### DIFF
--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     implementation 'org.bstats:bstats-base:2.2.0'
     implementation 'org.lanternpowered:lmbda:2.0.0'
 
-    implementation 'com.github.ben-manes.caffeine:caffeine:2.8.8'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.0.2'
 
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.1.2'
 


### PR DESCRIPTION
The latest version of Caffeine has completely removed usage of `sun.misc.Unsafe`. Unsafe is still in the JDK, but for future compatibility, which Velocity 3 aims at, it is better to less rely on it (netty still does, AFAIK).

There are no breaking changes in Caffeine 3 which affect Velocity's usage of it in EventManager -- all breaking changes in [release 3.0](https://github.com/ben-manes/caffeine/releases/tag/v3.0.0) cause compile-time errors.