### PR TITLE
Expose registered aliases in API

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
@@ -8,6 +8,7 @@
 package com.velocitypowered.api.command;
 
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -95,10 +96,18 @@ public interface CommandManager {
   CompletableFuture<Boolean> executeImmediatelyAsync(CommandSource source, String cmdLine);
 
   /**
+   * Returns an immutable collection of the case-insensitive aliases registered
+   * on this manager.
+   *
+   * @return the registered aliases
+   */
+  Collection<String> getAliases();
+
+  /**
    * Returns whether the given alias is registered on this manager.
    *
    * @param alias the command alias to check
-   * @return {@code true} if the alias is registered
+   * @return true if the alias is registered; false otherwise
    */
   boolean hasCommand(String alias);
 }

--- a/proxy/src/test/java/com/velocitypowered/proxy/command/CommandManagerTests.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/command/CommandManagerTests.java
@@ -17,11 +17,13 @@
 
 package com.velocitypowered.proxy.command;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.google.common.collect.ImmutableList;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.velocitypowered.api.command.BrigadierCommand;
 import com.velocitypowered.api.command.CommandSource;
@@ -41,6 +43,7 @@ public class CommandManagerTests extends CommandTestSuite {
     manager.register(meta, DummyCommand.INSTANCE);
 
     assertTrue(manager.hasCommand("hello"));
+    assertRegisteredAliases("hello");
   }
 
   @Test
@@ -55,6 +58,7 @@ public class CommandManagerTests extends CommandTestSuite {
     assertTrue(manager.hasCommand("bar"));
     assertTrue(manager.hasCommand("baz"));
     assertTrue(manager.hasCommand("qux"));
+    assertRegisteredAliases("foo", "bar", "baz", "qux");
   }
 
   @Test
@@ -66,6 +70,7 @@ public class CommandManagerTests extends CommandTestSuite {
 
     assertTrue(manager.hasCommand("foo"));
     assertTrue(manager.hasCommand("bar"));
+    assertRegisteredAliases("foo", "bar");
   }
 
   @Test
@@ -76,6 +81,7 @@ public class CommandManagerTests extends CommandTestSuite {
     manager.register(new BrigadierCommand(node));
 
     assertTrue(manager.hasCommand("hello"));
+    assertRegisteredAliases("hello");
   }
 
   @Test
@@ -125,6 +131,7 @@ public class CommandManagerTests extends CommandTestSuite {
     manager.unregister("hello");
 
     assertFalse(manager.hasCommand("hello"));
+    assertRegisteredAliases();
   }
 
   @Test
@@ -133,6 +140,7 @@ public class CommandManagerTests extends CommandTestSuite {
     manager.unregister("hello");
 
     assertFalse(manager.hasCommand("hello"));
+    assertRegisteredAliases();
   }
 
   @Test
@@ -145,6 +153,7 @@ public class CommandManagerTests extends CommandTestSuite {
 
     assertFalse(manager.hasCommand("bar"));
     assertTrue(manager.hasCommand("foo"));
+    assertRegisteredAliases("foo");
   }
 
   // Execution

--- a/proxy/src/test/java/com/velocitypowered/proxy/command/CommandTestSuite.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/command/CommandTestSuite.java
@@ -30,6 +30,7 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.proxy.event.MockEventManager;
 import com.velocitypowered.proxy.event.VelocityEventManager;
 import java.util.Arrays;
+import java.util.Collection;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,5 +80,13 @@ abstract class CommandTestSuite {
     when(player.getPermissionValue(any())).thenReturn(Tristate.UNDEFINED);
     final var actual = manager.offerSuggestions(player, input).join();
     assertEquals(Arrays.asList(expectedSuggestions), actual);
+  }
+
+  final void assertRegisteredAliases(final String... expected) {
+    final Collection<String> actual = manager.getAliases();
+    assertEquals(expected.length, actual.size());
+    final Collection<String> asList = Arrays.asList(expected);
+    assertTrue(asList.containsAll(actual));
+    assertTrue(actual.containsAll(asList));
   }
 }


### PR DESCRIPTION
We return an immutable copy since the method is unlikely to be called often by users. Exposing a view of the root node's children is somewhat complex (and would have pretty terrible access costs), and I imagine not that many plugins need access to these data so regularly. We make no ordering guarantees about the returned aliases.

Requested by @YouHaveTrouble.