### PR TITLE
Add Automatic-Module-Name to published api jar

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -63,6 +63,9 @@ task sourcesJar(type: Jar) {
 
 jar {
     from sourceSets.ap.output
+    manifest {
+        attributes 'Automatic-Module-Name': 'com.velocitypowered.api'
+    }
 }
 
 shadowJar {


### PR DESCRIPTION
This is the very first step towards #403 - declaring a stable module name which will let plugins compile against it. At the moment this is compile-time only and has no effect at runtime.

The reason I didn't create a similar PR for polymer is because it would serve no purpose. For polymer, there's no need to add a transitory Automatic-Module-Name. Polymer may jump straight to adding module descriptors (module-info files) for it to modularize. That, however, will involve more than a simple manifest attribute.