### PR TITLE
Add passthrough-default-server-ping option

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -78,6 +78,8 @@ public class VelocityConfiguration implements ProxyConfig {
   private boolean onlineModeKickExistingPlayers = false;
   @Expose
   private PingPassthroughMode pingPassthrough = PingPassthroughMode.DISABLED;
+  @Expose
+  private boolean passthroughDefaultServerPing = true;
   private final Servers servers;
   private final ForcedHosts forcedHosts;
   @Expose
@@ -105,8 +107,9 @@ public class VelocityConfiguration implements ProxyConfig {
       boolean preventClientProxyConnections, boolean announceForge,
       PlayerInfoForwarding playerInfoForwardingMode, byte[] forwardingSecret,
       boolean onlineModeKickExistingPlayers, PingPassthroughMode pingPassthrough,
-      boolean enablePlayerAddressLogging, Servers servers, ForcedHosts forcedHosts,
-      Advanced advanced, Query query, Metrics metrics, boolean forceKeyAuthentication) {
+      boolean passthroughDefaultServerPing, boolean enablePlayerAddressLogging, Servers servers,
+      ForcedHosts forcedHosts, Advanced advanced, Query query, Metrics metrics,
+      boolean forceKeyAuthentication) {
     this.bind = bind;
     this.motd = motd;
     this.showMaxPlayers = showMaxPlayers;
@@ -117,6 +120,7 @@ public class VelocityConfiguration implements ProxyConfig {
     this.forwardingSecret = forwardingSecret;
     this.onlineModeKickExistingPlayers = onlineModeKickExistingPlayers;
     this.pingPassthrough = pingPassthrough;
+    this.passthroughDefaultServerPing = passthroughDefaultServerPing;
     this.enablePlayerAddressLogging = enablePlayerAddressLogging;
     this.servers = servers;
     this.forcedHosts = forcedHosts;
@@ -371,6 +375,10 @@ public class VelocityConfiguration implements ProxyConfig {
     return pingPassthrough;
   }
 
+  public boolean isPassthroughDefaultServerPing() {
+    return passthroughDefaultServerPing;
+  }
+
   public boolean isPlayerAddressLoggingEnabled() {
     return enablePlayerAddressLogging;
   }
@@ -503,6 +511,8 @@ public class VelocityConfiguration implements ProxyConfig {
       final PingPassthroughMode pingPassthroughMode = config.getEnumOrElse("ping-passthrough",
               PingPassthroughMode.DISABLED);
 
+      final boolean passthroughDefaultServerPing = config.getOrElse("passthrough-default-server-ping", true);
+
       final String bind = config.getOrElse("bind", "0.0.0.0:25565");
       final int maxPlayers = config.getIntOrElse("show-max-players", 500);
       final boolean onlineMode = config.getOrElse("online-mode", true);
@@ -533,6 +543,7 @@ public class VelocityConfiguration implements ProxyConfig {
               forwardingSecret,
               kickExisting,
               pingPassthroughMode,
+              passthroughDefaultServerPing,
               enablePlayerAddressLogging,
               new Servers(serversConfig),
               new ForcedHosts(forcedHostsConfig),

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/ServerListPingHandler.java
@@ -153,6 +153,12 @@ public class ServerListPingHandler {
       String virtualHostStr = connection.getVirtualHost().map(InetSocketAddress::getHostString)
           .map(str -> str.toLowerCase(Locale.ROOT))
           .orElse("");
+
+      if (!configuration.isPassthroughDefaultServerPing()
+              && !configuration.getForcedHosts().containsKey(virtualHostStr)) {
+        return CompletableFuture.completedFuture(constructLocalPing(shownVersion));
+      }
+
       List<String> serversToTry = server.getConfiguration().getForcedHosts().getOrDefault(
           virtualHostStr, server.getConfiguration().getAttemptConnectionOrder());
       return attemptPingPassthrough(connection, passthroughMode, serversToTry, shownVersion);

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -66,6 +66,12 @@ kick-existing-players = false
 #                  configuration is used if no servers could be contacted.
 ping-passthrough = "DISABLED"
 
+# If enabled (default is true), then the proxy will pass all pings, including ones on hosts not
+# listed in forced-hosts, to the default backend server(s).
+# Otherwise, the proxy will use its own MOTD and version to reply to pings on other hosts.
+# Note that this option has no effect if ping-passthrough is set to DISABLED.
+passthrough-default-server-ping = true
+
 # If not enabled (default is true) player IP addresses will be replaced by <ip address withheld> in logs
 enable-player-address-logging = true
 


### PR DESCRIPTION
If `passthrough-default-server-ping` is set to false, then Velocity will respond with its own MOTD and version for pings that go to a host not listed in `forced-hosts`. This means that you can make it so Velocity has its own generic network-wide MOTD which is shown on the proxy's main IP(s), but also see the backend's MOTD and version if connecting to it specifically (using a forced host).

This option doesn't have any effect if `ping-passthrough` is disabled.