### PR TITLE
Limit chat message size

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -371,6 +371,10 @@ public class VelocityConfiguration implements ProxyConfig {
     return advanced.isLogCommandExecutions();
   }
 
+  public boolean isKickOnIllegalChatLength() {
+    return advanced.isKickOnIllegalChatLength();
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -630,6 +634,7 @@ public class VelocityConfiguration implements ProxyConfig {
     @Expose private boolean failoverOnUnexpectedServerDisconnect = true;
     @Expose private boolean announceProxyCommands = true;
     @Expose private boolean logCommandExecutions = false;
+    @Expose private boolean kickOnIllegalChatLength = false;
 
     private Advanced() {
     }
@@ -653,6 +658,7 @@ public class VelocityConfiguration implements ProxyConfig {
             .getOrElse("failover-on-unexpected-server-disconnect", true);
         this.announceProxyCommands = config.getOrElse("announce-proxy-commands", true);
         this.logCommandExecutions = config.getOrElse("log-command-executions", false);
+        this.kickOnIllegalChatLength = config.getOrElse("kick-chat-length", false);
       }
     }
 
@@ -704,6 +710,10 @@ public class VelocityConfiguration implements ProxyConfig {
       return logCommandExecutions;
     }
 
+    public boolean isKickOnIllegalChatLength() {
+      return kickOnIllegalChatLength;
+    }
+
     @Override
     public String toString() {
       return "Advanced{"
@@ -719,6 +729,7 @@ public class VelocityConfiguration implements ProxyConfig {
           + ", failoverOnUnexpectedServerDisconnect=" + failoverOnUnexpectedServerDisconnect
           + ", announceProxyCommands=" + announceProxyCommands
           + ", logCommandExecutions=" + logCommandExecutions
+          + ", kickOnIllegalChatLength=" + kickOnIllegalChatLength
           + '}';
     }
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -30,13 +30,11 @@ import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.event.player.PlayerChannelRegisterEvent;
 import com.velocitypowered.api.event.player.PlayerChatEvent;
 import com.velocitypowered.api.event.player.PlayerClientBrandEvent;
-import com.velocitypowered.api.event.player.PlayerResourcePackStatusEvent;
 import com.velocitypowered.api.event.player.TabCompleteEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.messages.LegacyChannelIdentifier;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
-import com.velocitypowered.api.proxy.player.ResourcePackInfo;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.ConnectionTypes;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
@@ -72,12 +70,10 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -157,6 +153,16 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
     }
 
     String msg = packet.getMessage();
+
+    if (msg.length() > Chat.MAX_SERVERBOUND_MESSAGE_LENGTH) {
+      if (server.getConfiguration().isKickOnIllegalChatLength()) {
+        player.disconnect(Component.translatable("velocity.error.illegal-chat-length"));
+        return true;
+      } else {
+        msg = msg.substring(0, Chat.MAX_SERVERBOUND_MESSAGE_LENGTH);
+      }
+    }
+
     if (CharacterUtil.containsIllegalCharacters(msg)) {
       player.disconnect(Component.translatable("velocity.error.illegal-chat-characters",
           NamedTextColor.RED));

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
@@ -30,6 +30,7 @@ velocity.error.modern-forwarding-failed=Your server did not send a forwarding re
 velocity.error.moved-to-new-server=You were kicked from {0}: {1}
 velocity.error.no-available-servers=There are no available servers to connect you to. Try again later or contact an admin.
 velocity.error.illegal-chat-characters=Illegal characters in chat
+velocity.error.illegal-chat-length=Chat message too long
 
 # Commands
 velocity.command.generic-error=An error occurred while running this command.

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -130,6 +130,10 @@ announce-proxy-commands = true
 # Enables the logging of commands
 log-command-executions = false
 
+# Kicks the player when they attempt to send a message that's too long for the latest Minecraft version.
+# If this is disabled, the message will be cut to fit the size.
+kick-chat-length = false
+
 [query]
 # Whether to enable responding to GameSpy 4 query responses or not.
 enabled = false


### PR DESCRIPTION
This allows server owners to block oversized messages on the proxy's end.  
They can either choose to kick the player or to just cut the message to fit within limits.