### PR TITLE
[Future] Support for Minecraft 1.18

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(-1, 43, "1.18"); // Snapshot: 21w39a, future protocol: 757
+  MINECRAFT_1_18(-1, 44, "1.18"); // Snapshot: 21w40a, future protocol: 757
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(-1, 48, "1.18"); // Snapshot: 21w44a, future protocol: 757
+  MINECRAFT_1_18(-1, 49, "1.18"); // Snapshot: 1.18-pre1, future protocol: 757
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(-1, 46, "1.18"); // Snapshot: 21w42a, future protocol: 757
+  MINECRAFT_1_18(-1, 47, "1.18"); // Snapshot: 21w43a, future protocol: 757
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(-1, 44, "1.18"); // Snapshot: 21w40a, future protocol: 757
+  MINECRAFT_1_18(-1, 45, "1.18"); // Snapshot: 21w41a, future protocol: 757
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(-1, 42, "1.18"); // Snapshot: 21w38a, future protocol: 757
+  MINECRAFT_1_18(-1, 43, "1.18"); // Snapshot: 21w39a, future protocol: 757
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(-1, 53, "1.18"); // Snapshot: 1.18-pre5, future protocol: 757
+  MINECRAFT_1_18(-1, 54, "1.18"); // Snapshot: 1.18-pre6, future protocol: 757
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(-1, 54, "1.18"); // Snapshot: 1.18-pre6, future protocol: 757
+  MINECRAFT_1_18(757, "1.18");
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(-1, 41, "1.18"); // Snapshot: 21w37a, future protocol: 757
+  MINECRAFT_1_18(-1, 42, "1.18"); // Snapshot: 21w38a, future protocol: 757
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(-1, 45, "1.18"); // Snapshot: 21w41a, future protocol: 757
+  MINECRAFT_1_18(-1, 46, "1.18"); // Snapshot: 21w42a, future protocol: 757
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(-1, 50, "1.18"); // Snapshot: 1.18-pre1, future protocol: 757
+  MINECRAFT_1_18(-1, 52, "1.18"); // Snapshot: 1.18-pre4, future protocol: 757
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(-1, 49, "1.18"); // Snapshot: 1.18-pre1, future protocol: 757
+  MINECRAFT_1_18(-1, 50, "1.18"); // Snapshot: 1.18-pre1, future protocol: 757
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(-1, 47, "1.18"); // Snapshot: 21w43a, future protocol: 757
+  MINECRAFT_1_18(-1, 48, "1.18"); // Snapshot: 21w44a, future protocol: 757
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -55,7 +55,8 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_3(753, "1.16.3"),
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
-  MINECRAFT_1_17_1(756, "1.17.1");
+  MINECRAFT_1_17_1(756, "1.17.1"),
+  MINECRAFT_1_18(-1, 41, "1.18"); // Snapshot: 21w37a, future protocol: 757
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(-1, 52, "1.18"); // Snapshot: 1.18-pre4, future protocol: 757
+  MINECRAFT_1_18(-1, 53, "1.18"); // Snapshot: 1.18-pre5, future protocol: 757
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/proxy/player/PlayerSettings.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/PlayerSettings.java
@@ -57,6 +57,16 @@ public interface PlayerSettings {
    */
   MainHand getMainHand();
 
+  /**
+   * Returns whether the client explicitly allows listing on the
+   * {@link com.velocitypowered.api.proxy.player.TabList} or not in
+   * anonymous TabList mode.
+   * This feature was introduced in 1.18.
+   *
+   * @return whether or not the client explicitly allows listing. Always false on older clients.
+   */
+  boolean isClientListingAllowed();
+
   enum ChatMode {
     SHOWN,
     COMMANDS_ONLY,

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientSettingsWrapper.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientSettingsWrapper.java
@@ -74,5 +74,9 @@ public class ClientSettingsWrapper implements PlayerSettings {
     return settings.getMainHand() == 1 ? MainHand.RIGHT : MainHand.LEFT;
   }
 
+  @Override
+  public boolean isClientListingAllowed() {
+    return settings.isClientListingAllowed();
+  }
 
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientSettingsWrapper.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientSettingsWrapper.java
@@ -26,7 +26,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class ClientSettingsWrapper implements PlayerSettings {
 
   static final PlayerSettings DEFAULT = new ClientSettingsWrapper(
-      new ClientSettings("en_US", (byte) 10, 0, true, (short) 127, 1, true));
+      new ClientSettings("en_US", (byte) 10, 0, true, (short) 127, 1, true, false));
 
   private final ClientSettings settings;
   private final SkinParts parts;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
@@ -27,6 +27,7 @@ import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_16;
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_16_2;
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_16_4;
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_17;
+import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_18;
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_7_2;
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_8;
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_9;
@@ -246,7 +247,8 @@ public enum StateRegistry {
           map(0x53, MINECRAFT_1_14, true),
           map(0x54, MINECRAFT_1_15, true),
           map(0x53, MINECRAFT_1_16, true),
-          map(0x5E, MINECRAFT_1_17, true));
+          map(0x5E, MINECRAFT_1_17, true),
+          map(0x5F, MINECRAFT_1_18, true));
       clientbound.register(LegacyTitlePacket.class, LegacyTitlePacket::new,
           map(0x45, MINECRAFT_1_8, true),
           map(0x45, MINECRAFT_1_9, true),
@@ -257,13 +259,16 @@ public enum StateRegistry {
           map(0x50, MINECRAFT_1_15, true),
           map(0x4F, MINECRAFT_1_16, MINECRAFT_1_16_4, true));
       clientbound.register(TitleSubtitlePacket.class, TitleSubtitlePacket::new,
-          map(0x57, MINECRAFT_1_17, true));
+          map(0x57, MINECRAFT_1_17, true),
+          map(0x58, MINECRAFT_1_18, true));
       clientbound.register(TitleTextPacket.class, TitleTextPacket::new,
-          map(0x59, MINECRAFT_1_17, true));
+          map(0x59, MINECRAFT_1_17, true),
+          map(0x5A, MINECRAFT_1_18, true));
       clientbound.register(TitleActionbarPacket.class, TitleActionbarPacket::new,
           map(0x41, MINECRAFT_1_17, true));
       clientbound.register(TitleTimesPacket.class, TitleTimesPacket::new,
-          map(0x5A, MINECRAFT_1_17, true));
+          map(0x5A, MINECRAFT_1_17, true),
+          map(0x5B, MINECRAFT_1_18, true));
       clientbound.register(TitleClearPacket.class, TitleClearPacket::new,
           map(0x10, MINECRAFT_1_17, true));
       clientbound.register(PlayerListItem.class, PlayerListItem::new,

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientSettings.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientSettings.java
@@ -34,18 +34,20 @@ public class ClientSettings implements MinecraftPacket {
   private short skinParts;
   private int mainHand;
   private boolean chatFilteringEnabled; // Added in 1.17
+  private boolean clientListingAllowed; // Added in 1.18, overwrites server-list "anonymous" mode
 
   public ClientSettings() {
   }
 
   public ClientSettings(String locale, byte viewDistance, int chatVisibility, boolean chatColors,
-      short skinParts, int mainHand, boolean chatFilteringEnabled) {
+      short skinParts, int mainHand, boolean chatFilteringEnabled, boolean clientListingAllowed) {
     this.locale = locale;
     this.viewDistance = viewDistance;
     this.chatVisibility = chatVisibility;
     this.chatColors = chatColors;
     this.skinParts = skinParts;
     this.mainHand = mainHand;
+    this.clientListingAllowed = clientListingAllowed;
   }
 
   public String getLocale() {
@@ -107,6 +109,14 @@ public class ClientSettings implements MinecraftPacket {
     this.chatFilteringEnabled = chatFilteringEnabled;
   }
 
+  public boolean isClientListingAllowed() {
+    return clientListingAllowed;
+  }
+
+  public void setClientListingAllowed(boolean clientListingAllowed) {
+    this.clientListingAllowed = clientListingAllowed;
+  }
+
   @Override
   public String toString() {
     return "ClientSettings{"
@@ -117,6 +127,7 @@ public class ClientSettings implements MinecraftPacket {
         + ", skinParts=" + skinParts
         + ", mainHand=" + mainHand
         + ", chatFilteringEnabled=" + chatFilteringEnabled
+        + ", clientListingAllowed=" + clientListingAllowed
         + '}';
   }
 
@@ -138,6 +149,10 @@ public class ClientSettings implements MinecraftPacket {
 
       if (version.compareTo(ProtocolVersion.MINECRAFT_1_17) >= 0) {
         this.chatFilteringEnabled = buf.readBoolean();
+
+        if (version.compareTo(ProtocolVersion.MINECRAFT_1_18) >= 0) {
+          this.clientListingAllowed = buf.readBoolean();
+        }
       }
     }
   }
@@ -163,6 +178,10 @@ public class ClientSettings implements MinecraftPacket {
 
       if (version.compareTo(ProtocolVersion.MINECRAFT_1_17) >= 0) {
         buf.writeBoolean(chatFilteringEnabled);
+
+        if (version.compareTo(ProtocolVersion.MINECRAFT_1_18) >= 0) {
+          buf.writeBoolean(clientListingAllowed);
+        }
       }
     }
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGame.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGame.java
@@ -50,6 +50,7 @@ public class JoinGame implements MinecraftPacket {
   private DimensionData currentDimensionData; // 1.16.2+
   private short previousGamemode; // 1.16+
   private CompoundBinaryTag biomeRegistry; // 1.16.2+
+  private int simulationDistance; // 1.18+
 
   public int getEntityId() {
     return entityId;
@@ -163,6 +164,14 @@ public class JoinGame implements MinecraftPacket {
     return currentDimensionData;
   }
 
+  public int getSimulationDistance(){
+    return simulationDistance;
+  }
+
+  public void setSimulationDistance(int simulationDistance) {
+    this.simulationDistance = simulationDistance;
+  }
+
   @Override
   public String toString() {
     return "JoinGame{"
@@ -178,6 +187,7 @@ public class JoinGame implements MinecraftPacket {
         + ", dimensionRegistry='" + dimensionRegistry + '\''
         + ", dimensionInfo='" + dimensionInfo + '\''
         + ", previousGamemode=" + previousGamemode
+        + ", simulationDistance=" + simulationDistance
         + '}';
   }
 
@@ -271,6 +281,10 @@ public class JoinGame implements MinecraftPacket {
     }
 
     this.viewDistance = ProtocolUtils.readVarInt(buf);
+    if (version.compareTo(ProtocolVersion.MINECRAFT_1_18) >= 0) {
+      this.simulationDistance = ProtocolUtils.readVarInt(buf);
+    }
+
     this.reducedDebugInfo = buf.readBoolean();
     this.showRespawnScreen = buf.readBoolean();
     boolean isDebug = buf.readBoolean();
@@ -360,6 +374,10 @@ public class JoinGame implements MinecraftPacket {
       buf.writeByte(maxPlayers);
     }
     ProtocolUtils.writeVarInt(buf, viewDistance);
+    if (version.compareTo(ProtocolVersion.MINECRAFT_1_18) >= 0) {
+      ProtocolUtils.writeVarInt(buf, simulationDistance);
+    }
+
     buf.writeBoolean(reducedDebugInfo);
     buf.writeBoolean(showRespawnScreen);
     buf.writeBoolean(dimensionInfo.isDebugType());


### PR DESCRIPTION
# Velocity support for Minecraft 1.18
This Pull-request exists to track the changes in the Minecraft development cycle and is aimed to prepare Velocity for the future release of Minecraft
 
## New Features
API-Changes here are not final (if any) and may be changed without warning. Proceed with caution.

## I want to run this!
You may want to run a proxy with snapshot support for any number of reasons.
Builds of this in-dev version can be found here: 
https://ci.velocitypowered.com/job/velocity-1.18-snapshot-build/
**Please make extra-sure to use the build for the snapshot you want to run**   

To make your Spigot/Paper servers support the snapshots, you can use the development versions of ViaVersion found [here](https://ci.viaversion.com/job/ViaVersion-DEV/).
If you plan on running a snapshot server, you can use [Fabric](https://fabricmc.net/use/) alongside the [FabricProxy-Lite](https://www.curseforge.com/minecraft/mc-mods/fabricproxy-lite) mod to integrate the server into the network.

## I found a bug!
Even if this isn't totally stable, it is definitely meant to be. If you use it and encounter any bugs **please let me know**.
Bugs I don't encounter are bugs I can't fix so I am glad for any tiny issue report.