### PR TITLE
Introduce `PlayerClientBrandEvent`

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/player/PlayerClientBrandEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/PlayerClientBrandEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.event.player;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.proxy.Player;
+
+/**
+ * Fired when a {@link Player} sends the <code>minecraft:brand</code> plugin message.
+ */
+public final class PlayerClientBrandEvent {
+  private final Player player;
+  private final String brand;
+
+  /**
+   * Creates a new instance.
+   *
+   * @param player the {@link Player} of the sent client brand
+   * @param brand the sent client brand
+   */
+  public PlayerClientBrandEvent(Player player, String brand) {
+    this.player = Preconditions.checkNotNull(player);
+    this.brand = Preconditions.checkNotNull(brand);
+  }
+
+  public Player getPlayer() {
+    return player;
+  }
+
+  public String getBrand() {
+    return brand;
+  }
+
+  @Override
+  public String toString() {
+    return "PlayerClientBrandEvent{"
+      + "player=" + player
+      + ", brand='" + brand + '\''
+      + '}';
+  }
+}
+

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -27,6 +27,7 @@ import com.velocitypowered.api.event.command.CommandExecuteEvent.CommandResult;
 import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.event.player.PlayerChannelRegisterEvent;
 import com.velocitypowered.api.event.player.PlayerChatEvent;
+import com.velocitypowered.api.event.player.PlayerClientBrandEvent;
 import com.velocitypowered.api.event.player.PlayerResourcePackStatusEvent;
 import com.velocitypowered.api.event.player.TabCompleteEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
@@ -229,7 +230,9 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
         player.getKnownChannels().removeAll(PluginMessageUtil.getChannels(packet));
         backendConn.write(packet.retain());
       } else if (PluginMessageUtil.isMcBrand(packet)) {
-        player.setClientBrand(PluginMessageUtil.readBrandMessage(packet.content()));
+        String brand = PluginMessageUtil.readBrandMessage(packet.content());
+        server.getEventManager().fireAndForget(new PlayerClientBrandEvent(player, brand));
+        player.setClientBrand(brand);
         backendConn.write(PluginMessageUtil
             .rewriteMinecraftBrand(packet, server.getVersion(), player.getProtocolVersion()));
       } else if (BungeeCordMessageResponder.isBungeeCordMessage(packet)) {


### PR DESCRIPTION
Fired when the player sends the `minecraft:brand` (or equivalent) plugin message.  If the result is
`DENIED`, the player brand is not set (`setClientBrand` is not called),
and it is not forwarded to the backend.