### PR TITLE
Add "stop" as an alias to "shutdown"

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -209,7 +209,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     // Initialize commands first
     commandManager.register("velocity", new VelocityCommand(this));
     commandManager.register("server", new ServerCommand(this));
-    commandManager.register("shutdown", new ShutdownCommand(this),"end");
+    commandManager.register("shutdown", new ShutdownCommand(this),"end", "stop");
     new GlistCommand(this).register();
 
     this.doStartupConfigLoad();


### PR DESCRIPTION
Many (Minecraft) server hosts shut down servers by entering the "stop" command, instead of sending SIGINT to the process. This is because many server softwares have issues with it. (Velocity also had issues with it until #637). This should not break anything and is just a quality of life patch. 