### PR TITLE
Specify the unit for getPing to milliseconds.

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -92,7 +92,7 @@ public interface Player extends CommandSource, Identified, InboundConnection,
   Optional<ModInfo> getModInfo();
 
   /**
-   * Returns the current player's ping.
+   * Gets the player's estimated ping in milliseconds.
    *
    * @return the player's ping or -1 if ping information is currently unknown
    */


### PR DESCRIPTION
Small PR to specify the unit of Player$getPing().

Just searched for that in the source code because I was unsure (could be µs, ms, seconds) and I want to prevent my future me or other people to waste time for that.