### PR TITLE
Fix title display after clearTitle()

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -370,18 +370,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
       GsonComponentSerializer serializer = ProtocolUtils.getJsonChatSerializer(this
           .getProtocolVersion());
 
-      GenericTitlePacket titlePkt = GenericTitlePacket.constructTitlePacket(
-                      GenericTitlePacket.ActionType.SET_TITLE, this.getProtocolVersion());
-      titlePkt.setComponent(serializer.serialize(translateMessage(title.title())));
-      connection.delayedWrite(titlePkt);
-
-      GenericTitlePacket subtitlePkt = GenericTitlePacket.constructTitlePacket(
-              GenericTitlePacket.ActionType.SET_SUBTITLE, this.getProtocolVersion());
-      subtitlePkt.setComponent(serializer.serialize(translateMessage(title.subtitle())));
-      connection.delayedWrite(subtitlePkt);
-
       GenericTitlePacket timesPkt = GenericTitlePacket.constructTitlePacket(
-              GenericTitlePacket.ActionType.SET_TIMES, this.getProtocolVersion());
+          GenericTitlePacket.ActionType.SET_TIMES, this.getProtocolVersion());
       net.kyori.adventure.title.Title.Times times = title.times();
       if (times != null) {
         timesPkt.setFadeIn((int) DurationUtils.toTicks(times.fadeIn()));
@@ -389,6 +379,16 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
         timesPkt.setFadeOut((int) DurationUtils.toTicks(times.fadeOut()));
       }
       connection.delayedWrite(timesPkt);
+
+      GenericTitlePacket subtitlePkt = GenericTitlePacket.constructTitlePacket(
+          GenericTitlePacket.ActionType.SET_SUBTITLE, this.getProtocolVersion());
+      subtitlePkt.setComponent(serializer.serialize(translateMessage(title.subtitle())));
+      connection.delayedWrite(subtitlePkt);
+
+      GenericTitlePacket titlePkt = GenericTitlePacket.constructTitlePacket(
+          GenericTitlePacket.ActionType.SET_TITLE, this.getProtocolVersion());
+      titlePkt.setComponent(serializer.serialize(translateMessage(title.title())));
+      connection.delayedWrite(titlePkt);
 
       connection.flush();
     }


### PR DESCRIPTION
Hello,

I've found a bug within the current title implementation. The title packets are sent in reverse order and therefore some things won't work:
* If you send `clearTitle()` and then `showTitle(Title)`, no title will be shown. Only if you use `showTitle(Title)` twice, the second invocation will indeed display a title to the client.
* Theoretically (I have not tested this case) the times packets should be wrongly assigned. That means if you send a title, that should be displayed for 5s and one title that should be displayed for 10s, the second title should be displayed for 5s.

I've aligned the order of the packets with what Bukkit does. That order is `Times -> Subtitle -> Title` and Velocity's current order is `Title -> Subtitle -> Times`.

To verify my fix, I've written this small plugin and confirmed it is effective:
```java
package net.scrayos;

import com.google.inject.Inject;
import com.mojang.brigadier.builder.LiteralArgumentBuilder;
import com.velocitypowered.api.command.BrigadierCommand;
import com.velocitypowered.api.command.CommandSource;
import com.velocitypowered.api.event.Subscribe;
import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
import com.velocitypowered.api.plugin.Plugin;
import com.velocitypowered.api.proxy.ProxyServer;
import net.kyori.adventure.text.Component;
import net.kyori.adventure.title.Title;

import java.time.Duration;

@Plugin(
    id = "velocity-title-test",
    name = "VelocityTitleTest",
    version = "1.0.0-SNAPSHOT"
)
public class VelocityTitleTest {

    private static final Title SHOW_TITLE = Title.title(
        Component.text("Title"),
        Component.text("Subitle"),
        Title.Times.of(
            Duration.ZERO,
            Duration.ofSeconds(1),
            Duration.ZERO
        )
    );


    private final ProxyServer server;


    @Inject
    public VelocityTitleTest(final ProxyServer server) {
        this.server = server;
    }

    @Subscribe
    public void onProxyInitialize(final ProxyInitializeEvent e) {
        server.getCommandManager().register(new BrigadierCommand(
            LiteralArgumentBuilder.<CommandSource>literal("test")
                .then(
                    LiteralArgumentBuilder.<CommandSource>literal("show")
                        .executes(command -> {
                            command.getSource().showTitle(SHOW_TITLE);
                            return 1;
                        })
                )
                .then(
                    LiteralArgumentBuilder.<CommandSource>literal("clear")
                        .executes(command -> {
                            command.getSource().clearTitle();
                            return 1;
                        })
                )
        ));
    }
}
```