### PR TITLE
Update old downloads URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ Once you've built Velocity, you can copy and run the `-all` JAR from
 `proxy/build/libs`. Velocity will generate a default configuration file
 and you can configure it from there.
 
-Alternatively, you can get the proxy JAR from the [downloads](https://velocitypowered.com/downloads)
+Alternatively, you can get the proxy JAR from the [downloads](https://papermc.io/downloads#Velocity)
 page.


### PR DESCRIPTION
Since Velocity became part of PaperMC is it only logical to update the URL to the new downloads page for the proxy jar.

On a separate note should it IMO be considered to add a section/docs about proper development of velocity plugins, such as *where* to actually get the latest releases from. I myself currently struggle to find out what the proper setup is or even what the latest (dev build) version is... And the docs on velocitypowered.com don't reflect the latest version...