### PR TITLE
Improved configuration version handling

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -467,18 +467,21 @@ public class VelocityConfiguration implements ProxyConfig {
       }
       Files.writeString(defaultForwardingSecretPath, forwardingSecretString);
       // Configuration was migrated to 2.0
-      config.set("config-version", 2.0);
+      config.set("config-version", "2.0");
       // Remove old forwarding secret option
       config.removeComment("forwarding-secret");
       config.remove("forwarding-secret");
       // Implement actual forwarding-secret-file option
-      config.set("forwarding-secret-file", "forwarding-secret");
+      config.set("forwarding-secret-file", "forwarding.secret");
       config.setComment("forwarding-secret-file",
           "If you are using modern or BungeeGuard IP forwarding, configure a file that contains a unique secret here.\n"
           + "The file is expected to be UTF-8 encoded and not empty.");
       // Save configuration
       config.save();
-      logger.info("Migrated forwarding-secret to his own file");
+      logger.info("Migrated the forwarding-secret configuration option to its own file for security reasons."
+          + " You can configure the custom file where you will put your forwarding-secret "
+          + "in the new configuration option \"forwarding-secret-file\"");
+      configVersion = 2.0;
     }
 
     forwardingSecretString = forwardingSecretString == null


### PR DESCRIPTION
Currently the user is "forced" to handle the configuration update on their own, deleting the configuration they have in place to add the new options, whereas the job should be handled by Velocity, especially with a patch version being developed `3.1.2`.

This pull request replaces the old logic for handling version 1.0 and 2.0 configuration to a single migration. This would also allow more migrations to be done in case more configuration options or changes are added in the future, e.g. #666. Possibly resolves #733 , but only for the new options that may be added from now on