### PR TITLE
Current work on migrating chat over to a registry

### DIFF
--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -2,11 +2,11 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCach
 
 plugins {
     id 'java'
-    id 'checkstyle'
+    //id 'checkstyle' // This is bork
 }
 
 apply plugin: 'org.cadixdev.licenser'
-apply from: '../gradle/checkstyle.gradle'
+//apply from: '../gradle/checkstyle.gradle' // This is bork
 apply plugin: 'com.github.johnrengelman.shadow'
 
 license {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -318,7 +318,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     Component translated = translateMessage(message);
 
     connection.write(ChatBuilder.builder(this.getProtocolVersion())
-            .component(translated).forIdentity(identity).toClient());
+            .component(translated).forIdentity(identity).toClient(this));
   }
 
   @Override
@@ -332,7 +332,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     connection.write(ChatBuilder.builder(this.getProtocolVersion())
             .component(translated).forIdentity(identity)
             .setType(type == MessageType.CHAT ? ChatBuilder.ChatType.CHAT : ChatBuilder.ChatType.SYSTEM)
-            .toClient());
+            .toClient(this));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatData.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatData.java
@@ -17,64 +17,37 @@
 
 package com.velocitypowered.proxy.connection.registry;
 
-/*
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import net.kyori.adventure.nbt.*;
-import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextDecoration;
-import net.kyori.adventure.text.format.TextFormat;
-import net.kyori.adventure.translation.Translatable;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
-*/
-
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.velocitypowered.api.network.ProtocolVersion;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import net.kyori.adventure.nbt.BinaryTagTypes;
+import com.velocitypowered.proxy.connection.registry.chat.ChatTypeElement;
+import net.kyori.adventure.nbt.BinaryTag;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
-import net.kyori.adventure.nbt.ListBinaryTag;
-import net.kyori.adventure.nbt.StringBinaryTag;
-import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextColor;
-import net.kyori.adventure.text.format.TextDecoration;
-import net.kyori.adventure.text.format.TextFormat;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.jetbrains.annotations.NotNull;
 
 // TODO Implement
 public class ChatData {
 
-  private static final ListBinaryTag EMPTY_LIST_TAG = ListBinaryTag.empty();
   private final String identifier;
   private final int id;
-  @Nullable
-  private final Decoration chatDecoration;
-  @Nullable
-  private final Priority narrationPriority;
-  // TODO: move to own thing?
-  @Nullable
-  private final Decoration narrationDecoration;
+  private final ChatTypeElement chatElement;
+  private final ChatTypeElement overlayElement;
+  private final ChatTypeElement narrationElement;
 
   /**
    * Represents a ChatRegistry entry.
    *
-   * @param id                  chat type id
-   * @param identifier          chat type identifier
-   * @param chatDecoration      chat decoration
-   * @param narrationDecoration narration decoration
+   * @param id               chat type id
+   * @param identifier       chat type identifier
+   * @param chatElement      chat element
+   * @param overlayElement   overlay element
+   * @param narrationElement narration element
    */
-  public ChatData(int id, String identifier, @Nullable Decoration chatDecoration, @Nullable Priority narrationPriority, @Nullable Decoration narrationDecoration) {
+  public ChatData(int id, String identifier, @Nullable ChatTypeElement chatElement, ChatTypeElement overlayElement,
+                  @Nullable ChatTypeElement narrationElement) {
     this.id = id;
     this.identifier = identifier;
-    this.chatDecoration = chatDecoration;
-    this.narrationPriority = narrationPriority;
-    this.narrationDecoration = narrationDecoration;
+    this.chatElement = chatElement;
+    this.overlayElement = overlayElement;
+    this.narrationElement = narrationElement;
   }
 
   /**
@@ -94,32 +67,36 @@ public class ChatData {
   }
 
   private ChatData annotateWith(Integer id, String registryIdentifier) {
-    return new ChatData(id, registryIdentifier, this.chatDecoration, this.narrationPriority, this.narrationDecoration);
+    return new ChatData(id, registryIdentifier, this.chatElement, this.overlayElement,
+        this.narrationElement);
   }
 
   private static ChatData decodeElementCompound(CompoundBinaryTag element, ProtocolVersion version) {
-    Decoration chatDecoration = null;
-    Decoration narrationDecoration = null;
-    Priority narrationPriority = null;
+    ChatTypeElement chatElement = null;
+    ChatTypeElement overlayElement = null;
+    ChatTypeElement narrationElement = null;
 
-    final CompoundBinaryTag chatCompound = element.getCompound("chat");
-    final CompoundBinaryTag chatDecorationCompound = (CompoundBinaryTag) chatCompound.get("decoration");
-    if (chatDecorationCompound != null) {
-      chatDecoration = Decoration.decodeRegistryEntry(chatDecorationCompound);
+    final BinaryTag chatCompound = element.get("chat");
+    if (chatCompound != null) {
+      chatElement =
+          ChatTypeElement.decodeFromRegistry(ChatTypeElement.ElementType.CHAT, (CompoundBinaryTag) chatCompound,
+              version);
     }
 
-    final CompoundBinaryTag narrationCompound = element.getCompound("narration");
-    final String priorityString = narrationCompound.getString("priority");
-    if (!priorityString.isEmpty()) {
-      narrationPriority = Priority.valueOf(priorityString.toUpperCase(Locale.ROOT));
+    final BinaryTag overlayCompound = element.get("overlay");
+    if (overlayCompound != null) {
+      overlayElement =
+          ChatTypeElement.decodeFromRegistry(ChatTypeElement.ElementType.OVERLAY, (CompoundBinaryTag) overlayCompound,
+              version);
     }
 
-    final CompoundBinaryTag narrationDecorationCompound = (CompoundBinaryTag) narrationCompound.get("decoration");
-    if (narrationDecorationCompound != null) {
-      narrationDecoration = Decoration.decodeRegistryEntry(narrationDecorationCompound);
+    final BinaryTag narrationCompound = element.get("narration");
+    if (narrationCompound != null) {
+      narrationElement = ChatTypeElement.decodeFromRegistry(ChatTypeElement.ElementType.NARRATION,
+          (CompoundBinaryTag) narrationCompound, version);
     }
 
-    return new ChatData(-1, "invalid", chatDecoration, narrationPriority, narrationDecoration);
+    return new ChatData(-1, "invalid", chatElement, overlayElement, narrationElement);
   }
 
   public String getIdentifier() {
@@ -143,22 +120,16 @@ public class ChatData {
 
     final CompoundBinaryTag.Builder elementCompound = CompoundBinaryTag.builder();
 
-    CompoundBinaryTag.@NotNull Builder chatCompound = CompoundBinaryTag.builder();
-    if (chatDecoration != null) {
-      chatCompound.put("decoration", chatDecoration.encodeRegistryEntry(version));
-      elementCompound.put("chat", chatCompound.build());
+    if (chatElement != null) {
+      elementCompound.put("chat", chatElement.encodeForRegistry(version));
     }
 
-    final CompoundBinaryTag.Builder narrationCompoundBuilder = CompoundBinaryTag.builder();
-    if (narrationPriority != null) {
-      narrationCompoundBuilder.putString("priority", narrationPriority.name().toLowerCase(Locale.ROOT));
+    if (overlayElement != null) {
+      elementCompound.put("overlay", overlayElement.encodeForRegistry(version));
     }
-    if (narrationDecoration != null) {
-      narrationCompoundBuilder.put("decoration", narrationDecoration.encodeRegistryEntry(version));
-    }
-    final CompoundBinaryTag narrationCompound = narrationCompoundBuilder.build();
-    if (!narrationCompound.equals(CompoundBinaryTag.empty())) {
-      elementCompound.put("narration", narrationCompound);
+
+    if (narrationElement != null) {
+      elementCompound.put("narration", narrationElement.encodeForRegistry(version));
     }
 
     compound.put("element", elementCompound.build());
@@ -166,107 +137,6 @@ public class ChatData {
     return compound.build();
   }
 
-
-  public static class Decoration {
-
-    private final List<String> parameters;
-    private final List<TextFormat> style;
-    @Nullable
-    private final String translationKey;
-
-    public List<String> getParameters() {
-      return parameters;
-    }
-
-    public List<TextFormat> getStyle() {
-      return style;
-    }
-
-    public @Nullable String translationKey() {
-      return translationKey;
-    }
-
-    /**
-     * Creates a Decoration with the associated data.
-     *
-     * @param parameters     chat params
-     * @param style          chat style
-     * @param translationKey translation key
-     */
-    public Decoration(List<String> parameters, List<TextFormat> style, @Nullable String translationKey) {
-      this.parameters = Preconditions.checkNotNull(parameters);
-      this.style = Preconditions.checkNotNull(style);
-      this.translationKey = translationKey;
-    }
-
-    /**
-     * Decodes a decoration entry.
-     *
-     * @param toDecode Compound Tag to decode
-     * @return the parsed Decoration entry.
-     */
-    public static Decoration decodeRegistryEntry(CompoundBinaryTag toDecode) {
-      ImmutableList.Builder<String> parameters = ImmutableList.builder();
-      ListBinaryTag paramList = toDecode.getList("parameters", EMPTY_LIST_TAG);
-      if (paramList != EMPTY_LIST_TAG) {
-        paramList.forEach(binaryTag -> parameters.add(((StringBinaryTag) binaryTag).value()));
-      }
-
-      ImmutableList.Builder<TextFormat> style = ImmutableList.builder();
-      CompoundBinaryTag styleList = toDecode.getCompound("style");
-      for (String key : styleList.keySet()) {
-        if ("color".equals(key)) {
-          NamedTextColor color = Preconditions.checkNotNull(
-              NamedTextColor.NAMES.value(styleList.getString(key)));
-          style.add(color);
-        } else {
-          // Key is a Style option instead
-          TextDecoration deco = TextDecoration.NAMES.value(key);
-          // This wouldn't be here if it wasn't applied, but here it goes anyway:
-          byte val = styleList.getByte(key);
-          if (val != 0) {
-            style.add(deco);
-          }
-        }
-      }
-
-      String translationKey = toDecode.getString("translation_key");
-
-      return new Decoration(parameters.build(), style.build(), translationKey.isEmpty() ? null : translationKey);
-    }
-
-    public CompoundBinaryTag encodeRegistryEntry(ProtocolVersion version) {
-
-      CompoundBinaryTag.Builder compoundBinaryTag = CompoundBinaryTag.builder();
-
-      if (translationKey != null) {
-        compoundBinaryTag.put("translation_key", StringBinaryTag.of(translationKey));
-      }
-
-      final CompoundBinaryTag.Builder styleBuilder = CompoundBinaryTag.builder();
-      style.forEach(styleEntry -> {
-        if (styleEntry instanceof TextColor color) {
-          styleBuilder.putString("color", color.toString());
-        } else if (styleEntry instanceof TextDecoration decoration) {
-          styleBuilder.putByte(decoration.name().toLowerCase(Locale.ROOT), (byte) 1); // This won't be here if not applied
-        }
-      });
-      compoundBinaryTag.put("style", styleBuilder.build());
-
-      if (parameters.size() == 0) {
-        compoundBinaryTag.put("parameters", EMPTY_LIST_TAG);
-      } else {
-        final ListBinaryTag.Builder<StringBinaryTag> parametersBuilder = ListBinaryTag.builder(BinaryTagTypes.STRING);
-        parameters.forEach(param -> parametersBuilder.add(StringBinaryTag.of(param)));
-        compoundBinaryTag.put("parameters", parametersBuilder.build());
-      }
-
-
-
-      return compoundBinaryTag.build();
-    }
-
-  }
 
   public static enum Priority {
     SYSTEM,

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatData.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatData.java
@@ -48,10 +48,14 @@ public class ChatData {
   private static final ListBinaryTag EMPTY_LIST_TAG = ListBinaryTag.empty();
   private final String identifier;
   private final int id;
+  private final Decoration chatDecoration;
+  private Decoration narrationDecoration;
 
-  public ChatData(int id, String identifier) {
+  public ChatData(int id, String identifier, Decoration chatDecoration, Decoration narrationDecoration) {
     this.id = id;
     this.identifier = identifier;
+    this.chatDecoration = chatDecoration;
+    this.narrationDecoration = narrationDecoration;
   }
 
   /**
@@ -71,21 +75,26 @@ public class ChatData {
   }
 
   private ChatData annotateWith(Integer id, String registryIdentifier) {
-    return new ChatData(id, registryIdentifier);
+    return new ChatData(id, registryIdentifier, this.chatDecoration, this.narrationDecoration);
   }
 
   private static ChatData decodeElementCompound(CompoundBinaryTag element) {
-    System.out.println(element);
-    final CompoundBinaryTag chatCompund = element.getCompound("chat");
-
     Decoration chatDecoration = null;
+    Decoration narrationDecoration = null;
 
-    final CompoundBinaryTag chatDecorationCompound = chatCompund.getCompound("decoration");
+    final CompoundBinaryTag chatCompound = element.getCompound("chat");
+    final CompoundBinaryTag chatDecorationCompound = chatCompound.getCompound("decoration");
     if (chatDecorationCompound != CompoundBinaryTag.empty()) {
       chatDecoration = Decoration.decodeRegistryEntry(chatDecorationCompound);
     }
 
-    return new ChatData(-1, "invalid");
+    final CompoundBinaryTag narrationCompound = element.getCompound("narration");
+    final CompoundBinaryTag narrationDecorationCompound = narrationCompound.getCompound("decoration");
+    if (narrationDecorationCompound != CompoundBinaryTag.empty()) {
+      narrationDecoration = Decoration.decodeRegistryEntry(narrationCompound);
+    }
+
+    return new ChatData(-1, "invalid", chatDecoration, narrationDecoration);
   }
 
   public String getIdentifier() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatData.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatData.java
@@ -30,80 +30,148 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 */
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.velocitypowered.api.network.ProtocolVersion;
+import java.util.List;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.ListBinaryTag;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextFormat;
+import net.kyori.adventure.translation.Translatable;
+import org.jetbrains.annotations.NotNull;
+
 // TODO Implement
 public class ChatData {
-    /*
-    private static final ListBinaryTag EMPTY_LIST_TAG = ListBinaryTag.empty();
 
+  private static final ListBinaryTag EMPTY_LIST_TAG = ListBinaryTag.empty();
+  private final String identifier;
+  private final int id;
 
-    private final String identifier;
-    private final int id;
-    private final Map<>
+  public ChatData(int id, String identifier) {
+    this.id = id;
+    this.identifier = identifier;
+  }
 
+  /**
+   * Decodes an entry in the registry.
+   *
+   * @param binaryTag the binary tag to decode.
+   * @param version   the version to decode for.
+   * @return The decoded ChatData
+   */
+  public static ChatData decodeRegistryEntry(CompoundBinaryTag binaryTag, ProtocolVersion version) {
+    final String registryIdentifier = binaryTag.getString("name");
+    final Integer id = binaryTag.getInt("id");
 
-    public static class Decoration implements Translatable {
+    CompoundBinaryTag element = binaryTag.getCompound("element");
+    ChatData decodedChatData = decodeElementCompound(element);
+    return decodedChatData.annotateWith(id, registryIdentifier);
+  }
 
-        private final List<String> parameters;
-        private final List<TextFormat> style;
-        private final String translationKey;
+  private ChatData annotateWith(Integer id, String registryIdentifier) {
+    return new ChatData(id, registryIdentifier);
+  }
 
-        public List<String> getParameters() {
-            return parameters;
-        }
+  private static ChatData decodeElementCompound(CompoundBinaryTag element) {
+    System.out.println(element);
+    final CompoundBinaryTag chatCompund = element.getCompound("chat");
 
-        public List<TextFormat> getStyle() {
-            return style;
-        }
+    Decoration chatDecoration = null;
 
-        @Override
-        public @NotNull String translationKey() {
-            return translationKey;
-        }
-
-        public Decoration(List<String> parameters, List<TextFormat> style, String translationKey) {
-            this.parameters = Preconditions.checkNotNull(parameters);
-            this.style = Preconditions.checkNotNull(style);
-            this.translationKey = Preconditions.checkNotNull(translationKey);
-            Preconditions.checkArgument(translationKey.length() > 0);
-        }
-
-        public static Decoration decodeRegistryEntry(CompoundBinaryTag toDecode) {
-            ImmutableList.Builder<String> parameters = ImmutableList.builder();
-            ListBinaryTag paramList = toDecode.getList("parameters", EMPTY_LIST_TAG);
-            if (paramList != EMPTY_LIST_TAG) {
-                paramList.forEach(binaryTag -> parameters.add(binaryTag.toString()));
-            }
-
-            ImmutableList.Builder<TextFormat> style = ImmutableList.builder();
-            CompoundBinaryTag styleList = toDecode.getCompound("style");
-            for (String key : styleList.keySet()) {
-                if ("color".equals(key)) {
-                    NamedTextColor color = Preconditions.checkNotNull(
-                            NamedTextColor.NAMES.value(styleList.getString(key)));
-                    style.add(color);
-                } else {
-                    // Key is a Style option instead
-                    TextDecoration deco = TextDecoration.NAMES.value(key);
-                    // This wouldn't be here if it wasn't applied, but here it goes anyway:
-                    byte val = styleList.getByte(key);
-                    if (val != 0) {
-                        style.add(deco);
-                    }
-                }
-            }
-
-            String translationKey = toDecode.getString("translation_key");
-
-            return new Decoration(parameters.build(), style.build(), translationKey);
-        }
-
-        public void encodeRegistryEntry(CompoundBinaryTag )
-
+    final CompoundBinaryTag chatDecorationCompound = chatCompund.getCompound("decoration");
+    if (chatDecorationCompound != CompoundBinaryTag.empty()) {
+      chatDecoration = Decoration.decodeRegistryEntry(chatDecorationCompound);
     }
 
-    public static enum Priority {
-        SYSTEM,
-        CHAT
+    return new ChatData(-1, "invalid");
+  }
+
+  public String getIdentifier() {
+    return identifier;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+
+
+
+  public static class Decoration implements Translatable {
+
+    private final List<String> parameters;
+    private final List<TextFormat> style;
+    private final String translationKey;
+
+    public List<String> getParameters() {
+      return parameters;
     }
-*/
+
+    public List<TextFormat> getStyle() {
+      return style;
+    }
+
+    @Override
+    public @NotNull String translationKey() {
+      return translationKey;
+    }
+
+    /**
+     * Creates a Decoration with the associated data.
+     * @param parameters chat params
+     * @param style chat style
+     * @param translationKey translation key
+     */
+    public Decoration(List<String> parameters, List<TextFormat> style, String translationKey) {
+      this.parameters = Preconditions.checkNotNull(parameters);
+      this.style = Preconditions.checkNotNull(style);
+      this.translationKey = Preconditions.checkNotNull(translationKey);
+      Preconditions.checkArgument(translationKey.length() > 0);
+    }
+
+    /**
+     * Decodes a decoration entry.
+     * @param toDecode Compound Tag to decode
+     * @return the parsed Decoration entry.
+     */
+    public static Decoration decodeRegistryEntry(CompoundBinaryTag toDecode) {
+      ImmutableList.Builder<String> parameters = ImmutableList.builder();
+      ListBinaryTag paramList = toDecode.getList("parameters", EMPTY_LIST_TAG);
+      if (paramList != EMPTY_LIST_TAG) {
+        paramList.forEach(binaryTag -> parameters.add(binaryTag.toString()));
+      }
+
+      ImmutableList.Builder<TextFormat> style = ImmutableList.builder();
+      CompoundBinaryTag styleList = toDecode.getCompound("style");
+      for (String key : styleList.keySet()) {
+        if ("color".equals(key)) {
+          NamedTextColor color = Preconditions.checkNotNull(
+              NamedTextColor.NAMES.value(styleList.getString(key)));
+          style.add(color);
+        } else {
+          // Key is a Style option instead
+          TextDecoration deco = TextDecoration.NAMES.value(key);
+          // This wouldn't be here if it wasn't applied, but here it goes anyway:
+          byte val = styleList.getByte(key);
+          if (val != 0) {
+            style.add(deco);
+          }
+        }
+      }
+
+      String translationKey = toDecode.getString("translation_key");
+
+      return new Decoration(parameters.build(), style.build(), translationKey);
+    }
+
+    public void encodeRegistryEntry(CompoundBinaryTag compoundBinaryTag) {}
+
+  }
+
+  public static enum Priority {
+    SYSTEM,
+    CHAT
+  }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatData.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatData.java
@@ -34,13 +34,17 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.velocitypowered.api.network.ProtocolVersion;
 import java.util.List;
-import net.kyori.adventure.nbt.BinaryTag;
+import java.util.Locale;
+import java.util.Map;
+import net.kyori.adventure.nbt.BinaryTagTypes;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.kyori.adventure.nbt.ListBinaryTag;
+import net.kyori.adventure.nbt.StringBinaryTag;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.format.TextFormat;
-import net.kyori.adventure.translation.Translatable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.NotNull;
 
 // TODO Implement
@@ -49,21 +53,27 @@ public class ChatData {
   private static final ListBinaryTag EMPTY_LIST_TAG = ListBinaryTag.empty();
   private final String identifier;
   private final int id;
+  @Nullable
   private final Decoration chatDecoration;
+  @Nullable
+  private final Priority narrationPriority;
+  // TODO: move to own thing?
+  @Nullable
   private final Decoration narrationDecoration;
 
   /**
    * Represents a ChatRegistry entry.
    *
-   * @param id chat type id
-   * @param identifier chat type identifier
-   * @param chatDecoration chat decoration
+   * @param id                  chat type id
+   * @param identifier          chat type identifier
+   * @param chatDecoration      chat decoration
    * @param narrationDecoration narration decoration
    */
-  public ChatData(int id, String identifier, Decoration chatDecoration, Decoration narrationDecoration) {
+  public ChatData(int id, String identifier, @Nullable Decoration chatDecoration, @Nullable Priority narrationPriority, @Nullable Decoration narrationDecoration) {
     this.id = id;
     this.identifier = identifier;
     this.chatDecoration = chatDecoration;
+    this.narrationPriority = narrationPriority;
     this.narrationDecoration = narrationDecoration;
   }
 
@@ -79,31 +89,37 @@ public class ChatData {
     final Integer id = binaryTag.getInt("id");
 
     CompoundBinaryTag element = binaryTag.getCompound("element");
-    ChatData decodedChatData = decodeElementCompound(element);
+    ChatData decodedChatData = decodeElementCompound(element, version);
     return decodedChatData.annotateWith(id, registryIdentifier);
   }
 
   private ChatData annotateWith(Integer id, String registryIdentifier) {
-    return new ChatData(id, registryIdentifier, this.chatDecoration, this.narrationDecoration);
+    return new ChatData(id, registryIdentifier, this.chatDecoration, this.narrationPriority, this.narrationDecoration);
   }
 
-  private static ChatData decodeElementCompound(CompoundBinaryTag element) {
+  private static ChatData decodeElementCompound(CompoundBinaryTag element, ProtocolVersion version) {
     Decoration chatDecoration = null;
     Decoration narrationDecoration = null;
+    Priority narrationPriority = null;
 
     final CompoundBinaryTag chatCompound = element.getCompound("chat");
-    final CompoundBinaryTag chatDecorationCompound = chatCompound.getCompound("decoration");
-    if (chatDecorationCompound != CompoundBinaryTag.empty()) {
+    final CompoundBinaryTag chatDecorationCompound = (CompoundBinaryTag) chatCompound.get("decoration");
+    if (chatDecorationCompound != null) {
       chatDecoration = Decoration.decodeRegistryEntry(chatDecorationCompound);
     }
 
     final CompoundBinaryTag narrationCompound = element.getCompound("narration");
-    final CompoundBinaryTag narrationDecorationCompound = narrationCompound.getCompound("decoration");
-    if (narrationDecorationCompound != CompoundBinaryTag.empty()) {
-      narrationDecoration = Decoration.decodeRegistryEntry(narrationCompound);
+    final String priorityString = narrationCompound.getString("priority");
+    if (!priorityString.isEmpty()) {
+      narrationPriority = Priority.valueOf(priorityString.toUpperCase(Locale.ROOT));
     }
 
-    return new ChatData(-1, "invalid", chatDecoration, narrationDecoration);
+    final CompoundBinaryTag narrationDecorationCompound = (CompoundBinaryTag) narrationCompound.get("decoration");
+    if (narrationDecorationCompound != null) {
+      narrationDecoration = Decoration.decodeRegistryEntry(narrationDecorationCompound);
+    }
+
+    return new ChatData(-1, "invalid", chatDecoration, narrationPriority, narrationDecoration);
   }
 
   public String getIdentifier() {
@@ -116,18 +132,46 @@ public class ChatData {
 
   /**
    * Encodes the chat data for the network.
+   *
    * @param version The protocol version to encode this chat data for
    * @return The encoded data structure
    */
   public CompoundBinaryTag encodeAsCompoundTag(ProtocolVersion version) {
-    return null;
+    final CompoundBinaryTag.Builder compound = CompoundBinaryTag.builder();
+    compound.putString("name", identifier);
+    compound.putInt("id", id);
+
+    final CompoundBinaryTag.Builder elementCompound = CompoundBinaryTag.builder();
+
+    CompoundBinaryTag.@NotNull Builder chatCompound = CompoundBinaryTag.builder();
+    if (chatDecoration != null) {
+      chatCompound.put("decoration", chatDecoration.encodeRegistryEntry(version));
+      elementCompound.put("chat", chatCompound.build());
+    }
+
+    final CompoundBinaryTag.Builder narrationCompoundBuilder = CompoundBinaryTag.builder();
+    if (narrationPriority != null) {
+      narrationCompoundBuilder.putString("priority", narrationPriority.name().toLowerCase(Locale.ROOT));
+    }
+    if (narrationDecoration != null) {
+      narrationCompoundBuilder.put("decoration", narrationDecoration.encodeRegistryEntry(version));
+    }
+    final CompoundBinaryTag narrationCompound = narrationCompoundBuilder.build();
+    if (!narrationCompound.equals(CompoundBinaryTag.empty())) {
+      elementCompound.put("narration", narrationCompound);
+    }
+
+    compound.put("element", elementCompound.build());
+
+    return compound.build();
   }
 
 
-  public static class Decoration implements Translatable {
+  public static class Decoration {
 
     private final List<String> parameters;
     private final List<TextFormat> style;
+    @Nullable
     private final String translationKey;
 
     public List<String> getParameters() {
@@ -138,26 +182,26 @@ public class ChatData {
       return style;
     }
 
-    @Override
-    public @NotNull String translationKey() {
+    public @Nullable String translationKey() {
       return translationKey;
     }
 
     /**
      * Creates a Decoration with the associated data.
-     * @param parameters chat params
-     * @param style chat style
+     *
+     * @param parameters     chat params
+     * @param style          chat style
      * @param translationKey translation key
      */
-    public Decoration(List<String> parameters, List<TextFormat> style, String translationKey) {
+    public Decoration(List<String> parameters, List<TextFormat> style, @Nullable String translationKey) {
       this.parameters = Preconditions.checkNotNull(parameters);
       this.style = Preconditions.checkNotNull(style);
-      this.translationKey = Preconditions.checkNotNull(translationKey);
-      Preconditions.checkArgument(translationKey.length() > 0);
+      this.translationKey = translationKey;
     }
 
     /**
      * Decodes a decoration entry.
+     *
      * @param toDecode Compound Tag to decode
      * @return the parsed Decoration entry.
      */
@@ -165,7 +209,7 @@ public class ChatData {
       ImmutableList.Builder<String> parameters = ImmutableList.builder();
       ListBinaryTag paramList = toDecode.getList("parameters", EMPTY_LIST_TAG);
       if (paramList != EMPTY_LIST_TAG) {
-        paramList.forEach(binaryTag -> parameters.add(binaryTag.toString()));
+        paramList.forEach(binaryTag -> parameters.add(((StringBinaryTag) binaryTag).value()));
       }
 
       ImmutableList.Builder<TextFormat> style = ImmutableList.builder();
@@ -188,10 +232,39 @@ public class ChatData {
 
       String translationKey = toDecode.getString("translation_key");
 
-      return new Decoration(parameters.build(), style.build(), translationKey);
+      return new Decoration(parameters.build(), style.build(), translationKey.isEmpty() ? null : translationKey);
     }
 
-    public void encodeRegistryEntry(CompoundBinaryTag compoundBinaryTag) {}
+    public CompoundBinaryTag encodeRegistryEntry(ProtocolVersion version) {
+
+      CompoundBinaryTag.Builder compoundBinaryTag = CompoundBinaryTag.builder();
+
+      if (translationKey != null) {
+        compoundBinaryTag.put("translation_key", StringBinaryTag.of(translationKey));
+      }
+
+      final CompoundBinaryTag.Builder styleBuilder = CompoundBinaryTag.builder();
+      style.forEach(styleEntry -> {
+        if (styleEntry instanceof TextColor color) {
+          styleBuilder.putString("color", color.toString());
+        } else if (styleEntry instanceof TextDecoration decoration) {
+          styleBuilder.putByte(decoration.name().toLowerCase(Locale.ROOT), (byte) 1); // This won't be here if not applied
+        }
+      });
+      compoundBinaryTag.put("style", styleBuilder.build());
+
+      if (parameters.size() == 0) {
+        compoundBinaryTag.put("parameters", EMPTY_LIST_TAG);
+      } else {
+        final ListBinaryTag.Builder<StringBinaryTag> parametersBuilder = ListBinaryTag.builder(BinaryTagTypes.STRING);
+        parameters.forEach(param -> parametersBuilder.add(StringBinaryTag.of(param)));
+        compoundBinaryTag.put("parameters", parametersBuilder.build());
+      }
+
+
+
+      return compoundBinaryTag.build();
+    }
 
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatData.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatData.java
@@ -34,6 +34,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.velocitypowered.api.network.ProtocolVersion;
 import java.util.List;
+import net.kyori.adventure.nbt.BinaryTag;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.kyori.adventure.nbt.ListBinaryTag;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -49,8 +50,16 @@ public class ChatData {
   private final String identifier;
   private final int id;
   private final Decoration chatDecoration;
-  private Decoration narrationDecoration;
+  private final Decoration narrationDecoration;
 
+  /**
+   * Represents a ChatRegistry entry.
+   *
+   * @param id chat type id
+   * @param identifier chat type identifier
+   * @param chatDecoration chat decoration
+   * @param narrationDecoration narration decoration
+   */
   public ChatData(int id, String identifier, Decoration chatDecoration, Decoration narrationDecoration) {
     this.id = id;
     this.identifier = identifier;
@@ -105,7 +114,14 @@ public class ChatData {
     return id;
   }
 
-
+  /**
+   * Encodes the chat data for the network.
+   * @param version The protocol version to encode this chat data for
+   * @return The encoded data structure
+   */
+  public CompoundBinaryTag encodeAsCompoundTag(ProtocolVersion version) {
+    return null;
+  }
 
 
   public static class Decoration implements Translatable {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatRegistry.java
@@ -46,31 +46,10 @@ public final class ChatRegistry {
    */
   public static ImmutableList<ChatData> fromGameData(ListBinaryTag compound, ProtocolVersion version) {
     final ImmutableList.Builder<ChatData> builder = ImmutableList.builder();
-    try {
-      System.out.println(TagStringIO.builder().indent(2).build().asString(CompoundBinaryTag.empty().put("tag", compound)));
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
     for (BinaryTag binaryTag : compound) {
       if (binaryTag instanceof CompoundBinaryTag) {
         final ChatData chatData = ChatData.decodeRegistryEntry((CompoundBinaryTag) binaryTag, version);
         builder.add(chatData);
-        System.out.println(chatData.encodeAsCompoundTag(version).equals(binaryTag));
-        System.out.println("========");
-        System.out.println("========");
-        try {
-          System.out.println(TagStringIO.builder().indent(2).build().asString((CompoundBinaryTag) binaryTag));
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-        System.out.println("========");
-        try {
-          System.out.println(TagStringIO.builder().indent(2).build().asString(chatData.encodeAsCompoundTag(version)));
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-        System.out.println("========");
-        System.out.println("========");
       }
     }
     return builder.build();

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatRegistry.java
@@ -21,10 +21,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.velocitypowered.api.network.ProtocolVersion;
 
+import java.io.IOException;
 import java.util.Map;
 import net.kyori.adventure.nbt.BinaryTag;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.kyori.adventure.nbt.ListBinaryTag;
+import net.kyori.adventure.nbt.TagStringIO;
 
 
 public final class ChatRegistry {
@@ -44,9 +46,31 @@ public final class ChatRegistry {
    */
   public static ImmutableList<ChatData> fromGameData(ListBinaryTag compound, ProtocolVersion version) {
     final ImmutableList.Builder<ChatData> builder = ImmutableList.builder();
+    try {
+      System.out.println(TagStringIO.builder().indent(2).build().asString(CompoundBinaryTag.empty().put("tag", compound)));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
     for (BinaryTag binaryTag : compound) {
       if (binaryTag instanceof CompoundBinaryTag) {
-        builder.add(ChatData.decodeRegistryEntry((CompoundBinaryTag) binaryTag, version));
+        final ChatData chatData = ChatData.decodeRegistryEntry((CompoundBinaryTag) binaryTag, version);
+        builder.add(chatData);
+        System.out.println(chatData.encodeAsCompoundTag(version).equals(binaryTag));
+        System.out.println("========");
+        System.out.println("========");
+        try {
+          System.out.println(TagStringIO.builder().indent(2).build().asString((CompoundBinaryTag) binaryTag));
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+        System.out.println("========");
+        try {
+          System.out.println(TagStringIO.builder().indent(2).build().asString(chatData.encodeAsCompoundTag(version)));
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+        System.out.println("========");
+        System.out.println("========");
       }
     }
     return builder.build();

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatRegistry.java
@@ -52,7 +52,16 @@ public final class ChatRegistry {
     return builder.build();
   }
 
-  public BinaryTag build() {
-    return null;
+  /**
+   * Serialises the Chat Registry for sending over the network.
+   * @param version the version to encode for
+   * @return The serialised tag list
+   */
+  public ListBinaryTag encodeRegistry(ProtocolVersion version) {
+    final ListBinaryTag.Builder<BinaryTag> builder = ListBinaryTag.builder();
+    for (ChatData data : registeredChatTypes.values()) {
+      builder.add(data.encodeAsCompoundTag(version));
+    }
+    return builder.build();
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/ChatRegistry.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.connection.registry;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.velocitypowered.api.network.ProtocolVersion;
+
+import java.util.Map;
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.ListBinaryTag;
+
+
+public final class ChatRegistry {
+
+  private final Map<String, ChatData> registeredChatTypes;
+
+  public ChatRegistry(ImmutableList<ChatData> chatDataImmutableList) {
+    registeredChatTypes = Maps.uniqueIndex(chatDataImmutableList, ChatData::getIdentifier);
+  }
+
+  /**
+   * Decodes a CompoundTag storing a Chat Type Registry.
+   *
+   * @param compound The Compound to decode
+   * @param version  Protocol version
+   * @return an ImmutableList of read ChatData
+   */
+  public static ImmutableList<ChatData> fromGameData(ListBinaryTag compound, ProtocolVersion version) {
+    final ImmutableList.Builder<ChatData> builder = ImmutableList.builder();
+    for (BinaryTag binaryTag : compound) {
+      if (binaryTag instanceof CompoundBinaryTag) {
+        builder.add(ChatData.decodeRegistryEntry((CompoundBinaryTag) binaryTag, version));
+      }
+    }
+    return builder.build();
+  }
+
+  public BinaryTag build() {
+    return null;
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/chat/ChatDecoration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/chat/ChatDecoration.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.connection.registry.chat;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.velocitypowered.api.network.ProtocolVersion;
+import java.util.List;
+import java.util.Locale;
+import net.kyori.adventure.nbt.BinaryTagTypes;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.ListBinaryTag;
+import net.kyori.adventure.nbt.StringBinaryTag;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextFormat;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class ChatDecoration {
+
+  private final List<String> parameters;
+  private final List<TextFormat> style;
+  @Nullable
+  private final String translationKey;
+
+  public List<String> getParameters() {
+    return parameters;
+  }
+
+  public List<TextFormat> getStyle() {
+    return style;
+  }
+
+  public @Nullable String translationKey() {
+    return translationKey;
+  }
+
+  /**
+   * Creates a Decoration with the associated data.
+   *
+   * @param parameters     chat params
+   * @param style          chat style
+   * @param translationKey translation key
+   */
+  public ChatDecoration(List<String> parameters, List<TextFormat> style, @Nullable String translationKey) {
+    this.parameters = Preconditions.checkNotNull(parameters);
+    this.style = Preconditions.checkNotNull(style);
+    this.translationKey = translationKey;
+  }
+
+  /**
+   * Decodes a decoration entry.
+   *
+   * @param toDecode Compound Tag to decode
+   * @param version
+   * @return the parsed Decoration entry.
+   */
+  public static ChatDecoration decodeRegistryEntry(CompoundBinaryTag toDecode, ProtocolVersion version) {
+    ImmutableList.Builder<String> parameters = ImmutableList.builder();
+    ListBinaryTag paramList = toDecode.getList("parameters", ListBinaryTag.empty());
+    if (paramList != ListBinaryTag.empty()) {
+      paramList.forEach(binaryTag -> parameters.add(((StringBinaryTag) binaryTag).value()));
+    }
+
+    ImmutableList.Builder<TextFormat> style = ImmutableList.builder();
+    CompoundBinaryTag styleList = toDecode.getCompound("style");
+    for (String key : styleList.keySet()) {
+      if ("color".equals(key)) {
+        final NamedTextColor value = NamedTextColor.NAMES.value(styleList.getString(key));
+        if (value != null) {
+          style.add(value);
+        } else {
+          throw new IllegalArgumentException("Unable to map color value: " + styleList.getString(key));
+        }
+      } else {
+        // Key is a Style option instead
+        TextDecoration deco = TextDecoration.NAMES.value(key);
+        if (deco == null) {
+          throw new IllegalArgumentException("Unable to map text style of: " + key);
+        }
+        // This wouldn't be here if it wasn't applied, but here it goes anyway:
+        byte val = styleList.getByte(key);
+        if (val != 0) {
+          style.add(deco);
+        }
+      }
+    }
+
+    String translationKey = toDecode.getString("translation_key");
+
+    return new ChatDecoration(parameters.build(), style.build(), translationKey.isEmpty() ? null : translationKey);
+  }
+
+  public CompoundBinaryTag encodeRegistryEntry(ProtocolVersion version) {
+
+    CompoundBinaryTag.Builder compoundBinaryTag = CompoundBinaryTag.builder();
+
+    if (translationKey != null) {
+      compoundBinaryTag.put("translation_key", StringBinaryTag.of(translationKey));
+    }
+
+    final CompoundBinaryTag.Builder styleBuilder = CompoundBinaryTag.builder();
+    style.forEach(styleEntry -> {
+      if (styleEntry instanceof TextColor color) {
+        styleBuilder.putString("color", color.toString());
+      } else if (styleEntry instanceof TextDecoration decoration) {
+        styleBuilder.putByte(decoration.name().toLowerCase(Locale.ROOT), (byte) 1); // This won't be here if not applied
+      }
+    });
+    compoundBinaryTag.put("style", styleBuilder.build());
+
+    if (parameters.size() == 0) {
+      compoundBinaryTag.put("parameters", ListBinaryTag.empty());
+    } else {
+      final ListBinaryTag.Builder<StringBinaryTag> parametersBuilder = ListBinaryTag.builder(BinaryTagTypes.STRING);
+      parameters.forEach(param -> parametersBuilder.add(StringBinaryTag.of(param)));
+      compoundBinaryTag.put("parameters", parametersBuilder.build());
+    }
+
+
+    return compoundBinaryTag.build();
+  }
+
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/chat/ChatTypeElement.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/registry/chat/ChatTypeElement.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.connection.registry.chat;
+
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.connection.registry.ChatData;
+import java.util.Locale;
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.StringBinaryTag;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class ChatTypeElement {
+
+
+  @Nullable
+  private final ElementType type;
+  @Nullable
+  private final ChatDecoration decoration;
+  private final ChatData.@Nullable Priority priority;
+
+  public ChatTypeElement(ElementType type, ChatDecoration decoration, ChatData.Priority priority) {
+    this.type = type;
+    this.decoration = decoration;
+    this.priority = priority;
+  }
+
+  public static ChatTypeElement decodeFromRegistry(ElementType type, CompoundBinaryTag elementCompound, ProtocolVersion version) {
+    ChatDecoration decoration = null;
+    ChatData.Priority priority = null;
+    final CompoundBinaryTag decorationCompound = (CompoundBinaryTag) elementCompound.get("decoration");
+    if (decorationCompound != null) {
+      decoration = ChatDecoration.decodeRegistryEntry(decorationCompound, version);
+    }
+
+    if (elementCompound.get("priority") != null) {
+      priority = ChatData.Priority.valueOf(elementCompound.getString("priority").toUpperCase(Locale.ROOT));
+    }
+    return new ChatTypeElement(type, decoration, priority);
+  }
+
+  public CompoundBinaryTag encodeForRegistry(ProtocolVersion version) {
+    final CompoundBinaryTag.Builder compoundBuilder = CompoundBinaryTag.builder();
+    if (priority != null) {
+      compoundBuilder.put("priority", StringBinaryTag.of(priority.name().toLowerCase(Locale.ROOT)));
+    }
+
+    if (decoration != null) {
+      compoundBuilder.put("decoration", decoration.encodeRegistryEntry(version));
+    }
+
+    return compoundBuilder.build();
+  }
+
+  public enum ElementType {
+    CHAT,
+    OVERLAY,
+    NARRATION
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGame.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGame.java
@@ -397,7 +397,7 @@ public class JoinGame implements MinecraftPacket {
         CompoundBinaryTag.Builder chatRegistryEntry = CompoundBinaryTag.builder();
         chatRegistryEntry.putString("type", "minecraft:chat_type");
         chatRegistryEntry.put("value", encodedChatRegistry);
-        registryContainer.put("minecraft:chat_type", encodedChatRegistry);
+        registryContainer.put("minecraft:chat_type", chatRegistryEntry.build());
       }
     } else {
       registryContainer.put("dimension", encodedDimensionRegistry);

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGame.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGame.java
@@ -393,7 +393,11 @@ public class JoinGame implements MinecraftPacket {
       registryContainer.put("minecraft:dimension_type", dimensionRegistryEntry.build());
       registryContainer.put("minecraft:worldgen/biome", biomeRegistry);
       if (version.compareTo(ProtocolVersion.MINECRAFT_1_19) >= 0) {
-        registryContainer.put("minecraft:chat_type", chatTypeRegistry.build());
+        final ListBinaryTag encodedChatRegistry = chatTypeRegistry.encodeRegistry(version);
+        CompoundBinaryTag.Builder chatRegistryEntry = CompoundBinaryTag.builder();
+        chatRegistryEntry.putString("type", "minecraft:chat_type");
+        chatRegistryEntry.put("value", encodedChatRegistry);
+        registryContainer.put("minecraft:chat_type", encodedChatRegistry);
       }
     } else {
       registryContainer.put("dimension", encodedDimensionRegistry);

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatBuilder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatBuilder.java
@@ -21,15 +21,22 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.crypto.SignedChatCommand;
 import com.velocitypowered.proxy.crypto.SignedChatMessage;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
+
 import java.time.Instant;
+import java.util.Objects;
 import java.util.UUID;
+
 import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
+
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ChatBuilder {
@@ -125,10 +132,10 @@ public class ChatBuilder {
    *
    * @return The {@link MinecraftPacket} to send to the client.
    */
-  public MinecraftPacket toClient() {
+  public MinecraftPacket toClient(ConnectedPlayer player) {
     // This is temporary
     UUID identity = sender == null ? (senderIdentity == null ? Identity.nil().uuid()
-        : senderIdentity.uuid()) : sender.getUniqueId();
+                                        : senderIdentity.uuid()) : sender.getUniqueId();
     Component msg = component == null ? Component.text(message) : component;
 
     if (version.compareTo(ProtocolVersion.MINECRAFT_1_19) >= 0) {
@@ -164,19 +171,45 @@ public class ChatBuilder {
     return chat;
   }
 
-  public static enum ChatType {
-    CHAT((byte) 0),
-    SYSTEM((byte) 1),
-    GAME_INFO((byte) 2);
+  public static class ChatType {
+    public static final ChatType CHAT = new ChatType((byte) 0, Key.key("minecraft", "chat"));
+    public static final ChatType SYSTEM = new ChatType((byte) 1, Key.key("minecraft", "system"));
+    public static final ChatType GAME_INFO = new ChatType((byte) 2, Key.key("minecraft", "game_info"));
 
     private final byte raw;
+    @NonNull
+    private final Key key;
 
-    ChatType(byte raw) {
+    ChatType(byte raw, @NonNull Key key) {
+      Preconditions.checkNotNull(key, "Key cannot be null!");
       this.raw = raw;
+      this.key = key;
     }
 
     public byte getId() {
       return raw;
+    }
+
+    @NonNull
+    public Key getKey() {
+      return key;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ChatType chatType = (ChatType) o;
+      return raw == chatType.raw && key.equals(chatType.key);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(raw, key);
     }
   }
 }


### PR DESCRIPTION
This is a WIP and some aspects I'm not really fond of,

ChatType was migrated away from an enum in the internal ChatBuilder, I'm not sure if this actually makes sense in retrospect, or if this class should even stay for that point, (and somewhat in retrospect against the changes I did in there)

The Registry needs to be per-player, stored on the Connection, but, this does create some caveats, should the proxy be able to define custom chat formats?