### PR TITLE
Override correct sendMessage method

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
@@ -27,6 +27,8 @@ import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.util.ClosestLocaleMatcher;
 import java.util.List;
 import java.util.Locale;
+
+import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.permission.PermissionChecker;
 import net.kyori.adventure.platform.facet.FacetPointers;
@@ -65,7 +67,7 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
   }
 
   @Override
-  public void sendMessage(@NonNull Identity identity, @NonNull Component message) {
+  public void sendMessage(@NonNull Identity identity, @NonNull Component message, @NonNull MessageType messageType) {
     Component translated = GlobalTranslator.render(message, ClosestLocaleMatcher.INSTANCE
         .lookupClosest(Locale.getDefault()));
     logger.info(LegacyComponentSerializer.legacySection().serialize(translated));


### PR DESCRIPTION
In the `Audience` interface, `sendMessage` has various overloads all calling the default method `sendMessage(Identity, Component, MessageType`. This method is blank by default. Velocity used to only override one specific overload instead of the "base method" which meant most messages to the console sender were dropped.