### PR TITLE
Fix legacy handshake with paper 1.16.5 and higher, update jenkins link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Velocity
 
-[![Build Status](https://img.shields.io/jenkins/s/https/ci.velocitypowered.com/job/velocity.svg)](https://ci.velocitypowered.com/job/velocity/)
+[![Build Status](https://img.shields.io/jenkins/s/https/ci.velocitypowered.com/job/velocity.svg)](https://ci.velocitypowered.com/job/velocity-3.0.0/)
 [![Join our Discord](https://img.shields.io/discord/472484458856185878.svg?logo=discord&label=)](https://discord.gg/8cB9Bgf)
 
 A Minecraft server proxy with unparalleled server support, scalability,

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -122,7 +122,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
             .orElseGet(() -> registeredServer.getServerInfo().getAddress())
             .getHostString())
         .append('\0')
-        .append(proxyPlayer.getRemoteAddress().getHostString())
+        .append(proxyPlayer.getRemoteAddress().getAddress().getHostAddress())
         .append('\0')
         .append(proxyPlayer.getGameProfile().getUndashedId())
         .append('\0');


### PR DESCRIPTION
If you have Minecraft servers on different versions (1.12.2 and 1.16.5 in our case), you can only use "bungeeguard" or "legacy" forwarding type. If you use the "bungeeguard" type, then everything will be ok, but if you use the "legacy" type, then players, who have an IP with a hostname (like 127.0.0.1.your-provider.net), won't be able to connect to the Paper 1.16.5+ Minecraft server. Players will see an error message "`If you wish to use IP forwarding, please enable it in your BungeeCord config as well!`"