### PR TITLE
Add version information for 1.18.1

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -56,7 +56,7 @@ public enum ProtocolVersion {
   MINECRAFT_1_16_4(754, "1.16.4", "1.16.5"),
   MINECRAFT_1_17(755, "1.17"),
   MINECRAFT_1_17_1(756, "1.17.1"),
-  MINECRAFT_1_18(757, "1.18");
+  MINECRAFT_1_18(757, "1.18", "1.18.1");
 
   private static final int SNAPSHOT_BIT = 30;
 


### PR DESCRIPTION
I am not entirely sure if this is everything that has to be changed - please verify. According to Wiki the protocol version has not changed: https://minecraft.fandom.com/wiki/Protocol_version#Java_Edition_2 so this is a rather cosmetic change.