### PR TITLE
Implement missing Pointers

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -152,6 +152,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
   private final @NotNull Pointers pointers = Player.super.pointers().toBuilder()
           .withDynamic(Identity.UUID, this::getUniqueId)
           .withDynamic(Identity.NAME, this::getUsername)
+          .withDynamic(Identity.DISPLAY_NAME, () -> Component.text(this.getUsername()))
+          .withDynamic(Identity.LOCALE, this::getEffectiveLocale)
           .withStatic(PermissionChecker.POINTER, getPermissionChecker())
           .withStatic(FacetPointers.TYPE, Type.PLAYER)
           .build();

--- a/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
@@ -55,6 +55,8 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
   private PermissionFunction permissionFunction = ALWAYS_TRUE;
   private final @NotNull Pointers pointers = ConsoleCommandSource.super.pointers().toBuilder()
           .withDynamic(PermissionChecker.POINTER, this::getPermissionChecker)
+          .withDynamic(Identity.LOCALE, () -> ClosestLocaleMatcher.INSTANCE
+              .lookupClosest(Locale.getDefault()))
           .withStatic(FacetPointers.TYPE, Type.CONSOLE)
           .build();
 


### PR DESCRIPTION
- Implement Player's LOCALE and DISPLAY_NAME pointers
- Implement VelocityConsole's LOCALE pointer

Pull request #453 was rejected because of the cross-platform Pointers implementation in Adventure (https://github.com/PaperMC/Velocity/pull/453#issuecomment-847452453), which include the Identity Pointer of DISPLAY_NAME, so I thought I should add it, besides the Identity.LOCALE Pointer has not been implemented yet