### PR TITLE
add legacy connection toString

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -229,5 +229,10 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
     public ProtocolVersion getProtocolVersion() {
       return ProtocolVersion.LEGACY;
     }
+
+    @Override
+    public String toString() {
+      return "[legacy connection] " + this.getRemoteAddress().toString();
+    }
   }
 }


### PR DESCRIPTION
This is to prevent logs like `com.velocitypowered.proxy.connection.client.HandshakeSessionHandler$LegacyInboundConnection@78e0c47a is pinging the server with version Legacy`