### PR TITLE
Expand Adventure Support

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
@@ -16,6 +16,7 @@ import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.permission.PermissionChecker;
 import net.kyori.adventure.pointer.Pointer;
+import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacytext3.LegacyText3ComponentSerializer;
 import net.kyori.adventure.util.TriState;
@@ -44,12 +45,8 @@ public interface CommandSource extends Audience, PermissionSubject, PermissionCh
   }
 
   @Override
-  @SuppressWarnings("unchecked") // safe casts
-  default @NotNull <T> Optional<T> get(final @NotNull Pointer<T> pointer) {
-    if (pointer == PermissionChecker.POINTER) {
-      return Optional.of((T) this);
-    }
-    return Audience.super.get(pointer);
+  default @NotNull Pointers pointers() {
+    return Pointers.builder().withStatic(PermissionChecker.POINTER, this).build();
   }
 
   @Override

--- a/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
@@ -9,13 +9,11 @@ package com.velocitypowered.api.command;
 
 import com.velocitypowered.api.permission.PermissionSubject;
 import com.velocitypowered.api.permission.Tristate;
-import java.util.Optional;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.permission.PermissionChecker;
-import net.kyori.adventure.pointer.Pointer;
 import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacytext3.LegacyText3ComponentSerializer;

--- a/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
@@ -9,6 +9,7 @@ package com.velocitypowered.api.command;
 
 import com.velocitypowered.api.permission.PermissionSubject;
 import com.velocitypowered.api.permission.Tristate;
+import java.util.Optional;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identified;
@@ -20,7 +21,6 @@ import net.kyori.adventure.text.serializer.legacytext3.LegacyText3ComponentSeria
 import net.kyori.adventure.util.TriState;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
-import java.util.Optional;
 
 /**
  * Represents something that can be used to run a {@link Command}.

--- a/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
@@ -8,15 +8,12 @@
 package com.velocitypowered.api.command;
 
 import com.velocitypowered.api.permission.PermissionSubject;
-import com.velocitypowered.api.permission.Tristate;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
-import net.kyori.adventure.permission.PermissionChecker;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacytext3.LegacyText3ComponentSerializer;
-import net.kyori.adventure.util.TriState;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -38,25 +35,5 @@ public interface CommandSource extends Audience, PermissionSubject {
   default void sendMessage(@NonNull Identity identity, @NonNull Component message,
                            @NonNull MessageType type) {
     this.sendMessage(LegacyText3ComponentSerializer.get().serialize(message));
-  }
-
-  /**
-   * Gets the permission checker for the invoker.
-   *
-   * @return invoker's permission checker
-   */
-  default PermissionChecker getPermissionChecker() {
-    return permission -> {
-      final Tristate state = getPermissionValue(permission);
-      if (state == Tristate.TRUE) {
-        return TriState.TRUE;
-      } else if (state == Tristate.UNDEFINED) {
-        return TriState.NOT_SET;
-      } else if (state == Tristate.FALSE) {
-        return TriState.FALSE;
-      } else {
-        throw new IllegalArgumentException();
-      }
-    };
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
@@ -14,12 +14,10 @@ import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.permission.PermissionChecker;
-import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacytext3.LegacyText3ComponentSerializer;
 import net.kyori.adventure.util.TriState;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents something that can be used to run a {@link Command}.
@@ -40,11 +38,6 @@ public interface CommandSource extends Audience, PermissionSubject {
   default void sendMessage(@NonNull Identity identity, @NonNull Component message,
                            @NonNull MessageType type) {
     this.sendMessage(LegacyText3ComponentSerializer.get().serialize(message));
-  }
-
-  @Override
-  default @NotNull Pointers pointers() {
-    return Pointers.builder().withStatic(PermissionChecker.POINTER, getPermissionChecker()).build();
   }
 
   /**

--- a/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
@@ -8,18 +8,23 @@
 package com.velocitypowered.api.command;
 
 import com.velocitypowered.api.permission.PermissionSubject;
+import com.velocitypowered.api.permission.Tristate;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.permission.PermissionChecker;
+import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacytext3.LegacyText3ComponentSerializer;
+import net.kyori.adventure.util.TriState;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents something that can be used to run a {@link Command}.
  */
-public interface CommandSource extends Audience, PermissionSubject {
+public interface CommandSource extends Audience, PermissionSubject, PermissionChecker {
 
   /**
    * Sends the specified {@code component} to the invoker.
@@ -35,5 +40,20 @@ public interface CommandSource extends Audience, PermissionSubject {
   default void sendMessage(@NonNull Identity identity, @NonNull Component message,
                            @NonNull MessageType type) {
     this.sendMessage(LegacyText3ComponentSerializer.get().serialize(message));
+  }
+
+  @Override
+  default @NotNull Pointers pointers() {
+    return Pointers.builder().withStatic(PermissionChecker.POINTER, this).build();
+  }
+
+  @Override
+  default @NotNull TriState value(String permission) {
+    Tristate state = getPermissionValue(permission);
+    if (state == Tristate.TRUE)
+      return TriState.TRUE;
+    if (state == Tristate.UNDEFINED)
+      return TriState.NOT_SET;
+    return TriState.FALSE;
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Represents something that can be used to run a {@link Command}.
  */
-public interface CommandSource extends Audience, PermissionSubject, PermissionChecker {
+public interface CommandSource extends Audience, PermissionSubject {
 
   /**
    * Sends the specified {@code component} to the invoker.
@@ -44,18 +44,26 @@ public interface CommandSource extends Audience, PermissionSubject, PermissionCh
 
   @Override
   default @NotNull Pointers pointers() {
-    return Pointers.builder().withStatic(PermissionChecker.POINTER, this).build();
+    return Pointers.builder().withStatic(PermissionChecker.POINTER, getPermissionChecker()).build();
   }
 
-  @Override
-  default @NotNull TriState value(String permission) {
-    Tristate state = getPermissionValue(permission);
-    if (state == Tristate.TRUE) {
-      return TriState.TRUE;
-    }
-    if (state == Tristate.UNDEFINED) {
-      return TriState.NOT_SET;
-    }
-    return TriState.FALSE;
+  /**
+   * Gets the permission checker for the invoker.
+   *
+   * @return invoker's permission checker
+   */
+  default PermissionChecker getPermissionChecker() {
+    return permission -> {
+      final Tristate state = getPermissionValue(permission);
+      if (state == Tristate.TRUE) {
+        return TriState.TRUE;
+      } else if (state == Tristate.UNDEFINED) {
+        return TriState.NOT_SET;
+      } else if (state == Tristate.FALSE) {
+        return TriState.FALSE;
+      } else {
+        throw new IllegalArgumentException();
+      }
+    };
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
@@ -14,12 +14,13 @@ import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.permission.PermissionChecker;
-import net.kyori.adventure.pointer.Pointers;
+import net.kyori.adventure.pointer.Pointer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacytext3.LegacyText3ComponentSerializer;
 import net.kyori.adventure.util.TriState;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
+import java.util.Optional;
 
 /**
  * Represents something that can be used to run a {@link Command}.
@@ -43,8 +44,12 @@ public interface CommandSource extends Audience, PermissionSubject, PermissionCh
   }
 
   @Override
-  default @NotNull Pointers pointers() {
-    return Pointers.builder().withStatic(PermissionChecker.POINTER, this).build();
+  @SuppressWarnings("unchecked") // safe casts
+  default @NotNull <T> Optional<T> get(final @NotNull Pointer<T> pointer) {
+    if (pointer == PermissionChecker.POINTER) {
+      return Optional.of((T) this);
+    }
+    return Audience.super.get(pointer);
   }
 
   @Override

--- a/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
@@ -50,10 +50,12 @@ public interface CommandSource extends Audience, PermissionSubject, PermissionCh
   @Override
   default @NotNull TriState value(String permission) {
     Tristate state = getPermissionValue(permission);
-    if (state == Tristate.TRUE)
+    if (state == Tristate.TRUE) {
       return TriState.TRUE;
-    if (state == Tristate.UNDEFINED)
+    }
+    if (state == Tristate.UNDEFINED) {
       return TriState.NOT_SET;
+    }
     return TriState.FALSE;
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
@@ -7,6 +7,9 @@
 
 package com.velocitypowered.api.permission;
 
+import net.kyori.adventure.permission.PermissionChecker;
+import net.kyori.adventure.util.TriState;
+
 /**
  * Represents a object that has a set of queryable permissions.
  */
@@ -29,4 +32,24 @@ public interface PermissionSubject {
    * @return the value the permission is set to
    */
   Tristate getPermissionValue(String permission);
+
+  /**
+   * Gets the permission checker for the subject.
+   *
+   * @return subject's permission checker
+   */
+  default PermissionChecker getPermissionChecker() {
+    return permission -> {
+      final Tristate state = getPermissionValue(permission);
+      if (state == Tristate.TRUE) {
+        return TriState.TRUE;
+      } else if (state == Tristate.UNDEFINED) {
+        return TriState.NOT_SET;
+      } else if (state == Tristate.FALSE) {
+        return TriState.FALSE;
+      } else {
+        throw new IllegalArgumentException();
+      }
+    };
+  }
 }

--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
@@ -39,17 +39,6 @@ public interface PermissionSubject {
    * @return subject's permission checker
    */
   default PermissionChecker getPermissionChecker() {
-    return permission -> {
-      final Tristate state = getPermissionValue(permission);
-      if (state == Tristate.TRUE) {
-        return TriState.TRUE;
-      } else if (state == Tristate.UNDEFINED) {
-        return TriState.NOT_SET;
-      } else if (state == Tristate.FALSE) {
-        return TriState.FALSE;
-      } else {
-        throw new IllegalArgumentException();
-      }
-    };
+    return permission -> getPermissionValue(permission).toAdventureTriState();
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/permission/Tristate.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/Tristate.java
@@ -7,6 +7,7 @@
 
 package com.velocitypowered.api.permission;
 
+import net.kyori.adventure.util.TriState;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -80,5 +81,17 @@ public enum Tristate {
    */
   public boolean asBoolean() {
     return this.booleanValue;
+  }
+
+  public TriState toAdventureTriState() {
+    if (this == Tristate.TRUE) {
+      return TriState.TRUE;
+    } else if (this == Tristate.UNDEFINED) {
+      return TriState.NOT_SET;
+    } else if (this == Tristate.FALSE) {
+      return TriState.FALSE;
+    } else {
+      throw new IllegalArgumentException();
+    }
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/permission/Tristate.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/Tristate.java
@@ -83,6 +83,11 @@ public enum Tristate {
     return this.booleanValue;
   }
 
+  /**
+   * Returns the equivalent Adventure {@link TriState}.
+   *
+   * @return equivalent Adventure TriState
+   */
   public TriState toAdventureTriState() {
     if (this == Tristate.TRUE) {
       return TriState.TRUE;

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -28,7 +28,6 @@ import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
-import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.event.ClickEvent;
@@ -303,14 +302,5 @@ public interface Player extends CommandSource, Identified, InboundConnection,
           @NotNull UnaryOperator<HoverEvent.ShowEntity> op) {
     return HoverEvent.showEntity(op.apply(HoverEvent.ShowEntity.of(this, getUniqueId(),
             Component.text(getUsername()))));
-  }
-
-  @Override
-  default @NotNull Pointers pointers() {
-    return CommandSource.super.pointers().toBuilder()
-            .withDynamic(Identity.NAME, this::getUsername)
-            .withDynamic(Identity.DISPLAY_NAME, this::asComponent)
-            .withDynamic(Identity.UUID, this::getUniqueId)
-            .build();
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -31,6 +31,7 @@ import net.kyori.adventure.key.Keyed;
 import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -292,7 +293,9 @@ public interface Player extends CommandSource, Identified, InboundConnection,
 
   @Override
   default @NotNull Component asComponent() {
-    return Component.text(getUsername()).hoverEvent(this);
+    return Component.text(getUsername()).hoverEvent(this)
+            .clickEvent(ClickEvent.suggestCommand("/tell " + getUsername()))
+            .insertion(getUsername());
   }
 
   @Override

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -28,7 +28,6 @@ import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
-import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
@@ -283,15 +282,6 @@ public interface Player extends CommandSource, Identified, InboundConnection,
    */
   @Override
   boolean sendPluginMessage(ChannelIdentifier identifier, byte[] data);
-
-  @Override
-  default @NotNull Pointers pointers() {
-    return CommandSource.super.pointers().toBuilder()
-            .withDynamic(Identity.UUID, this::getUniqueId)
-            .withDynamic(Identity.NAME, this::getUsername)
-            .withDynamic(Identity.DISPLAY_NAME, this::getDisplayName)
-            .build();
-  }
 
   @Override
   default @NotNull Key key() {

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -28,6 +28,7 @@ import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
+import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.event.ClickEvent;
@@ -284,6 +285,15 @@ public interface Player extends CommandSource, Identified, InboundConnection,
    */
   @Override
   boolean sendPluginMessage(ChannelIdentifier identifier, byte[] data);
+
+  @Override
+  default @NotNull Pointers pointers() {
+    return CommandSource.super.pointers().toBuilder()
+            .withDynamic(Identity.UUID, this::getUniqueId)
+            .withDynamic(Identity.NAME, this::getUsername)
+            .withDynamic(Identity.DISPLAY_NAME, this::asComponent)
+            .build();
+  }
 
   @Override
   default @NotNull Key key() {

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -29,7 +29,6 @@ import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -286,17 +285,6 @@ public interface Player extends CommandSource, Identified, InboundConnection,
   @Override
   default @NotNull Key key() {
     return Key.key("player");
-  }
-
-  /**
-   * Gets a {@link Component} that renders a player name similarly to vanilla.
-   *
-   * @return a Component representing this player
-   */
-  default @NotNull Component getDisplayName() {
-    return Component.text(getUsername()).hoverEvent(this)
-            .clickEvent(ClickEvent.suggestCommand("/tell " + getUsername()))
-            .insertion(getUsername());
   }
 
   @Override

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -30,7 +30,6 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
 import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
@@ -41,8 +40,7 @@ import org.jetbrains.annotations.NotNull;
  * Represents a player who is connected to the proxy.
  */
 public interface Player extends CommandSource, Identified, InboundConnection,
-    ChannelMessageSource, ChannelMessageSink, HoverEventSource<HoverEvent.ShowEntity>,
-    ComponentLike, Keyed {
+    ChannelMessageSource, ChannelMessageSink, HoverEventSource<HoverEvent.ShowEntity>, Keyed {
 
   /**
    * Returns the player's current username.
@@ -300,7 +298,6 @@ public interface Player extends CommandSource, Identified, InboundConnection,
     return Key.key("player");
   }
 
-  @Override
   default @NotNull Component asComponent() {
     return Component.text(getUsername()).hoverEvent(this)
             .clickEvent(ClickEvent.suggestCommand("/tell " + getUsername()))

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -289,7 +289,7 @@ public interface Player extends CommandSource, Identified, InboundConnection,
     return CommandSource.super.pointers().toBuilder()
             .withDynamic(Identity.UUID, this::getUniqueId)
             .withDynamic(Identity.NAME, this::getUsername)
-            .withDynamic(Identity.DISPLAY_NAME, this::asComponent)
+            .withDynamic(Identity.DISPLAY_NAME, this::getDisplayName)
             .build();
   }
 
@@ -298,7 +298,12 @@ public interface Player extends CommandSource, Identified, InboundConnection,
     return Key.key("player");
   }
 
-  default @NotNull Component asComponent() {
+  /**
+   * Gets a {@link Component} that renders a player name similarly to vanilla.
+   *
+   * @return a Component representing this player
+   */
+  default @NotNull Component getDisplayName() {
     return Component.text(getUsername()).hoverEvent(this)
             .clickEvent(ClickEvent.suggestCommand("/tell " + getUsername()))
             .insertion(getUsername());

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -148,7 +148,6 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   private final @NotNull Pointers pointers = Player.super.pointers().toBuilder()
           .withDynamic(Identity.UUID, this::getUniqueId)
           .withDynamic(Identity.NAME, this::getUsername)
-          .withDynamic(Identity.DISPLAY_NAME, this::getDisplayName)
           .withStatic(PermissionChecker.POINTER, getPermissionChecker())
           .build();
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -94,6 +94,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -105,6 +106,7 @@ import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
 
@@ -142,6 +144,11 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   private final Queue<ResourcePackInfo> outstandingResourcePacks = new ArrayDeque<>();
   private @Nullable ResourcePackInfo pendingResourcePack;
   private @Nullable ResourcePackInfo appliedResourcePack;
+  private final @NotNull Pointers pointers = Player.super.pointers().toBuilder()
+          .withDynamic(Identity.UUID, this::getUniqueId)
+          .withDynamic(Identity.NAME, this::getUsername)
+          .withDynamic(Identity.DISPLAY_NAME, this::getDisplayName)
+          .build();
 
   ConnectedPlayer(VelocityServer server, GameProfile profile, MinecraftConnection connection,
       @Nullable InetSocketAddress virtualHost, boolean onlineMode) {
@@ -1067,6 +1074,11 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
     // Otherwise, we need to see if the player already knows this channel or it's known by the
     // proxy.
     return minecraftOrFmlMessage || knownChannels.contains(message.getChannel());
+  }
+
+  @Override
+  public @NotNull Pointers pointers() {
+    return pointers;
   }
 
   private class IdentityImpl implements Identity {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -285,8 +285,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
       return Optional.of((T) this.getUniqueId());
     } else if (pointer == Identity.NAME) {
       return Optional.of((T) this.getGameProfile().getName());
-    } else if (pointer == PermissionChecker.POINTER) {
-      return Optional.of((T) this.permissionChecker);
+    } else if (pointer == Identity.DISPLAY_NAME) {
+      return Optional.of((T) asComponent());
     }
     return Player.super.get(pointer);
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -95,7 +95,6 @@ import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.permission.PermissionChecker;
-import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -108,7 +107,6 @@ import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.jetbrains.annotations.NotNull;
 
 public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
 
@@ -277,15 +275,6 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   @Override
   public ProtocolVersion getProtocolVersion() {
     return connection.getProtocolVersion();
-  }
-
-  @Override
-  public @NotNull Pointers pointers() {
-    return Player.super.pointers().toBuilder()
-            .withDynamic(Identity.UUID, this::getUniqueId)
-            .withDynamic(Identity.NAME, this::getUsername)
-            .withDynamic(Identity.DISPLAY_NAME, this::asComponent)
-            .build();
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -96,6 +96,7 @@ import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.permission.PermissionChecker;
 import net.kyori.adventure.pointer.Pointer;
+import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -108,6 +109,7 @@ import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
 
@@ -279,16 +281,12 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   }
 
   @Override
-  @SuppressWarnings("unchecked") // safe casts
-  public <T> Optional<T> get(final Pointer<T> pointer) {
-    if (pointer == Identity.UUID) {
-      return Optional.of((T) this.getUniqueId());
-    } else if (pointer == Identity.NAME) {
-      return Optional.of((T) this.getGameProfile().getName());
-    } else if (pointer == Identity.DISPLAY_NAME) {
-      return Optional.of((T) asComponent());
-    }
-    return Player.super.get(pointer);
+  public @NotNull Pointers pointers() {
+    return Player.super.pointers().toBuilder()
+            .withDynamic(Identity.UUID, this::getUniqueId)
+            .withDynamic(Identity.NAME, this::getUsername)
+            .withDynamic(Identity.DISPLAY_NAME, this::asComponent)
+            .build();
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -94,6 +94,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.permission.PermissionChecker;
 import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
@@ -148,6 +149,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
           .withDynamic(Identity.UUID, this::getUniqueId)
           .withDynamic(Identity.NAME, this::getUsername)
           .withDynamic(Identity.DISPLAY_NAME, this::getDisplayName)
+          .withStatic(PermissionChecker.POINTER, getPermissionChecker())
           .build();
 
   ConnectedPlayer(VelocityServer server, GameProfile profile, MinecraftConnection connection,

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -94,14 +94,12 @@ import java.util.concurrent.ThreadLocalRandom;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.identity.Identity;
-import net.kyori.adventure.permission.PermissionChecker;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
-import net.kyori.adventure.util.TriState;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -124,7 +122,6 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   private final MinecraftConnection connection;
   private final @Nullable InetSocketAddress virtualHost;
   private GameProfile profile;
-  private PermissionChecker permissionChecker;
   private PermissionFunction permissionFunction;
   private int tryIndex = 0;
   private long ping = -1;
@@ -152,7 +149,6 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
     this.profile = profile;
     this.connection = connection;
     this.virtualHost = virtualHost;
-    this.permissionChecker = PermissionChecker.always(TriState.FALSE);
     this.permissionFunction = PermissionFunction.ALWAYS_UNDEFINED;
     this.connectionPhase = connection.getType().getInitialClientPhase();
     this.knownChannels = CappedSet.create(MAX_PLUGIN_CHANNELS);
@@ -253,18 +249,6 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
 
   void setPermissionFunction(PermissionFunction permissionFunction) {
     this.permissionFunction = permissionFunction;
-    this.permissionChecker = permission -> {
-      final Tristate state = permissionFunction.getPermissionValue(permission);
-      if (state == Tristate.TRUE) {
-        return TriState.TRUE;
-      } else if (state == Tristate.UNDEFINED) {
-        return TriState.NOT_SET;
-      } else if (state == Tristate.FALSE) {
-        return TriState.FALSE;
-      } else {
-        throw new IllegalArgumentException();
-      }
-    };
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -95,7 +95,6 @@ import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.permission.PermissionChecker;
-import net.kyori.adventure.pointer.Pointer;
 import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;

--- a/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
@@ -26,6 +26,8 @@ import com.velocitypowered.api.proxy.ConsoleCommandSource;
 import com.velocitypowered.proxy.VelocityServer;
 import java.util.List;
 import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.permission.PermissionChecker;
+import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.text.TextComponent;
 import net.kyori.text.format.TextColor;
@@ -35,6 +37,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.io.IoBuilder;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.jline.reader.Candidate;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -45,6 +48,8 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
 
   private final VelocityServer server;
   private PermissionFunction permissionFunction = ALWAYS_TRUE;
+  private final @NotNull Pointers pointers = ConsoleCommandSource.super.pointers().toBuilder()
+          .withDynamic(PermissionChecker.POINTER, this::getPermissionChecker).build();
 
   public VelocityConsole(VelocityServer server) {
     this.server = server;
@@ -130,5 +135,10 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
   @Override
   protected void shutdown() {
     this.server.shutdown(true);
+  }
+
+  @Override
+  public @NotNull Pointers pointers() {
+    return pointers;
   }
 }


### PR DESCRIPTION
- Adds Player#asComponent which mirrors vanilla behavior
- Adds DISPLAY_NAME pointer for ^
- Adds Player#key (yes it is a little useless)
- Adds Player#asHoverEvent
- Uses the new(?) Pointers class to allow #getOrDefault (and #getOrDefaultFrom) to work
- Moves the PermissionChecker pointer to the CommandSource class
- Moves other pointers to Player (not sure about this one-- it uses exclusively API methods so it makes sense to me that it should be on Player instead of ConnectedPlayer, but I'm open to criticism on that front, and everything else here for that matter :P)

first time making a PR like this, hope it's alright 😅