### PR TITLE
dont crash when attempt-servers order is empty, return empty optional instead

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -690,7 +690,12 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
     }
 
     if (serversToTry.isEmpty()) {
-      serversToTry = server.getConfiguration().getAttemptConnectionOrder();
+      List<String> connOrder = server.getConfiguration().getAttemptConnectionOrder();
+      if (connOrder.isEmpty()) {
+        return Optional.empty();
+      } else {
+        serversToTry = connOrder;
+      }
     }
 
     for (int i = tryIndex; i < serversToTry.size(); i++) {


### PR DESCRIPTION
If the `try: []` servers array was empty, velocity would crash when trying to **fallback** a player from a server to another. Yes, this is weird for the fact that the player was on the network at all given the empty `try: []` array. Though, this can be bypassed with plugins setting the initial target server on the initial network connect.

This change simply returns an empty optional when this array is null, is subsequently handled by kick the player from the network rather than producing an error.