### PR TITLE
Bump Adventure library version to 4.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ allprojects {
 
     ext {
         // dependency versions
-        adventureVersion = '4.9.3'
+        adventureVersion = '4.10.0'
         junitVersion = '5.7.0'
         slf4jVersion = '1.7.30'
         log4jVersion = '2.17.1'


### PR DESCRIPTION
Bumps the version of Kyori's Adventure library to 4.10.0

Release with changelog:
https://github.com/KyoriPowered/adventure/releases/tag/v4.10.0