### PR TITLE
Limiting inbound EncryptionResponse packets

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginSessionHandler.java
@@ -82,6 +82,7 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
   private @MonotonicNonNull ServerLogin login;
   private byte[] verify = EMPTY_BYTE_ARRAY;
   private @MonotonicNonNull ConnectedPlayer connectedPlayer;
+  private boolean receivedEncryptionResponse = false;
 
   LoginSessionHandler(VelocityServer server, MinecraftConnection mcConnection,
       LoginInboundConnection inbound) {
@@ -113,6 +114,12 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
     if (verify.length == 0) {
       throw new IllegalStateException("No EncryptionRequest packet sent yet.");
     }
+
+    if (receivedEncryptionResponse) {
+      throw new IllegalStateException("Too many EncryptionResponse packets received.");
+    }
+
+    receivedEncryptionResponse = true;
 
     try {
       KeyPair serverKeyPair = server.getServerKeyPair();


### PR DESCRIPTION
Prohibiting players from sending more than one EncryptionResponse packet, as this could cause DoS-attacks. Attackers don't even need to have multiple IPs to perform this attack, as we can send too many EncryptionResponse packets from one player. The attack overloads both CPU and RAM.

Before, during the attack:
Firstly, this error appears
![image](https://user-images.githubusercontent.com/14876058/163126078-01249b09-25a6-41df-afe1-1094d946fa71.png)
Then that error
![image](https://user-images.githubusercontent.com/14876058/163125738-bc78b8ae-947a-4942-a33c-542d8309c64f.png)
And then (even when the attack is stopped, as I sent 10000 EncryptionResponses from one player)
![image](https://user-images.githubusercontent.com/14876058/163126818-6f4b8d2b-3223-41a9-ab6e-a99715aca55f.png)

After this patch:
Just works well.