### PR TITLE
Expose CommandMeta in CommandManager and add a ref to the plugin instance

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
@@ -8,6 +8,7 @@
 package com.velocitypowered.api.command;
 
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -72,6 +73,13 @@ public interface CommandManager {
    * @param alias the command alias to unregister
    */
   void unregister(String alias);
+
+  /**
+   * Retrieves the {@link CommandMeta} from the specified command alias, if registered.
+   * @param alias the command alias to lookup
+   * @return an {@link Optional} {@link CommandMeta} of the alias
+   */
+  Optional<CommandMeta> getCommandMeta(String alias);
 
   /**
    * Attempts to asynchronously execute a command from the given {@code cmdLine}.

--- a/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
@@ -8,8 +8,8 @@
 package com.velocitypowered.api.command;
 
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Handles the registration and execution of commands.
@@ -77,9 +77,9 @@ public interface CommandManager {
   /**
    * Retrieves the {@link CommandMeta} from the specified command alias, if registered.
    * @param alias the command alias to lookup
-   * @return an {@link Optional} {@link CommandMeta} of the alias
+   * @return an {@link CommandMeta} of the alias
    */
-  Optional<CommandMeta> getCommandMeta(String alias);
+  @Nullable CommandMeta getCommandMeta(String alias);
 
   /**
    * Attempts to asynchronously execute a command from the given {@code cmdLine}.

--- a/api/src/main/java/com/velocitypowered/api/command/CommandMeta.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandMeta.java
@@ -9,6 +9,7 @@ package com.velocitypowered.api.command;
 
 import com.mojang.brigadier.tree.CommandNode;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Contains metadata for a {@link Command}.
@@ -33,6 +34,14 @@ public interface CommandMeta {
   Collection<CommandNode<CommandSource>> getHints();
 
   /**
+   * Returns the plugin who registered the command.
+   * Note some {@link Command} registrations may not provide this information.
+   *
+   * @return the registering plugin
+   */
+  Optional<Object> getPlugin();
+
+  /**
    * Provides a fluent interface to create {@link CommandMeta}s.
    */
   interface Builder {
@@ -55,6 +64,14 @@ public interface CommandMeta {
      *         {@link com.mojang.brigadier.Command}, or has a redirect.
      */
     Builder hint(CommandNode<CommandSource> node);
+
+    /**
+     * Specifies the plugin who registers the {@link Command}.
+     *
+     * @param plugin the registering plugin
+     * @return this builder, for chaining
+     */
+    Builder plugin(Object plugin);
 
     /**
      * Returns a newly-created {@link CommandMeta} based on the specified parameters.

--- a/api/src/main/java/com/velocitypowered/api/command/CommandMeta.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandMeta.java
@@ -9,7 +9,7 @@ package com.velocitypowered.api.command;
 
 import com.mojang.brigadier.tree.CommandNode;
 import java.util.Collection;
-import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Contains metadata for a {@link Command}.
@@ -39,7 +39,7 @@ public interface CommandMeta {
    *
    * @return the registering plugin
    */
-  Optional<Object> getPlugin();
+  @Nullable Object getPlugin();
 
   /**
    * Provides a fluent interface to create {@link CommandMeta}s.

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -160,12 +160,18 @@ public class VelocityCommandManager implements CommandManager {
       CommandMeta meta = commandMetas.get(alias);
       if (meta != null) {
         for (String metaAlias : meta.getAliases()) {
-          commandMetas.remove(metaAlias);
+          commandMetas.remove(metaAlias, meta);
         }
       }
     } finally {
       lock.writeLock().unlock();
     }
+  }
+
+  @Override
+  public @Nullable CommandMeta getCommandMeta(String alias) {
+    Preconditions.checkNotNull(alias, "alias");
+    return commandMetas.get(alias);
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -41,7 +41,6 @@ import com.velocitypowered.proxy.event.VelocityEventManager;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -50,6 +49,7 @@ import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.checkerframework.checker.lock.qual.GuardedBy;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
 public class VelocityCommandManager implements CommandManager {
@@ -154,9 +154,9 @@ public class VelocityCommandManager implements CommandManager {
   }
 
   @Override
-  public Optional<CommandMeta> getCommandMeta(String alias) {
+  public @Nullable CommandMeta getCommandMeta(String alias) {
     Preconditions.checkNotNull(alias, "alias");
-    return Optional.ofNullable(commandMeta.get(alias.toLowerCase(Locale.ENGLISH)));
+    return commandMeta.get(alias.toLowerCase(Locale.ENGLISH));
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -20,7 +20,6 @@ package com.velocitypowered.proxy.command;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -44,6 +43,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import net.kyori.adventure.identity.Identity;
@@ -79,7 +79,7 @@ public class VelocityCommandManager implements CommandManager {
             new RawCommandRegistrar(root, this.lock.writeLock()));
     this.suggestionsProvider = new SuggestionsProvider<>(this.dispatcher, this.lock.readLock());
     this.injector = new CommandGraphInjector<>(this.dispatcher, this.lock.readLock());
-    this.commandMeta = Maps.newConcurrentMap();
+    this.commandMeta = new ConcurrentHashMap<>();
   }
 
   public void setAnnounceProxyCommands(boolean announceProxyCommands) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandMeta.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandMeta.java
@@ -28,8 +28,10 @@ import com.velocitypowered.api.command.CommandSource;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class VelocityCommandMeta implements CommandMeta {
 
@@ -37,12 +39,14 @@ public final class VelocityCommandMeta implements CommandMeta {
 
     private final ImmutableSet.Builder<String> aliases;
     private final ImmutableList.Builder<CommandNode<CommandSource>> hints;
+    private Object plugin;
 
     public Builder(final String alias) {
       Preconditions.checkNotNull(alias, "alias");
       this.aliases = ImmutableSet.<String>builder()
               .add(alias.toLowerCase(Locale.ENGLISH));
       this.hints = ImmutableList.builder();
+      this.plugin = null;
     }
 
     @Override
@@ -70,8 +74,15 @@ public final class VelocityCommandMeta implements CommandMeta {
     }
 
     @Override
+    public CommandMeta.Builder plugin(Object plugin) {
+      Preconditions.checkNotNull(plugin, "plugin");
+      this.plugin = plugin;
+      return this;
+    }
+
+    @Override
     public CommandMeta build() {
-      return new VelocityCommandMeta(this.aliases.build(), this.hints.build());
+      return new VelocityCommandMeta(this.aliases.build(), this.hints.build(), this.plugin);
     }
   }
 
@@ -111,11 +122,16 @@ public final class VelocityCommandMeta implements CommandMeta {
 
   private final Set<String> aliases;
   private final List<CommandNode<CommandSource>> hints;
+  private final Object plugin;
 
   private VelocityCommandMeta(
-          final Set<String> aliases, final List<CommandNode<CommandSource>> hints) {
+          final Set<String> aliases,
+          final List<CommandNode<CommandSource>> hints,
+          final @Nullable Object plugin
+  ) {
     this.aliases = aliases;
     this.hints = hints;
+    this.plugin = plugin;
   }
 
   @Override
@@ -126,6 +142,11 @@ public final class VelocityCommandMeta implements CommandMeta {
   @Override
   public Collection<CommandNode<CommandSource>> getHints() {
     return this.hints;
+  }
+
+  @Override
+  public Optional<Object> getPlugin() {
+    return Optional.ofNullable(plugin);
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandMeta.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandMeta.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class VelocityCommandMeta implements CommandMeta {
@@ -38,7 +39,7 @@ public final class VelocityCommandMeta implements CommandMeta {
 
     private final ImmutableSet.Builder<String> aliases;
     private final ImmutableList.Builder<CommandNode<CommandSource>> hints;
-    private Object plugin;
+    private @MonotonicNonNull Object plugin;
 
     public Builder(final String alias) {
       Preconditions.checkNotNull(alias, "alias");

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandMeta.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandMeta.java
@@ -28,7 +28,6 @@ import com.velocitypowered.api.command.CommandSource;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -145,8 +144,8 @@ public final class VelocityCommandMeta implements CommandMeta {
   }
 
   @Override
-  public Optional<Object> getPlugin() {
-    return Optional.ofNullable(plugin);
+  public @Nullable Object getPlugin() {
+    return plugin;
   }
 
   @Override


### PR DESCRIPTION
Instead of having a reference to the plugin instance, a string with the plugin id might also be a nice idea -- but not sure which one would be preferred.