### PR TITLE
Fix forced-hosts

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -726,6 +726,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
     if (serversToTry == null) {
       String virtualHostStr = getVirtualHost().map(InetSocketAddress::getHostString)
           .orElse("")
+          .split("/", 2)[0]
           .toLowerCase(Locale.ROOT);
       serversToTry = server.getConfiguration().getForcedHosts().getOrDefault(virtualHostStr,
           Collections.emptyList());


### PR DESCRIPTION
Fix #653 by splitting the host string at `/` and taking only the first sub-string