### PR TITLE
Make RegisteredServer implementations stateless

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
@@ -78,7 +78,8 @@ public interface ProxyServer extends Audience {
    * case-insensitive.
    *
    * @param name the name of the server
-   * @return the registered server, which may be empty
+   * @return the registered server, which may be empty if the server doesn't exist or if it wasn't registered with
+   *         the proxy
    */
   Optional<RegisteredServer> getServer(String name);
 

--- a/api/src/main/java/com/velocitypowered/api/proxy/server/MutableServerState.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/server/MutableServerState.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.proxy.server;
+
+import com.velocitypowered.api.proxy.Player;
+
+/**
+ * A mutable view on a server's state.
+ *
+ * <p>This interface's methods may be called from different threads. As such, <strong>it is important to consider
+ * thread-safety in implementations.</strong>
+ */
+public interface MutableServerState extends ServerState {
+  /**
+   * Called when a player has switched to the {@link RegisteredServer} associated with this state.
+   *
+   * @param player the player
+   */
+  void addPlayer(Player player);
+
+  /**
+   * Called when a player has disconnected from {@link RegisteredServer} associated with this state.
+   *
+   * @param player the player
+   */
+  void removePlayer(Player player);
+}

--- a/api/src/main/java/com/velocitypowered/api/proxy/server/RegisteredServer.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/server/RegisteredServer.java
@@ -8,15 +8,18 @@
 package com.velocitypowered.api.proxy.server;
 
 import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.messages.ChannelMessageSink;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import net.kyori.adventure.audience.Audience;
 
 /**
- * Represents a server that has been registered with the proxy. The {@code Audience} associated with
- * a {@code RegisteredServer} represent all players on the server connected to this proxy and do not
- * interact with the server in any way.
+ * Represents a server that has been registered with the proxy.
+ *
+ * <p>This is an immutable and stateless view over a server's information. To get the server's current state
+ * (such as players connected), use {@link RegisteredServer#getState()}.
+ * </p>
  */
 public interface RegisteredServer extends ChannelMessageSink, Audience {
 
@@ -31,8 +34,12 @@ public interface RegisteredServer extends ChannelMessageSink, Audience {
    * Returns a list of all the players currently connected to this server on this proxy.
    *
    * @return the players on this proxy
+   * @deprecated use {@link ServerState#getPlayersConnected()} instead
    */
-  Collection<Player> getPlayersConnected();
+  @Deprecated
+  default Collection<Player> getPlayersConnected() {
+    return getState().getPlayersConnected();
+  }
 
   /**
    * Attempts to ping the remote server and return the server list ping result.
@@ -40,4 +47,25 @@ public interface RegisteredServer extends ChannelMessageSink, Audience {
    * @return the server ping result from the server
    */
   CompletableFuture<ServerPing> ping();
+
+  /**
+   * Returns the current state of this server on the proxy.
+   *
+   * @return the server state
+   */
+  ServerState getState();
+
+  /**
+   * Sends a plugin message to all the players connected this server.
+   *
+   * @param identifier the channel identifier to send the message on
+   * @param data the data to send
+   * @return whether or not the message could be sent
+   * @deprecated use {@link ServerState#sendPluginMessage(ChannelIdentifier, byte[])} instead
+   */
+  @Override
+  @Deprecated
+  default boolean sendPluginMessage(ChannelIdentifier identifier, byte[] data) {
+    return getState().sendPluginMessage(identifier, data);
+  }
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/server/ServerState.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/server/ServerState.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.proxy.server;
+
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.messages.ChannelMessageSink;
+import java.util.Collection;
+import net.kyori.adventure.audience.Audience;
+
+/**
+ * A server's current state. This differs from {@link RegisteredServer} for providing a stateful view
+ * on a backend server instance.
+ *
+ * <p>The {@code Audience} associated with a {@code ServerState} represent all players on the server
+ * connected to this proxy and do not interact with the server in any way.
+ * </p>
+ */
+public interface ServerState extends ChannelMessageSink, Audience {
+  /**
+   * Returns an <strong>immutable</strong> list of all the players currently connected to this server on this proxy.
+   *
+   * @return the players on the proxy connected to this server
+   */
+  Collection<Player> getPlayersConnected();
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -398,7 +398,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
       if (!rs.isPresent()) {
         servers.register(newInfo);
       } else if (!rs.get().getServerInfo().equals(newInfo)) {
-        for (Player player : rs.get().getPlayersConnected()) {
+        for (Player player : rs.get().getState().getPlayersConnected()) {
           if (!(player instanceof ConnectedPlayer)) {
             throw new IllegalStateException("ConnectedPlayer not found for player " + player
                 + " in server " + rs.get().getServerInfo().getName());

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/GlistCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/GlistCommand.java
@@ -113,7 +113,7 @@ public class GlistCommand {
   }
 
   private void sendServerPlayers(CommandSource target, RegisteredServer server, boolean fromAll) {
-    List<Player> onServer = ImmutableList.copyOf(server.getPlayersConnected());
+    List<Player> onServer = ImmutableList.copyOf(server.getState().getPlayersConnected());
     if (onServer.isEmpty() && fromAll) {
       return;
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/ServerCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/ServerCommand.java
@@ -110,7 +110,7 @@ public class ServerCommand implements SimpleCommand {
     ServerInfo serverInfo = server.getServerInfo();
     TextComponent serverTextComponent = Component.text(serverInfo.getName());
 
-    int connectedPlayers = server.getPlayersConnected().size();
+    int connectedPlayers = server.getState().getPlayersConnected().size();
     TranslatableComponent playersTextComponent;
     if (connectedPlayers == 1) {
       playersTextComponent = Component.translatable("velocity.command.server-tooltip-player-online");

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -30,6 +30,7 @@ import com.velocitypowered.api.event.player.ServerResourcePackSendEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.player.ResourcePackInfo;
+import com.velocitypowered.api.proxy.server.MutableServerState;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.command.CommandGraphInjector;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
@@ -93,7 +94,7 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
 
   @Override
   public void activated() {
-    serverConn.getServer().addPlayer(serverConn.getPlayer());
+    ((MutableServerState) serverConn.getServer().getState()).addPlayer(serverConn.getPlayer());
 
     if (server.getConfiguration().isBungeePluginChannelEnabled()) {
       MinecraftConnection serverMc = serverConn.ensureConnected();
@@ -308,7 +309,7 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
 
   @Override
   public void disconnected() {
-    serverConn.getServer().removePlayer(serverConn.getPlayer());
+    ((MutableServerState) serverConn.getServer().getState()).removePlayer(serverConn.getPlayer());
     if (!serverConn.isGracefulDisconnect() && !exceptionTriggered) {
       if (server.getConfiguration().isFailoverOnUnexpectedServerDisconnect()) {
         serverConn.getPlayer().handleConnectionException(serverConn.getServer(),

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BungeeCordMessageResponder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BungeeCordMessageResponder.java
@@ -31,8 +31,7 @@ import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.protocol.packet.PluginMessage;
 import com.velocitypowered.proxy.protocol.util.ByteBufDataInput;
 import com.velocitypowered.proxy.protocol.util.ByteBufDataOutput;
-import com.velocitypowered.proxy.server.VelocityRegisteredServer;
-import edu.umd.cs.findbugs.annotations.Nullable;
+import com.velocitypowered.proxy.server.DefaultMutableServerState;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -104,7 +103,7 @@ public class BungeeCordMessageResponder {
       out.writeInt(proxy.getPlayerCount());
     } else {
       proxy.getServer(target).ifPresent(rs -> {
-        int playersOnServer = rs.getPlayersConnected().size();
+        int playersOnServer = rs.getState().getPlayersConnected().size();
         out.writeUTF("PlayerCount");
         out.writeUTF(rs.getServerInfo().getName());
         out.writeInt(playersOnServer);
@@ -138,7 +137,7 @@ public class BungeeCordMessageResponder {
         out.writeUTF(info.getServerInfo().getName());
 
         StringJoiner joiner = new StringJoiner(", ");
-        for (Player online : info.getPlayersConnected()) {
+        for (Player online : info.getState().getPlayersConnected()) {
           joiner.add(online.getUsername());
         }
         out.writeUTF(joiner.toString());
@@ -273,7 +272,7 @@ public class BungeeCordMessageResponder {
       try {
         for (RegisteredServer rs : proxy.getAllServers()) {
           if (!rs.getServerInfo().equals(currentUserServer)) {
-            ((VelocityRegisteredServer) rs).sendPluginMessage(LEGACY_CHANNEL,
+            ((DefaultMutableServerState) rs.getState()).sendPluginMessage(LEGACY_CHANNEL,
                 toForward.retainedSlice());
           }
         }
@@ -283,7 +282,7 @@ public class BungeeCordMessageResponder {
     } else {
       Optional<RegisteredServer> server = proxy.getServer(target);
       if (server.isPresent()) {
-        ((VelocityRegisteredServer) server.get()).sendPluginMessage(LEGACY_CHANNEL, toForward);
+        ((DefaultMutableServerState) server.get().getState()).sendPluginMessage(LEGACY_CHANNEL, toForward);
       } else {
         toForward.release();
       }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -41,11 +41,9 @@ import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.packet.Handshake;
 import com.velocitypowered.proxy.protocol.packet.PluginMessage;
 import com.velocitypowered.proxy.protocol.packet.ServerLogin;
-import com.velocitypowered.proxy.server.VelocityRegisteredServer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
-import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
@@ -58,8 +56,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class VelocityServerConnection implements MinecraftConnectionAssociation, ServerConnection {
 
-  private final VelocityRegisteredServer registeredServer;
-  private final @Nullable VelocityRegisteredServer previousServer;
+  private final RegisteredServer registeredServer;
+  private final @Nullable RegisteredServer previousServer;
   private final ConnectedPlayer proxyPlayer;
   private final VelocityServer server;
   private @Nullable MinecraftConnection connection;
@@ -76,8 +74,8 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
    * @param proxyPlayer the player connecting to the server
    * @param server the Velocity proxy instance
    */
-  public VelocityServerConnection(VelocityRegisteredServer registeredServer,
-      @Nullable VelocityRegisteredServer previousServer,
+  public VelocityServerConnection(RegisteredServer registeredServer,
+      @Nullable RegisteredServer previousServer,
       ConnectedPlayer proxyPlayer, VelocityServer server) {
     this.registeredServer = registeredServer;
     this.previousServer = previousServer;
@@ -211,7 +209,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
   }
 
   @Override
-  public VelocityRegisteredServer getServer() {
+  public RegisteredServer getServer() {
     return registeredServer;
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/StatusSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/StatusSessionHandler.java
@@ -35,7 +35,7 @@ import com.velocitypowered.proxy.protocol.packet.LegacyPing;
 import com.velocitypowered.proxy.protocol.packet.StatusPing;
 import com.velocitypowered.proxy.protocol.packet.StatusRequest;
 import com.velocitypowered.proxy.protocol.packet.StatusResponse;
-import com.velocitypowered.proxy.server.VelocityRegisteredServer;
+import com.velocitypowered.proxy.server.RegisteredServerImpl;
 import com.velocitypowered.proxy.util.except.QuietRuntimeException;
 import io.netty.buffer.ByteBuf;
 import java.net.InetSocketAddress;
@@ -95,8 +95,11 @@ public class StatusSessionHandler implements MinecraftSessionHandler {
       if (!rs.isPresent()) {
         continue;
       }
-      VelocityRegisteredServer vrs = (VelocityRegisteredServer) rs.get();
-      pings.add(vrs.ping(connection.eventLoop(), pingingVersion));
+      RegisteredServer server = rs.get();
+      if (server instanceof RegisteredServerImpl) { // this should be the case if it was registered in the config
+        RegisteredServerImpl vrs = (RegisteredServerImpl) server;
+        pings.add(vrs.ping(connection.eventLoop(), pingingVersion));
+      }
     }
     if (pings.isEmpty()) {
       return CompletableFuture.completedFuture(fallback);

--- a/proxy/src/main/java/com/velocitypowered/proxy/server/DefaultMutableServerState.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/server/DefaultMutableServerState.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.server;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
+import com.velocitypowered.api.proxy.server.MutableServerState;
+import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
+import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.audience.ForwardingAudience;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public class DefaultMutableServerState implements MutableServerState, ForwardingAudience {
+  private final Map<UUID, ConnectedPlayer> players = new ConcurrentHashMap<>();
+
+  @Override
+  public Collection<Player> getPlayersConnected() {
+    return ImmutableList.copyOf(players.values());
+  }
+
+  @Override
+  public void addPlayer(Player player) {
+    Preconditions.checkState(player instanceof ConnectedPlayer, "player is not a proxy player");
+    players.put(player.getUniqueId(), (ConnectedPlayer) player);
+  }
+
+  @Override
+  public void removePlayer(Player player) {
+    Preconditions.checkState(player instanceof ConnectedPlayer, "player is not a proxy player");
+    players.remove(player.getUniqueId(), player);
+  }
+
+  @Override
+  public boolean sendPluginMessage(ChannelIdentifier identifier, byte[] data) {
+    return sendPluginMessage(identifier, Unpooled.wrappedBuffer(data));
+  }
+
+  /**
+   * Sends a plugin message to the server through this connection. The message will be released
+   * afterwards.
+   *
+   * @param identifier the channel ID to use
+   * @param data the data
+   * @return whether or not the message was sent
+   */
+  public boolean sendPluginMessage(ChannelIdentifier identifier, ByteBuf data) {
+    for (ConnectedPlayer player : players.values()) {
+      VelocityServerConnection connection = player.getConnectedServer();
+      if (connection != null && connection.getServer().getState() == this) {
+        return connection.sendPluginMessage(identifier, data);
+      }
+    }
+
+    data.release();
+    return false;
+  }
+
+  @Override
+  public @NonNull Iterable<? extends Audience> audiences() {
+    return this.getPlayersConnected();
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/server/ServerMap.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/server/ServerMap.java
@@ -62,7 +62,7 @@ public class ServerMap {
    * @return the {@link RegisteredServer} built from the {@link ServerInfo}
    */
   public RegisteredServer createRawRegisteredServer(ServerInfo serverInfo) {
-    return new VelocityRegisteredServer(server, serverInfo);
+    return new RegisteredServerImpl(server, serverInfo);
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/InformationUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/InformationUtils.java
@@ -184,7 +184,7 @@ public enum InformationUtils {
    */
   public static JsonObject collectServerInfo(RegisteredServer server) {
     JsonObject info = new JsonObject();
-    info.addProperty("currentPlayers", server.getPlayersConnected().size());
+    info.addProperty("currentPlayers", server.getState().getPlayersConnected().size());
     InetSocketAddress iaddr = server.getServerInfo().getAddress();
     if (iaddr.isUnresolved()) {
       // Greetings form Netty 4aa10db9


### PR DESCRIPTION
This is a first attempt at solving #566.

This shifts the stateful logic behind `VelocityRegisteredServer` (keeping track of connected players and sending plugin messages to those players) to a new class (`VelocityServerState`, backed by the `RegisteredServerState` API).

This way one could make a custom `RegisteredServer` that doesn't have to be registered to the proxy, perhaps forwarding the stateful logic to a server that's actually registered. (server aliasing)  
For instance, you can now write this:

```java
public class AliasedServer implements RegisteredServer {
    private final RegisteredServer handle;
    private final ServerInfo serverInfo;

    public AliasedServer(RegisteredServer handle, String alias) {
        this.handle = handle;
        this.serverInfo = new ServerInfo(alias, handle.getServerInfo().getAddress());
    }

    @Override
    public ServerInfo getServerInfo() {
        return serverInfo;
    }

    @Override
    public CompletableFuture<ServerPing> ping() {
        return handle.ping();
    }

    @Override
    public RegisteredServerState getState() {
        return handle.getState();
    }
}

```

This is a breaking API change, but backwards compatibility is kept through deprecated methods.
