### PR TITLE
Improved Scheduler API

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/Command.java
+++ b/api/src/main/java/com/velocitypowered/api/command/Command.java
@@ -7,11 +7,7 @@
 
 package com.velocitypowered.api.command;
 
-import com.google.common.collect.ImmutableList;
 import com.velocitypowered.api.proxy.Player;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Represents a command that can be executed by a {@link CommandSource}

--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
@@ -8,7 +8,6 @@
 package com.velocitypowered.api.permission;
 
 import net.kyori.adventure.permission.PermissionChecker;
-import net.kyori.adventure.util.TriState;
 
 /**
  * Represents a object that has a set of queryable permissions.

--- a/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 import net.kyori.adventure.audience.Audience;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Provides an interface to a Minecraft server proxy.

--- a/api/src/main/java/com/velocitypowered/api/scheduler/ScheduledTask.java
+++ b/api/src/main/java/com/velocitypowered/api/scheduler/ScheduledTask.java
@@ -7,6 +7,8 @@
 
 package com.velocitypowered.api.scheduler;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents a task that is scheduled to run on the proxy.
  */
@@ -17,7 +19,7 @@ public interface ScheduledTask {
    *
    * @return the plugin that scheduled this task
    */
-  Object plugin();
+  @NotNull Object plugin();
 
   /**
    * Returns the current status of this task.

--- a/api/src/main/java/com/velocitypowered/api/scheduler/Scheduler.java
+++ b/api/src/main/java/com/velocitypowered/api/scheduler/Scheduler.java
@@ -33,9 +33,10 @@ public interface Scheduler {
    * Initializes a new {@link TaskBuilder} for creating a task on the proxy.
    *
    * @param plugin the plugin to request the task for
+   * @param consumer the task to be run when scheduled with the capacity to cancel itself
    * @return the task builder
    */
-  TaskBuilder builder(@NotNull Object plugin);
+  TaskBuilder buildTask(@NotNull Object plugin, @NotNull Consumer<ScheduledTask> consumer);
 
   /**
    * Get the {@link ScheduledTask} for a specific plugin.
@@ -49,22 +50,6 @@ public interface Scheduler {
    * Represents a fluent interface to schedule tasks on the proxy.
    */
   interface TaskBuilder {
-
-    /**
-     * Specifies the task to be executed.
-     *
-     * @param runnable the task to run
-     * @return this builder, for chaining
-     */
-    TaskBuilder task(@NotNull Runnable runnable);
-
-    /**
-     * Specifies the task to be executed.
-     *
-     * @param consumer the task to be run with the capacity to cancel itself
-     * @return this builder, for chaining
-     */
-    TaskBuilder task(@NotNull Consumer<ScheduledTask> consumer);
 
     /**
      * Specifies that the task should delay its execution by the specified amount of time.

--- a/api/src/main/java/com/velocitypowered/api/scheduler/Scheduler.java
+++ b/api/src/main/java/com/velocitypowered/api/scheduler/Scheduler.java
@@ -8,8 +8,12 @@
 package com.velocitypowered.api.scheduler;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
 import org.checkerframework.common.value.qual.IntRange;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a scheduler to execute tasks on the proxy.
@@ -23,12 +27,44 @@ public interface Scheduler {
    * @param runnable the task to run when scheduled
    * @return the task builder
    */
-  TaskBuilder buildTask(Object plugin, Runnable runnable);
+  TaskBuilder buildTask(@NotNull Object plugin, @NotNull Runnable runnable);
+
+  /**
+   * Initializes a new {@link TaskBuilder} for creating a task on the proxy.
+   *
+   * @param plugin the plugin to request the task for
+   * @return the task builder
+   */
+  TaskBuilder builder(@NotNull Object plugin);
+
+  /**
+   * Get the {@link ScheduledTask} for a specific plugin.
+   *
+   * @param plugin the plugin object
+   * @return the list of {@link ScheduledTask} corresponding to a specific plugin
+   */
+  @NotNull Collection<ScheduledTask> tasksByPlugin(@NotNull Object plugin);
 
   /**
    * Represents a fluent interface to schedule tasks on the proxy.
    */
   interface TaskBuilder {
+
+    /**
+     * Specifies the task to be executed.
+     *
+     * @param runnable the task to run
+     * @return this builder, for chaining
+     */
+    TaskBuilder task(@NotNull Runnable runnable);
+
+    /**
+     * Specifies the task to be executed.
+     *
+     * @param consumer the task to be run with the capacity to cancel itself
+     * @return this builder, for chaining
+     */
+    TaskBuilder task(@NotNull Consumer<ScheduledTask> consumer);
 
     /**
      * Specifies that the task should delay its execution by the specified amount of time.
@@ -37,7 +73,7 @@ public interface Scheduler {
      * @param unit the unit of time for {@code time}
      * @return this builder, for chaining
      */
-    TaskBuilder delay(@IntRange(from = 0) long time, TimeUnit unit);
+    TaskBuilder delay(@IntRange(from = 0) long time, @NotNull TimeUnit unit);
 
     /**
      * Specifies that the task should delay its execution by the specified amount of time.
@@ -45,7 +81,7 @@ public interface Scheduler {
      * @param duration the duration of the delay
      * @return this builder, for chaining
      */
-    default TaskBuilder delay(Duration duration) {
+    default TaskBuilder delay(@NotNull Duration duration) {
       return delay(duration.toMillis(), TimeUnit.MILLISECONDS);
     }
 
@@ -57,7 +93,7 @@ public interface Scheduler {
      * @param unit the unit of time for {@code time}
      * @return this builder, for chaining
      */
-    TaskBuilder repeat(@IntRange(from = 0) long time, TimeUnit unit);
+    TaskBuilder repeat(@IntRange(from = 0) long time, @NotNull TimeUnit unit);
 
     /**
      * Specifies that the task should continue running after waiting for the specified amount, until
@@ -66,7 +102,7 @@ public interface Scheduler {
      * @param duration the duration of the delay
      * @return this builder, for chaining
      */
-    default TaskBuilder repeat(Duration duration) {
+    default TaskBuilder repeat(@NotNull Duration duration) {
       return repeat(duration.toMillis(), TimeUnit.MILLISECONDS);
     }
 

--- a/native/src/main/java/com/velocitypowered/natives/compression/JavaVelocityCompressor.java
+++ b/native/src/main/java/com/velocitypowered/natives/compression/JavaVelocityCompressor.java
@@ -20,7 +20,6 @@ package com.velocitypowered.natives.compression;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.velocitypowered.natives.compression.CompressorUtils.ZLIB_BUFFER_SIZE;
-import static com.velocitypowered.natives.compression.CompressorUtils.ensureMaxSize;
 
 import com.velocitypowered.natives.util.BufferPreference;
 import io.netty.buffer.ByteBuf;

--- a/native/src/test/java/com/velocitypowered/natives/compression/VelocityCompressorTest.java
+++ b/native/src/test/java/com/velocitypowered/natives/compression/VelocityCompressorTest.java
@@ -34,9 +34,7 @@ import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnJre;
 import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.JRE;
 
 class VelocityCompressorTest {
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/scheduler/VelocityScheduler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/scheduler/VelocityScheduler.java
@@ -18,7 +18,7 @@
 package com.velocitypowered.proxy.scheduler;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.requireNonNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
@@ -68,23 +68,23 @@ public class VelocityScheduler implements Scheduler {
 
   @Override
   public TaskBuilder buildTask(Object plugin, Runnable runnable) {
-    requireNonNull(runnable, () -> "the scheduled task cannot be null");
-    requireNonNull(plugin, () -> "the plugin cannot be null");
+    checkNotNull(plugin, "plugin");
+    checkNotNull(runnable, "runnable");
     checkArgument(pluginManager.fromInstance(plugin).isPresent(), "plugin is not registered");
     return new TaskBuilderImpl(plugin, runnable, null);
   }
 
   @Override
   public TaskBuilder buildTask(Object plugin, Consumer<ScheduledTask> consumer) {
-    requireNonNull(consumer, () -> "the scheduled task cannot be null");
-    requireNonNull(plugin, () -> "the plugin cannot be null");
+    checkNotNull(plugin, "plugin");
+    checkNotNull(consumer, "consumer");
     checkArgument(pluginManager.fromInstance(plugin).isPresent(), "plugin is not registered");
     return new TaskBuilderImpl(plugin, null, consumer);
   }
 
   @Override
   public @NonNull Collection<ScheduledTask> tasksByPlugin(@NonNull Object plugin) {
-    requireNonNull(plugin, () -> "the plugin cannot be null");
+    checkNotNull(plugin, "plugin");
     checkArgument(pluginManager.fromInstance(plugin).isPresent(), "plugin is not registered");
     final Collection<ScheduledTask> tasks = tasksByPlugin.get(plugin);
     synchronized (tasksByPlugin) {

--- a/proxy/src/test/java/com/velocitypowered/proxy/scheduler/VelocitySchedulerTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/scheduler/VelocitySchedulerTest.java
@@ -75,13 +75,12 @@ class VelocitySchedulerTest {
     scheduler.buildTask(FakePluginManager.PLUGIN_A, task -> {
       if (i.getAndIncrement() >= 1) {
         task.cancel();
+      } else {
+        scheduler.buildTask(FakePluginManager.PLUGIN_A, () ->
+          assertEquals(scheduler.tasksByPlugin(FakePluginManager.PLUGIN_A).size(), 1)
+        ).schedule();
       }
-      scheduler.buildTask(FakePluginManager.PLUGIN_A, () -> {
-        assertEquals(scheduler.tasksByPlugin(FakePluginManager.PLUGIN_A).size(), 1);
-      })
-        .schedule();
-    })
-      .delay(50, TimeUnit.MILLISECONDS)
+    }).delay(50, TimeUnit.MILLISECONDS)
       .repeat(Duration.ofMillis(5))
       .schedule();
   }
@@ -94,12 +93,8 @@ class VelocitySchedulerTest {
       actualTask.cancel();
       scheduler.buildTask(FakePluginManager.PLUGIN_B, () ->
         assertEquals(TaskStatus.CANCELLED, actualTask.status())
-      )
-        .delay(20, TimeUnit.MILLISECONDS)
-        .schedule();
-    })
-        .repeat(5, TimeUnit.MILLISECONDS)
-        .schedule();
+      ).delay(20, TimeUnit.MILLISECONDS).schedule();
+    }).repeat(5, TimeUnit.MILLISECONDS).schedule();
 
     Thread.sleep(50);
   }

--- a/proxy/src/test/java/com/velocitypowered/proxy/scheduler/VelocitySchedulerTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/scheduler/VelocitySchedulerTest.java
@@ -18,7 +18,6 @@
 package com.velocitypowered.proxy.scheduler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.velocitypowered.api.scheduler.ScheduledTask;
 import com.velocitypowered.api.scheduler.TaskStatus;
@@ -67,20 +66,10 @@ class VelocitySchedulerTest {
   }
 
   @Test
-  void nullSchedulerTest() throws Exception {
-    VelocityScheduler scheduler = new VelocityScheduler(new FakePluginManager());
-
-    assertThrows(NullPointerException.class, () -> scheduler.builder(null).schedule());
-    assertThrows(IllegalArgumentException.class, () -> scheduler.builder(FakePluginManager.PLUGIN_A)
-        .schedule());
-  }
-
-  @Test
   void obtainTasksFromPlugin() throws Exception {
     VelocityScheduler scheduler = new VelocityScheduler(new FakePluginManager());
 
-    scheduler.builder(FakePluginManager.PLUGIN_A)
-      .task(ScheduledTask::cancel)
+    scheduler.buildTask(FakePluginManager.PLUGIN_A, ScheduledTask::cancel)
       .delay(100, TimeUnit.MILLISECONDS)
       .schedule();
 
@@ -91,12 +80,11 @@ class VelocitySchedulerTest {
   void testConsumerCancel() throws Exception {
     VelocityScheduler scheduler = new VelocityScheduler(new FakePluginManager());
 
-    ScheduledTask task = scheduler.builder(FakePluginManager.PLUGIN_B)
-        .task(ScheduledTask::cancel)
+    ScheduledTask task = scheduler.buildTask(FakePluginManager.PLUGIN_B, ScheduledTask::cancel)
         .repeat(5, TimeUnit.MILLISECONDS)
         .schedule();
 
-    Thread.sleep(50);
+    Thread.sleep(75);
 
     assertEquals(TaskStatus.CANCELLED, task.status());
   }


### PR DESCRIPTION
- Added `Scheduler#buildTask(plugin, Consumer<ScheduledTask>)`
- Added `Scheduler#tasksByPlugin(plugin)`
Allows to obtain the tasks that a plugin has schedule to execute and that are currently active

Resolves #276 