### PR TITLE
Flip output for queued resource pack status passthrough conditional

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -165,7 +165,7 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
                   .setOriginalOrigin(ResourcePackInfo.Origin.DOWNSTREAM_SERVER);
         }
 
-        serverConn.getPlayer().queueResourcePack(builder.build());
+        serverConn.getPlayer().queueResourcePack(toSend);
       } else if (serverConn.getConnection() != null) {
         serverConn.getConnection().write(new ResourcePackResponse(
             packet.getHash(),

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -986,7 +986,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
     }
 
     return queued != null
-            && queued.getOriginalOrigin() == ResourcePackInfo.Origin.DOWNSTREAM_SERVER;
+            && queued.getOriginalOrigin() != ResourcePackInfo.Origin.DOWNSTREAM_SERVER;
   }
 
   /**


### PR DESCRIPTION
This should solve #654 

It looks like the conditional should be:
* false if we want the packet to passthrough to the downstream server
* true if velocity sent the packet

The current implementation has it `true` for when the downstream server sent the resource pack, and `false` for when the proxy sent the resource pack.