### PR TITLE
Fixed possible IOException if forwarding-secret-file path is a directory

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -424,7 +424,7 @@ public class VelocityConfiguration implements ProxyConfig {
 
     // Create the forwarding-secret file on first-time startup if it doesn't exist
     Path defaultForwardingSecretPath = Path.of("forwarding.secret");
-    if (!Files.exists(path) && !Files.exists(defaultForwardingSecretPath)) {
+    if (Files.notExists(path) && Files.notExists(defaultForwardingSecretPath)) {
       Files.writeString(defaultForwardingSecretPath, generateRandomString(12));
     }
 
@@ -448,8 +448,16 @@ public class VelocityConfiguration implements ProxyConfig {
     CommentedFileConfig defaultConfig = CommentedFileConfig.of(tmpFile, TomlFormat.instance());
     defaultConfig.load();
 
+    // TODO: migrate this on Velocity Polymer
+    double configVersion;
+    try {
+      configVersion = Double.parseDouble(config.getOrElse("config-version", "1.0"));
+    } catch (NumberFormatException e) {
+      configVersion = 1.0;
+    }
+
     // Whether or not this config version is older than 2.0 which uses the deprecated "forwarding-secret" parameter
-    boolean legacyConfig = Double.parseDouble(config.getOrElse("config-version", "1.0")) < 2.0;
+    boolean legacyConfig = configVersion < 2.0;
 
     String forwardingSecretString;
     byte[] forwardingSecret;

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -424,7 +424,7 @@ public class VelocityConfiguration implements ProxyConfig {
 
     // Create the forwarding-secret file on first-time startup if it doesn't exist
     Path defaultForwardingSecretPath = Path.of("forwarding.secret");
-    if (!path.toFile().exists() && !defaultForwardingSecretPath.toFile().exists()) {
+    if (!Files.exists(path) && !Files.exists(defaultForwardingSecretPath)) {
       Files.writeString(defaultForwardingSecretPath, generateRandomString(12));
     }
 
@@ -478,8 +478,10 @@ public class VelocityConfiguration implements ProxyConfig {
       // New handling
       forwardingSecretString = System.getenv().getOrDefault("VELOCITY_FORWARDING_SECRET", "");
       if (forwardingSecretString.isEmpty()) {
-        String forwardSecretFile = config.getOrElse("forwarding-secret-file", "forwarding.secret");
-        Path secretPath = Path.of(forwardSecretFile);
+        String forwardSecretFile = config.get("forwarding-secret-file");
+        Path secretPath = forwardSecretFile == null
+            ? defaultForwardingSecretPath
+            : Path.of(forwardSecretFile);
         if (Files.exists(secretPath)) {
           if (Files.isRegularFile(secretPath)) {
             forwardingSecretString = String.join("", Files.readAllLines(secretPath));


### PR DESCRIPTION
Actually an IOException will occur in some cases where the config-version option does not exist, is not exactly "1.0", among other reasons.
This change will give an informational error in case the forwarding-secret-file is not a valid file, does not exist or is a directory, or in case the config-version does not exist or is not exactly "1.0" as for example if an alternative version has been tested that changes that previous value (i.e #666 )

resolves #740 