### PR TITLE
Disable Log4J's built-in shutdown hook which broke our shutdown sequence.

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -502,6 +502,9 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
         Thread.currentThread().interrupt();
       }
 
+      // Since we manually removed the shutdown hook, we need to handle the shutdown ourselves.
+      LogManager.shutdown();
+
       shutdown = true;
 
       if (explicitExit) {

--- a/proxy/src/main/resources/log4j2.xml
+++ b/proxy/src/main/resources/log4j2.xml
@@ -16,7 +16,8 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 
-<Configuration status="warn">
+<!-- Disable shutdown hook, because we have our own -->
+<Configuration status="warn" shutdownHook="disable">
   <Appenders>
     <TerminalConsole name="TerminalConsole">
       <PatternLayout>


### PR DESCRIPTION
When exiting by pressing CTRL + C, log4j shuts down before we do. Which causes any calls to the logger in our shutdown sequence to throw an exception. This resulted in Velocity (and running plugins) not shutting down gracefully.

I have disabled the built-in hook and added a line to shutdown Log4J ourselves. You might consider moving it to earlier parts of the shutdown sequence.