### PR TITLE
Custom localization for each player

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -47,9 +47,12 @@ public interface Player extends CommandSource, Identified, InboundConnection,
   String getUsername();
 
   /**
+   * The locale the velocity proxy is translating its messages to. By default {@link PlayerSettings#getLocale()}
    *
-   * @return the locale the velocity proxy is translating its messages to. By default {@link PlayerSettings#getLocale()}
-   * Can be null when the settings have not been initialized yet.
+   * <p>Can be null when the settings have not been initialized yet.</p>
+   *
+   * @return the locale.
+   *
    */
   @Nullable Locale getProxyLocale();
 

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -49,14 +49,14 @@ public interface Player extends CommandSource, Identified, InboundConnection,
   /**
    * The locale the velocity proxy is translating its messages to. By default {@link PlayerSettings#getLocale()}
    *
-   * <p>Can be {@code null} when the settings have not been initialized yet.</p>
+   * <p>This can be {@code null} when the client has not yet connected to any server.</p>
    *
    * @return the locale.
    */
   @Nullable Locale getEffectiveLocale();
 
   /**
-   * Change the locale the proxy is translating its messages to.
+   * Change the locale the proxy will be translating its messages to.
    *
    * @param locale the locale to translate to
    */

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -49,17 +49,18 @@ public interface Player extends CommandSource, Identified, InboundConnection,
   /**
    * The locale the velocity proxy is translating its messages to. By default {@link PlayerSettings#getLocale()}
    *
-   * <p>Can be null when the settings have not been initialized yet.</p>
+   * <p>Can be {@code null} when the settings have not been initialized yet.</p>
    *
    * @return the locale.
-   *
    */
-  @Nullable Locale getProxyLocale();
+  @Nullable Locale getEffectiveLocale();
 
-  /*
-  Change the locale the proxy is translating its messages to.
+  /**
+   * Change the locale the proxy is translating its messages to.
+   *
+   * @param locale the locale to translate to
    */
-  void setProxyLocale(Locale locale);
+  void setEffectiveLocale(Locale locale);
 
   /**
    * Returns the player's UUID.

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -19,6 +19,7 @@ import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.util.GameProfile;
 import com.velocitypowered.api.util.ModInfo;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.UnaryOperator;
@@ -45,6 +46,17 @@ public interface Player extends CommandSource, Identified, InboundConnection,
    */
   String getUsername();
 
+  /**
+   *
+   * @return the locale the velocity proxy is translating its messages to. By default {@link PlayerSettings#getLocale()}
+   * Can be null when the settings have not been initialized yet.
+   */
+  @Nullable Locale getProxyLocale();
+
+  /*
+  Change the locale the proxy is translating its messages to.
+   */
+  void setProxyLocale(Locale locale);
 
   /**
    * Returns the player's UUID.

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -47,7 +47,8 @@ public interface Player extends CommandSource, Identified, InboundConnection,
   String getUsername();
 
   /**
-   * The locale the velocity proxy is translating its messages to. By default {@link PlayerSettings#getLocale()}
+   * Returns the locale the proxy will use to send messages translated via the Adventure global translator.
+   * By default, the value of {@link PlayerSettings#getLocale()} is used.
    *
    * <p>This can be {@code null} when the client has not yet connected to any server.</p>
    *

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -48,7 +48,6 @@ import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.util.GameProfile;
 import com.velocitypowered.api.util.ModInfo;
 import com.velocitypowered.proxy.VelocityServer;
-import com.velocitypowered.proxy.config.VelocityConfiguration;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftConnectionAssociation;
 import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
@@ -79,7 +78,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
@@ -97,8 +95,6 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
-import net.kyori.adventure.title.Title;
-import net.kyori.adventure.title.Title.Times;
 import net.kyori.adventure.translation.GlobalTranslator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -149,6 +145,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
           .withStatic(PermissionChecker.POINTER, getPermissionChecker())
           .build();
   private @Nullable String clientBrand;
+  private @Nullable Locale proxyLocale;
 
   ConnectedPlayer(VelocityServer server, GameProfile profile, MinecraftConnection connection,
       @Nullable InetSocketAddress virtualHost, boolean onlineMode) {
@@ -176,6 +173,21 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   @Override
   public String getUsername() {
     return profile.getName();
+  }
+
+  @Override
+  public Locale getProxyLocale() {
+    if(proxyLocale == null){
+      if(settings == null)
+        return null;
+      return settings.getLocale();
+    }
+    return proxyLocale;
+  }
+
+  @Override
+  public void setProxyLocale(Locale locale) {
+    proxyLocale = locale;
   }
 
   @Override
@@ -276,7 +288,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
    */
   public Component translateMessage(Component message) {
     Locale locale = ClosestLocaleMatcher.INSTANCE
-        .lookupClosest(this.settings == null ? Locale.getDefault() : this.settings.getLocale());
+        .lookupClosest(getProxyLocale() == null ? Locale.getDefault() : getProxyLocale());
     return GlobalTranslator.render(message, locale);
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -145,7 +145,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
           .withStatic(PermissionChecker.POINTER, getPermissionChecker())
           .build();
   private @Nullable String clientBrand;
-  private @Nullable Locale proxyLocale;
+  private @Nullable Locale effectiveLocale;
 
   ConnectedPlayer(VelocityServer server, GameProfile profile, MinecraftConnection connection,
       @Nullable InetSocketAddress virtualHost, boolean onlineMode) {
@@ -176,19 +176,19 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   }
 
   @Override
-  public Locale getProxyLocale() {
-    if (proxyLocale == null) {
+  public Locale getEffectiveLocale() {
+    if (effectiveLocale == null) {
       if (settings == null) {
         return null;
       }
       return settings.getLocale();
     }
-    return proxyLocale;
+    return effectiveLocale;
   }
 
   @Override
-  public void setProxyLocale(Locale locale) {
-    proxyLocale = locale;
+  public void setEffectiveLocale(Locale locale) {
+    effectiveLocale = locale;
   }
 
   @Override
@@ -289,7 +289,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
    */
   public Component translateMessage(Component message) {
     Locale locale = ClosestLocaleMatcher.INSTANCE
-        .lookupClosest(getProxyLocale() == null ? Locale.getDefault() : getProxyLocale());
+        .lookupClosest(getEffectiveLocale() == null ? Locale.getDefault() : getEffectiveLocale());
     return GlobalTranslator.render(message, locale);
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -177,10 +177,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
 
   @Override
   public Locale getEffectiveLocale() {
-    if (effectiveLocale == null) {
-      if (settings == null) {
-        return null;
-      }
+    if (effectiveLocale == null && settings != null) {
       return settings.getLocale();
     }
     return effectiveLocale;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -177,9 +177,10 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
 
   @Override
   public Locale getProxyLocale() {
-    if(proxyLocale == null){
-      if(settings == null)
+    if (proxyLocale == null) {
+      if (settings == null) {
         return null;
+      }
       return settings.getLocale();
     }
     return proxyLocale;


### PR DESCRIPTION
I have a network where the player can choose their language for the network independently of their client language.
Velocity won't cooperate with this, so I have added a method to switch their language with a method. 

If not set by a plugin, it will return the default language of the player in the settings object or null if the settings are null(On player login). The result of the getLocale method in the settings object will be unchanged by the set value.