### PR TITLE
Add ProxyExceptionEvent to allow for outsourcing exception logging

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/proxy/ProxyExceptionEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/ProxyExceptionEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.event.proxy;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.proxy.exception.ProxyException;
+
+/**
+ * This event is fired by the proxy when an exception is thrown
+ * in a recoverable section of the server.
+ */
+public class ProxyExceptionEvent {
+
+  private final ProxyException exception;
+
+  public ProxyExceptionEvent(ProxyException exception) {
+    this.exception = Preconditions.checkNotNull(exception, "exception");
+  }
+
+  /**
+   * Gets the wrapped exception that was thrown.
+   *
+   * @return Thrown exception
+   */
+  public ProxyException getException() {
+    return exception;
+  }
+
+  @Override
+  public String toString() {
+    return "ProxyExceptionEvent{"
+        + "exception=" + exception
+        + '}';
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyCommandException.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyCommandException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.proxy.exception;
+
+import com.velocitypowered.api.command.CommandSource;
+
+public class ProxyCommandException extends ProxyException {
+
+  private final CommandSource commandSource;
+  private final String command;
+
+  /**
+   * Constructor for a ProxyCommandException.
+   */
+  public ProxyCommandException(String message, Throwable cause,
+                               CommandSource commandSource, String command) {
+    super(message, cause);
+    this.commandSource = commandSource;
+    this.command = command;
+  }
+
+  protected ProxyCommandException(String message, Throwable cause, boolean enableSuppression,
+                                  boolean writableStackTrace, CommandSource commandSource, String command) {
+    super(message, cause, enableSuppression, writableStackTrace);
+    this.commandSource = commandSource;
+    this.command = command;
+  }
+
+  /**
+   * Constructor for a ProxyCommandException.
+   */
+  public ProxyCommandException(Throwable cause, CommandSource commandSource, String command) {
+    super(cause);
+    this.commandSource = commandSource;
+    this.command = command;
+  }
+
+  public CommandSource getCommandSource() {
+    return commandSource;
+  }
+
+  public String getCommand() {
+    return command;
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyEventException.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyEventException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.proxy.exception;
+
+import com.velocitypowered.api.plugin.PluginContainer;
+
+public class ProxyEventException extends ProxyPluginException {
+
+  private final Class<?> eventType;
+
+  public ProxyEventException(String message, Throwable cause, PluginContainer plugin, Class<?> eventType) {
+    super(message, cause, plugin);
+    this.eventType = eventType;
+  }
+
+  protected ProxyEventException(String message, Throwable cause, boolean enableSuppression,
+                                boolean writableStackTrace, PluginContainer plugin, Class<?> eventType) {
+    super(message, cause, enableSuppression, writableStackTrace, plugin);
+    this.eventType = eventType;
+  }
+
+  public ProxyEventException(Throwable cause, PluginContainer plugin, Class<?> eventType) {
+    super(cause, plugin);
+    this.eventType = eventType;
+  }
+
+  public Class<?> getEventType() {
+    return eventType;
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyException.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.proxy.exception;
+
+public class ProxyException extends Exception {
+
+  public ProxyException(String message) {
+    super(message);
+  }
+
+  public ProxyException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  protected ProxyException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+  public ProxyException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyInternalException.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyInternalException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.proxy.exception;
+
+public class ProxyInternalException extends ProxyException {
+
+  public ProxyInternalException(String message) {
+    super(message);
+  }
+
+  public ProxyInternalException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  protected ProxyInternalException(String message, Throwable cause,
+                                   boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+  public ProxyInternalException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyPluginException.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyPluginException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.proxy.exception;
+
+import com.velocitypowered.api.plugin.PluginContainer;
+
+public class ProxyPluginException extends ProxyException {
+
+  private final PluginContainer plugin;
+
+  public ProxyPluginException(String message, Throwable cause, PluginContainer plugin) {
+    super(message, cause);
+    this.plugin = plugin;
+  }
+
+  protected ProxyPluginException(String message, Throwable cause, boolean enableSuppression,
+                                 boolean writableStackTrace, PluginContainer plugin) {
+    super(message, cause, enableSuppression, writableStackTrace);
+    this.plugin = plugin;
+  }
+
+  public ProxyPluginException(Throwable cause, PluginContainer plugin) {
+    super(cause);
+    this.plugin = plugin;
+  }
+
+  public PluginContainer getPlugin() {
+    return plugin;
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyPluginMessageException.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyPluginMessageException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.proxy.exception;
+
+import com.velocitypowered.api.event.connection.PluginMessageEvent;
+
+public class ProxyPluginMessageException extends ProxyException {
+
+  private final PluginMessageEvent event;
+
+  public ProxyPluginMessageException(String message, PluginMessageEvent event) {
+    super(message);
+    this.event = event;
+  }
+
+  public ProxyPluginMessageException(String message, Throwable cause, PluginMessageEvent event) {
+    super(message, cause);
+    this.event = event;
+  }
+
+  protected ProxyPluginMessageException(String message, Throwable cause, boolean enableSuppression,
+                                        boolean writableStackTrace, PluginMessageEvent event) {
+    super(message, cause, enableSuppression, writableStackTrace);
+    this.event = event;
+  }
+
+  public ProxyPluginMessageException(Throwable cause, PluginMessageEvent event) {
+    super(cause);
+    this.event = event;
+  }
+
+  public PluginMessageEvent getEvent() {
+    return event;
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxySchedulerException.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxySchedulerException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.proxy.exception;
+
+import com.velocitypowered.api.plugin.PluginContainer;
+import com.velocitypowered.api.scheduler.ScheduledTask;
+
+public class ProxySchedulerException extends ProxyPluginException {
+
+  private final ScheduledTask task;
+
+  public ProxySchedulerException(String message, Throwable cause, PluginContainer plugin, ScheduledTask task) {
+    super(message, cause, plugin);
+    this.task = task;
+  }
+
+  protected ProxySchedulerException(String message, Throwable cause, boolean enableSuppression,
+                                    boolean writableStackTrace, PluginContainer plugin, ScheduledTask task) {
+    super(message, cause, enableSuppression, writableStackTrace, plugin);
+    this.task = task;
+  }
+
+  public ProxySchedulerException(Throwable cause, PluginContainer plugin, ScheduledTask task) {
+    super(cause, plugin);
+    this.task = task;
+  }
+
+  public ScheduledTask getTask() {
+    return task;
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyTabCompleteException.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/exception/ProxyTabCompleteException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.proxy.exception;
+
+import com.velocitypowered.api.command.CommandSource;
+
+public class ProxyTabCompleteException extends ProxyCommandException {
+
+  public ProxyTabCompleteException(String message, Throwable cause, CommandSource commandSource, String command) {
+    super(message, cause, commandSource, command);
+  }
+
+  protected ProxyTabCompleteException(String message, Throwable cause, boolean enableSuppression,
+                                      boolean writableStackTrace, CommandSource commandSource, String command) {
+    super(message, cause, enableSuppression, writableStackTrace, commandSource, command);
+  }
+
+  public ProxyTabCompleteException(Throwable cause, CommandSource commandSource, String command) {
+    super(cause, commandSource, command);
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/event/VelocityEventManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/event/VelocityEventManager.java
@@ -23,9 +23,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Multimap;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.velocitypowered.api.event.Continuation;
@@ -34,8 +32,10 @@ import com.velocitypowered.api.event.EventManager;
 import com.velocitypowered.api.event.EventTask;
 import com.velocitypowered.api.event.PostOrder;
 import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.proxy.ProxyExceptionEvent;
 import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.PluginManager;
+import com.velocitypowered.api.proxy.exception.ProxyEventException;
 import com.velocitypowered.proxy.event.UntargetedEventHandler.EventTaskHandler;
 import com.velocitypowered.proxy.event.UntargetedEventHandler.VoidHandler;
 import com.velocitypowered.proxy.event.UntargetedEventHandler.WithContinuationHandler;
@@ -607,10 +607,14 @@ public class VelocityEventManager implements EventManager {
     }
   }
 
-  private static void logHandlerException(
+  private void logHandlerException(
       final HandlerRegistration registration, final Throwable t) {
     logger.error("Couldn't pass {} to {}", registration.eventType.getSimpleName(),
         registration.plugin.getDescription().getId(), t);
+    if (!ProxyExceptionEvent.class.equals(registration.eventType)) {
+      fireAndForget(new ProxyExceptionEvent(new ProxyEventException(t, registration.plugin,
+              registration.eventType)));
+    }
   }
 
   public boolean shutdown() throws InterruptedException {

--- a/proxy/src/main/java/com/velocitypowered/proxy/plugin/VelocityPluginManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/plugin/VelocityPluginManager.java
@@ -26,11 +26,13 @@ import com.google.inject.Module;
 import com.google.inject.name.Names;
 import com.velocitypowered.api.command.CommandManager;
 import com.velocitypowered.api.event.EventManager;
+import com.velocitypowered.api.event.proxy.ProxyExceptionEvent;
 import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.PluginDescription;
 import com.velocitypowered.api.plugin.PluginManager;
 import com.velocitypowered.api.plugin.meta.PluginDependency;
 import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.exception.ProxyInternalException;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.plugin.loader.VelocityPluginContainer;
 import com.velocitypowered.proxy.plugin.loader.java.JavaPluginLoader;
@@ -93,6 +95,7 @@ public class VelocityPluginManager implements PluginManager {
           found.add(loader.loadPluginDescription(path));
         } catch (Exception e) {
           logger.error("Unable to load plugin {}", path, e);
+          server.getEventManager().fireAndForget(new ProxyExceptionEvent(new ProxyInternalException(e)));
         }
       }
     }
@@ -125,6 +128,7 @@ public class VelocityPluginManager implements PluginManager {
         loadedPluginsById.add(realPlugin.getId());
       } catch (Exception e) {
         logger.error("Can't create module for plugin {}", candidate.getId(), e);
+        server.getEventManager().fireAndForget(new ProxyExceptionEvent(new ProxyInternalException(e)));
       }
     }
 
@@ -152,6 +156,7 @@ public class VelocityPluginManager implements PluginManager {
         loader.createPlugin(container, plugin.getValue(), commonModule);
       } catch (Exception e) {
         logger.error("Can't create plugin {}", description.getId(), e);
+        server.getEventManager().fireAndForget(new ProxyExceptionEvent(new ProxyInternalException(e)));
         continue;
       }
 

--- a/proxy/src/test/java/com/velocitypowered/proxy/scheduler/VelocitySchedulerTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/scheduler/VelocitySchedulerTest.java
@@ -21,18 +21,39 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.velocitypowered.api.scheduler.ScheduledTask;
 import com.velocitypowered.api.scheduler.TaskStatus;
+import com.velocitypowered.proxy.event.MockEventManager;
+import com.velocitypowered.proxy.event.VelocityEventManager;
 import com.velocitypowered.proxy.testutil.FakePluginManager;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class VelocitySchedulerTest {
   // TODO: The timings here will be inaccurate on slow systems.
 
+  private static VelocityEventManager eventManager;
+
+  @BeforeAll
+  static void beforeAll() {
+    eventManager = new MockEventManager();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    try {
+      eventManager.shutdown();
+      eventManager = null;
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
   @Test
   void buildTask() throws Exception {
-    VelocityScheduler scheduler = new VelocityScheduler(new FakePluginManager());
+    VelocityScheduler scheduler = new VelocityScheduler(new FakePluginManager(), eventManager);
     CountDownLatch latch = new CountDownLatch(1);
     ScheduledTask task = scheduler.buildTask(FakePluginManager.PLUGIN_A, latch::countDown)
         .schedule();
@@ -42,7 +63,7 @@ class VelocitySchedulerTest {
 
   @Test
   void cancelWorks() throws Exception {
-    VelocityScheduler scheduler = new VelocityScheduler(new FakePluginManager());
+    VelocityScheduler scheduler = new VelocityScheduler(new FakePluginManager(), eventManager);
     AtomicInteger i = new AtomicInteger(3);
     ScheduledTask task = scheduler.buildTask(FakePluginManager.PLUGIN_A, i::decrementAndGet)
         .delay(100, TimeUnit.SECONDS)
@@ -55,7 +76,7 @@ class VelocitySchedulerTest {
 
   @Test
   void repeatTaskWorks() throws Exception {
-    VelocityScheduler scheduler = new VelocityScheduler(new FakePluginManager());
+    VelocityScheduler scheduler = new VelocityScheduler(new FakePluginManager(), eventManager);
     CountDownLatch latch = new CountDownLatch(3);
     ScheduledTask task = scheduler.buildTask(FakePluginManager.PLUGIN_A, latch::countDown)
         .delay(100, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
Adds ProxyExceptionEvent in a similar fashion to [Waterfall's implementation](https://papermc.io/javadocs/waterfall/1.17/io/github/waterfallmc/waterfall/event/ProxyExceptionEvent.html). 