### PR TITLE
Added logPlayerConnections configuration option

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -378,6 +378,10 @@ public class VelocityConfiguration implements ProxyConfig {
     return advanced.isLogCommandExecutions();
   }
 
+  public boolean isLogPlayerConnections() {
+    return advanced.isLogPlayerConnections();
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -640,6 +644,7 @@ public class VelocityConfiguration implements ProxyConfig {
     @Expose private boolean failoverOnUnexpectedServerDisconnect = true;
     @Expose private boolean announceProxyCommands = true;
     @Expose private boolean logCommandExecutions = false;
+    @Expose private boolean logPlayerConnections = true;
 
     private Advanced() {
     }
@@ -663,6 +668,7 @@ public class VelocityConfiguration implements ProxyConfig {
             .getOrElse("failover-on-unexpected-server-disconnect", true);
         this.announceProxyCommands = config.getOrElse("announce-proxy-commands", true);
         this.logCommandExecutions = config.getOrElse("log-command-executions", false);
+        this.logPlayerConnections = config.getOrElse("log-player-connections", true);
       }
     }
 
@@ -714,6 +720,10 @@ public class VelocityConfiguration implements ProxyConfig {
       return logCommandExecutions;
     }
 
+    public boolean isLogPlayerConnections() {
+      return logPlayerConnections;
+    }
+
     @Override
     public String toString() {
       return "Advanced{"
@@ -729,6 +739,7 @@ public class VelocityConfiguration implements ProxyConfig {
           + ", failoverOnUnexpectedServerDisconnect=" + failoverOnUnexpectedServerDisconnect
           + ", announceProxyCommands=" + announceProxyCommands
           + ", logCommandExecutions=" + logCommandExecutions
+          + ", logPlayerConnections=" + logPlayerConnections
           + '}';
     }
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -82,7 +82,7 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
   private @Nullable MinecraftSessionHandler sessionHandler;
   private ProtocolVersion protocolVersion;
   private @Nullable MinecraftConnectionAssociation association;
-  private final VelocityServer server;
+  public final VelocityServer server;
   private ConnectionType connectionType = ConnectionTypes.UNDETERMINED;
   private boolean knownDisconnect = false;
 
@@ -104,7 +104,7 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
       sessionHandler.connected();
     }
 
-    if (association != null) {
+    if (association != null && server.getConfiguration().isLogPlayerConnections()) {
       logger.info("{} has connected", association);
     }
   }
@@ -116,7 +116,8 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
     }
 
     if (association != null && !knownDisconnect
-        && !(sessionHandler instanceof StatusSessionHandler)) {
+        && !(sessionHandler instanceof StatusSessionHandler)
+        && server.getConfiguration().isLogPlayerConnections()) {
       logger.info("{} has disconnected", association);
     }
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -506,8 +506,10 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   public void disconnect0(Component reason, boolean duringLogin) {
     Component translated = this.translateMessage(reason);
 
-    logger.info("{} has disconnected: {}", this,
-        LegacyComponentSerializer.legacySection().serialize(translated));
+    if (server.getConfiguration().isLogPlayerConnections()) {
+      logger.info("{} has disconnected: {}", this,
+          LegacyComponentSerializer.legacySection().serialize(translated));
+    }
     connection.closeWith(Disconnect.create(translated, this.getProtocolVersion()));
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialInboundConnection.java
@@ -85,9 +85,10 @@ public final class InitialInboundConnection implements InboundConnection,
   public void disconnect(Component reason) {
     Component translated = GlobalTranslator.render(reason, ClosestLocaleMatcher.INSTANCE
         .lookupClosest(Locale.getDefault()));
-
-    logger.info("{} has disconnected: {}", this,
-        LegacyComponentSerializer.legacySection().serialize(translated));
+    if (connection.server.getConfiguration().isLogPlayerConnections()) {
+      logger.info("{} has disconnected: {}", this,
+          LegacyComponentSerializer.legacySection().serialize(translated));
+    }
     connection.closeWith(Disconnect.create(translated, getProtocolVersion()));
   }
 

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -133,6 +133,10 @@ announce-proxy-commands = true
 # Enables the logging of commands
 log-command-executions = false
 
+# Enables logging of player connections when connecting to the proxy, switching servers
+# and disconnecting from the proxy.
+log-player-connections = true
+
 [query]
 # Whether to enable responding to GameSpy 4 query responses or not.
 enabled = false


### PR DESCRIPTION
Some servers have to rely on an external plugin to filter login, server change and logout messages from their consoles. This becomes really necessary the larger the server is, especially for server change messages. Currently Velocity already has some similar options and this seems to me a good addition especially for large servers.

I have put this option in the Advanced section as I don't think everyone wants to or should disable this option.