### PR TITLE
Add support for retrieving the Player's client brand

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -275,4 +275,11 @@ public interface Player extends CommandSource, Identified, InboundConnection,
    */
   @Override
   boolean sendPluginMessage(ChannelIdentifier identifier, byte[] data);
+
+  /**
+   * Gets the player's client brand.
+   *
+   * @return the player's client brand
+   */
+  Optional<String> getClientBrand();
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -281,5 +281,5 @@ public interface Player extends CommandSource, Identified, InboundConnection,
    *
    * @return the player's client brand
    */
-  Optional<String> getClientBrand();
+  @Nullable String getClientBrand();
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -230,6 +230,7 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
         player.getKnownChannels().removeAll(PluginMessageUtil.getChannels(packet));
         backendConn.write(packet.retain());
       } else if (PluginMessageUtil.isMcBrand(packet)) {
+        player.setClientBrand(PluginMessageUtil.readBrandMessage(packet.content()));
         backendConn.write(PluginMessageUtil
             .rewriteMinecraftBrand(packet, server.getVersion(), player.getProtocolVersion()));
       } else if (BungeeCordMessageResponder.isBungeeCordMessage(packet)) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -142,6 +142,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   private final Queue<ResourcePackInfo> outstandingResourcePacks = new ArrayDeque<>();
   private @Nullable ResourcePackInfo pendingResourcePack;
   private @Nullable ResourcePackInfo appliedResourcePack;
+  private @Nullable String clientBrand;
 
   ConnectedPlayer(VelocityServer server, GameProfile profile, MinecraftConnection connection,
       @Nullable InetSocketAddress virtualHost, boolean onlineMode) {
@@ -869,6 +870,15 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
     PluginMessage message = new PluginMessage(identifier.getId(), Unpooled.wrappedBuffer(data));
     connection.write(message);
     return true;
+  }
+
+  @Override
+  public Optional<String> getClientBrand() {
+    return Optional.ofNullable(clientBrand);
+  }
+
+  void setClientBrand(String clientBrand) {
+    this.clientBrand = clientBrand;
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -873,8 +873,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   }
 
   @Override
-  public Optional<String> getClientBrand() {
-    return Optional.ofNullable(clientBrand);
+  public String getClientBrand() {
+    return clientBrand;
   }
 
   void setClientBrand(String clientBrand) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/util/PluginMessageUtil.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/util/PluginMessageUtil.java
@@ -160,11 +160,15 @@ public final class PluginMessageUtil {
     return new PluginMessage(message.getChannel(), rewrittenBuf);
   }
 
-  private static String readBrandMessage(ByteBuf content) {
-    // Some clients (mostly poorly-implemented bots) do not send validly-formed brand messages.
-    // In order to accommodate their broken behavior, we'll first try to read in the 1.8 format, and
-    // if that fails, treat it as a 1.7-format message (which has no prefixed length). (The message
-    // Velocity sends will be in the correct format depending on the protocol.)
+  /**
+   * Some clients (mostly poorly-implemented bots) do not send validly-formed brand messages.
+   * In order to accommodate their broken behavior, we'll first try to read in the 1.8 format, and
+   * if that fails, treat it as a 1.7-format message (which has no prefixed length). (The message
+   * Velocity sends will be in the correct format depending on the protocol.)
+   * @param content the brand packet
+   * @return the client brand
+   */
+  public static String readBrandMessage(ByteBuf content) {
     try {
       return ProtocolUtils.readString(content.slice());
     } catch (Exception e) {


### PR DESCRIPTION
This Pull Request adds the `getClientBrand()` method to the Player object to retrieve the client's brand.

```
[23:39:53 INFO]: [server connection] ArtutoGamer -> lobby has connected
[23:39:53 INFO]: CLIENT BRAND: fabric
[23:40:59 INFO]: [connected player] artuto_is_dev (/127.0.0.1:50674) has connected
[23:40:59 INFO]: [server connection] artuto_is_dev -> lobby has connected
[23:41:02 INFO]: CLIENT BRAND: vanilla
```