### PR TITLE
Improve annotation processor

### DIFF
--- a/api/src/ap/java/com/velocitypowered/api/plugin/ap/PluginAnnotationProcessor.java
+++ b/api/src/ap/java/com/velocitypowered/api/plugin/ap/PluginAnnotationProcessor.java
@@ -12,6 +12,7 @@ import com.velocitypowered.api.plugin.Plugin;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
@@ -74,7 +75,9 @@ public class PluginAnnotationProcessor extends AbstractProcessor {
 
       Plugin plugin = element.getAnnotation(Plugin.class);
       if (!SerializedPluginDescription.ID_PATTERN.matcher(plugin.id()).matches()) {
-        environment.getMessager().printMessage(Diagnostic.Kind.ERROR, "Invalid ID for plugin "
+        environment.getMessager().printMessage(Diagnostic.Kind.ERROR, "Invalid ID: \""
+            + plugin.id()
+            +"\" for plugin "
             + qualifiedName
             + ". IDs must start alphabetically, have alphanumeric characters, and can "
             + "contain dashes or underscores.");

--- a/api/src/ap/java/com/velocitypowered/api/plugin/ap/SerializedPluginDescription.java
+++ b/api/src/ap/java/com/velocitypowered/api/plugin/ap/SerializedPluginDescription.java
@@ -11,17 +11,15 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.velocitypowered.api.plugin.Plugin;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class SerializedPluginDescription {
 
-  public static final Pattern ID_PATTERN = Pattern.compile("[a-z][a-z0-9-_]{0,63}");
+  public static final Pattern ID_PATTERN = Pattern.compile("[a-z-A-Z][a-z-A-Z-0-9-_]{0,63}");
 
   // @Nullable is used here to make GSON skip these in the serialized file
   private final String id;
@@ -38,7 +36,7 @@ public final class SerializedPluginDescription {
       List<String> authors, List<Dependency> dependencies, String main) {
     Preconditions.checkNotNull(id, "id");
     Preconditions.checkArgument(ID_PATTERN.matcher(id).matches(), "id is not valid");
-    this.id = id;
+    this.id = id.toLowerCase(Locale.ROOT);
     this.name = Strings.emptyToNull(name);
     this.version = Strings.emptyToNull(version);
     this.description = Strings.emptyToNull(description);


### PR DESCRIPTION
Currently, the annotation processor rejects all plugin id's that contain uppercase letters. This PR proposes the idea of handling them quietly and improving the error message sent to the developer when they make the mistake of adding any non-alphanumeric characters. 