### PR TITLE
fix missing server info in some events when kicked from current server

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/ServerConnection.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/ServerConnection.java
@@ -11,6 +11,7 @@ import com.velocitypowered.api.proxy.messages.ChannelMessageSink;
 import com.velocitypowered.api.proxy.messages.ChannelMessageSource;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
+import java.util.Optional;
 
 /**
  * Represents a connection to a backend server from the proxy for a client.
@@ -23,6 +24,14 @@ public interface ServerConnection extends ChannelMessageSource, ChannelMessageSi
    * @return the server this connection is connected to
    */
   RegisteredServer getServer();
+
+  /**
+   * Returns the server that the player associated with this connection was connected to before
+   * switching to this connection.
+   *
+   * @return the server the player was connected to.
+   */
+  Optional<RegisteredServer> getPreviousServer();
 
   /**
    * Returns the server info for this connection.

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.ServerConnection;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
 import com.velocitypowered.api.util.GameProfile.Property;
 import com.velocitypowered.proxy.VelocityServer;
@@ -49,6 +50,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -57,6 +59,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class VelocityServerConnection implements MinecraftConnectionAssociation, ServerConnection {
 
   private final VelocityRegisteredServer registeredServer;
+  private final @Nullable VelocityRegisteredServer previousServer;
   private final ConnectedPlayer proxyPlayer;
   private final VelocityServer server;
   private @Nullable MinecraftConnection connection;
@@ -69,12 +72,15 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
   /**
    * Initializes a new server connection.
    * @param registeredServer the server to connect to
+   * @param previousServer the server the player is coming from
    * @param proxyPlayer the player connecting to the server
    * @param server the Velocity proxy instance
    */
   public VelocityServerConnection(VelocityRegisteredServer registeredServer,
+      @Nullable VelocityRegisteredServer previousServer,
       ConnectedPlayer proxyPlayer, VelocityServer server) {
     this.registeredServer = registeredServer;
+    this.previousServer = previousServer;
     this.proxyPlayer = proxyPlayer;
     this.server = server;
   }
@@ -207,6 +213,11 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
   @Override
   public VelocityRegisteredServer getServer() {
     return registeredServer;
+  }
+
+  @Override
+  public Optional<RegisteredServer> getPreviousServer() {
+    return Optional.ofNullable(this.previousServer);
   }
 
   @Override


### PR DESCRIPTION
👋  Just stumbled over this issue myself and saw some other struggling with it as well. I am not sure if my current solution for the problem is the best one, but it seems to be the easiest one without needing to potentially break other stuff. 

In a nutshell, this PR just passes down the previous server when creating a connection request rather than letting the code rely on the current connection of the player which is reset before connecting when the player was kicked from the current server he is connected to (seems like to prevent "already connected" issues).

Fixes #633