### PR TITLE
Tablist-changes for 1.19

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/player/TabListEntry.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/TabListEntry.java
@@ -158,6 +158,8 @@ public interface TabListEntry extends KeyIdentifiable {
 
     /**
      * Sets the {@link IdentifiedKey} of the {@link TabListEntry}.
+     * <p>This is only intended and only works for players currently <b>not</b> connected to this proxy.</p>
+     * <p>For any player currently connected to this proxy this will be filled automatically.</p>
      *
      * @param playerKey key to set
      * @return {@code this}, for chaining

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -176,9 +176,9 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     this.onlineMode = onlineMode;
 
     if (connection.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_8) >= 0) {
-      this.tabList = new VelocityTabList(this);
+      this.tabList = new VelocityTabList(this, server);
     } else {
-      this.tabList = new VelocityTabListLegacy(this);
+      this.tabList = new VelocityTabListLegacy(this, server);
     }
     this.playerKey = playerKey;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/crypto/IdentifiedKeyImpl.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/crypto/IdentifiedKeyImpl.java
@@ -17,6 +17,7 @@
 
 package com.velocitypowered.proxy.crypto;
 
+import com.google.common.base.Objects;
 import com.velocitypowered.api.proxy.crypto.IdentifiedKey;
 import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
@@ -94,5 +95,26 @@ public class IdentifiedKeyImpl implements IdentifiedKey {
         + ", expiryTemporal=" + expiryTemporal
         + ", isSignatureValid=" + isSignatureValid
         + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof IdentifiedKey)) {
+      return false;
+    }
+    IdentifiedKey that = (IdentifiedKey) o; // This cannot be simplified because checkstyle doesn't like it.
+
+    return Objects.equal(this.getSignedPublicKey(), that.getSignedPublicKey())
+            && Objects.equal(this.getExpiryTemporal(), that.getExpiryTemporal())
+            && Objects.equal(this.getSignature(), that.getSignature())
+            && Objects.equal(this.getSigner(), that.getSigner());
+  }
+
+  @Override
+  public int hashCode() {
+    return 0;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/crypto/IdentifiedKeyImpl.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/crypto/IdentifiedKeyImpl.java
@@ -109,7 +109,7 @@ public class IdentifiedKeyImpl implements IdentifiedKey {
 
     return Objects.equal(this.getSignedPublicKey(), that.getSignedPublicKey())
             && Objects.equal(this.getExpiryTemporal(), that.getExpiryTemporal())
-            && Objects.equal(this.getSignature(), that.getSignature())
+            && Arrays.equals(this.getSignature(), that.getSignature())
             && Objects.equal(this.getSigner(), that.getSigner());
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/crypto/IdentifiedKeyImpl.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/crypto/IdentifiedKeyImpl.java
@@ -112,9 +112,4 @@ public class IdentifiedKeyImpl implements IdentifiedKey {
             && Objects.equal(this.getSignature(), that.getSignature())
             && Objects.equal(this.getSigner(), that.getSigner());
   }
-
-  @Override
-  public int hashCode() {
-    return 0;
-  }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -18,6 +18,8 @@
 package com.velocitypowered.proxy.tablist;
 
 import com.google.common.base.Preconditions;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.crypto.IdentifiedKey;
 import com.velocitypowered.api.proxy.player.TabList;
 import com.velocitypowered.api.proxy.player.TabListEntry;
@@ -31,6 +33,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,10 +44,15 @@ public class VelocityTabList implements TabList {
 
   protected final ConnectedPlayer player;
   protected final MinecraftConnection connection;
+  protected final ProxyServer proxyServer;
   protected final Map<UUID, VelocityTabListEntry> entries = new ConcurrentHashMap<>();
 
-  public VelocityTabList(final ConnectedPlayer player) {
+  /**
+  * Creates a new VelocityTabList.
+  */
+  public VelocityTabList(final ConnectedPlayer player, final ProxyServer proxyServer) {
     this.player = player;
+    this.proxyServer = proxyServer;
     this.connection = player.getConnection();
   }
 
@@ -156,11 +164,31 @@ public class VelocityTabList implements TabList {
           if (name == null || properties == null) {
             throw new IllegalStateException("Got null game profile for ADD_PLAYER");
           }
+          // Verify key
+          IdentifiedKey providedKey = item.getPlayerKey();
+          Optional<Player> connected = proxyServer.getPlayer(uuid);
+          if (connected.isPresent()) {
+            IdentifiedKey expectedKey = connected.get().getIdentifiedKey();
+            if (providedKey != null) {
+              if (!Objects.equals(expectedKey, providedKey)) {
+                throw new IllegalStateException("Server provided incorrect player key in playerlist for "
+                        + name + " UUID: " + uuid);
+              }
+            } else {
+              // Substitute the key
+              // It shouldn't be propagated to remove the signature.
+              if (expectedKey != null) {
+                providedKey = expectedKey;
+              }
+            }
+          }
+
           entries.putIfAbsent(item.getUuid(), (VelocityTabListEntry) TabListEntry.builder()
               .tabList(this)
               .profile(new GameProfile(uuid, name, properties))
               .displayName(item.getDisplayName())
               .latency(item.getLatency())
+              .playerKey(providedKey)
               .gameMode(item.getGameMode())
               .build());
           break;
@@ -199,6 +227,10 @@ public class VelocityTabList implements TabList {
   void updateEntry(int action, TabListEntry entry) {
     if (entries.containsKey(entry.getProfile().getId())) {
       PlayerListItem.Item packetItem = PlayerListItem.Item.from(entry);
+
+      Optional<Player> existing = proxyServer.getPlayer(entry.getProfile().getId());
+      existing.ifPresent(value -> packetItem.setPlayerKey(value.getIdentifiedKey()));
+
       connection.write(new PlayerListItem(action, Collections.singletonList(packetItem)));
     }
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -177,9 +177,7 @@ public class VelocityTabList implements TabList {
             } else {
               // Substitute the key
               // It shouldn't be propagated to remove the signature.
-              if (expectedKey != null) {
-                providedKey = expectedKey;
-              }
+              providedKey = expectedKey;
             }
           }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListLegacy.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListLegacy.java
@@ -18,6 +18,7 @@
 package com.velocitypowered.proxy.tablist;
 
 import com.google.common.collect.ImmutableList;
+import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.player.TabListEntry;
 import com.velocitypowered.api.util.GameProfile;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
@@ -35,8 +36,8 @@ public class VelocityTabListLegacy extends VelocityTabList {
 
   private final Map<String, UUID> nameMapping = new ConcurrentHashMap<>();
 
-  public VelocityTabListLegacy(final ConnectedPlayer player) {
-    super(player);
+  public VelocityTabListLegacy(final ConnectedPlayer player, final ProxyServer proxyServer) {
+    super(player, proxyServer);
   }
 
   @Deprecated


### PR DESCRIPTION
This change helps ensure player signatures are propagated correctly.
Signatures should never be removed, so to compensate for legacy plugins and for the
proxy api function we have to enforce this.
Fixes https://github.com/PaperMC/Velocity/issues/759