### PR TITLE
Update command server and remove aliases for avoid conflicts

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -209,9 +209,8 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
 
     // Initialize commands first
     commandManager.register("velocity", new VelocityCommand(this));
-    commandManager.register("server", new ServerCommand(this));
-    commandManager.register("shutdown", ShutdownCommand.command(this),
-        "end", "stop");
+    commandManager.register("goto", new ServerCommand(this));
+    commandManager.register("shutdown", ShutdownCommand.command(this));
     new GlistCommand(this).register();
 
     this.doStartupConfigLoad();


### PR DESCRIPTION
Update command server with a command that no proxy has so far, and to avoid conflicts with spigot / paper remove the shutdown aliases.

