### PR TITLE
feat: added VELOCITY_FORWARDING_SECRET environment variable

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -426,15 +426,12 @@ public class VelocityConfiguration implements ProxyConfig {
 
     // Retrieve the forwarding secret. First, from environment variable, then from config.
     byte[] forwardingSecret;
-    String forwardingSecretString = System.getenv("VELOCITY_FORWARDING_SECRET");
+    String forwardingSecretString = System.getenv()
+        .getOrDefault("VELOCITY_FORWARDING_SECRET", config.get("forwarding-secret"));
     if (forwardingSecretString == null || forwardingSecretString.isEmpty()) {
-      forwardingSecretString = config.get("forwarding-secret");
-
-      if (forwardingSecretString == null || forwardingSecretString.isEmpty()) {
-        forwardingSecretString = generateRandomString(12);
-        config.set("forwarding-secret", forwardingSecretString);
-        mustResave = true;
-      }
+      forwardingSecretString = generateRandomString(12);
+      config.set("forwarding-secret", forwardingSecretString);
+      mustResave = true;
     }
     forwardingSecret = forwardingSecretString.getBytes(StandardCharsets.UTF_8);
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -424,16 +424,21 @@ public class VelocityConfiguration implements ProxyConfig {
     CommentedFileConfig defaultConfig = CommentedFileConfig.of(tmpFile, TomlFormat.instance());
     defaultConfig.load();
 
-    // Handle any cases where the config needs to be saved again
+    // Retrieve the forwarding secret. First, from environment variable, then from config.
     byte[] forwardingSecret;
-    String forwardingSecretString = config.get("forwarding-secret");
+    String forwardingSecretString = System.getenv("VELOCITY_FORWARDING_SECRET");
     if (forwardingSecretString == null || forwardingSecretString.isEmpty()) {
-      forwardingSecretString = generateRandomString(12);
-      config.set("forwarding-secret", forwardingSecretString);
-      mustResave = true;
+      forwardingSecretString = config.get("forwarding-secret");
+
+      if (forwardingSecretString == null || forwardingSecretString.isEmpty()) {
+        forwardingSecretString = generateRandomString(12);
+        config.set("forwarding-secret", forwardingSecretString);
+        mustResave = true;
+      }
     }
     forwardingSecret = forwardingSecretString.getBytes(StandardCharsets.UTF_8);
 
+    // Handle any cases where the config needs to be saved again
     if (mustResave) {
       config.save();
     }


### PR DESCRIPTION
This PR allows Velocity forwarding secret to be set at runtime, instead of being defined in the config.
Therefore, it is perfect for containerized environments, such as: Kubernetes and Docker.

Related issue(s):
https://github.com/PaperMC/Paper/issues/6332

*PS: Please mark this PR as `hacktoberfest-accepted` once accepted.*