### PR TITLE
don't error out when forwarding-file doesn't exist and is not needed

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -422,12 +422,6 @@ public class VelocityConfiguration implements ProxyConfig {
       throw new RuntimeException("Default configuration file does not exist.");
     }
 
-    // Create the forwarding-secret file on first-time startup if it doesn't exist
-    Path defaultForwardingSecretPath = Path.of("forwarding.secret");
-    if (Files.notExists(path) && Files.notExists(defaultForwardingSecretPath)) {
-      Files.writeString(defaultForwardingSecretPath, generateRandomString(12));
-    }
-
     boolean mustResave = false;
     CommentedFileConfig config = CommentedFileConfig.builder(path)
         .defaultData(defaultConfigLocation)
@@ -488,7 +482,7 @@ public class VelocityConfiguration implements ProxyConfig {
       if (forwardingSecretString.isEmpty()) {
         String forwardSecretFile = config.get("forwarding-secret-file");
         Path secretPath = forwardSecretFile == null
-            ? defaultForwardingSecretPath
+            ? Path.of("forwarding.secret")
             : Path.of(forwardSecretFile);
         if (Files.exists(secretPath)) {
           if (Files.isRegularFile(secretPath)) {
@@ -496,6 +490,9 @@ public class VelocityConfiguration implements ProxyConfig {
           } else {
             throw new RuntimeException("The file " + forwardSecretFile + " is not a valid file or it is a directory.");
           }
+        } else {
+          forwardingSecretString = generateRandomString(12);
+          Files.writeString(secretPath, forwardingSecretString);
         }
       }
     }
@@ -527,14 +524,6 @@ public class VelocityConfiguration implements ProxyConfig {
         true);
     Boolean kickExisting = config.getOrElse("kick-existing-players", false);
     Boolean enablePlayerAddressLogging = config.getOrElse("enable-player-address-logging", true);
-
-    // Throw an exception if the forwarding-secret file is empty and the proxy is using a 
-    // forwarding mode that requires it.
-    if (forwardingSecret.length == 0
-        && (forwardingMode == PlayerInfoForwarding.MODERN
-        || forwardingMode == PlayerInfoForwarding.BUNGEEGUARD)) {
-      throw new RuntimeException("The forwarding-secret file must exist and must not be empty.");
-    }
 
     return new VelocityConfiguration(
         bind,

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -496,8 +496,6 @@ public class VelocityConfiguration implements ProxyConfig {
           } else {
             throw new RuntimeException("The file " + forwardSecretFile + " is not a valid file or it is a directory.");
           }
-        } else {
-          throw new RuntimeException("The forwarding-secret-file does not exists.");
         }
       }
     }
@@ -535,7 +533,7 @@ public class VelocityConfiguration implements ProxyConfig {
     if (forwardingSecret.length == 0
         && (forwardingMode == PlayerInfoForwarding.MODERN
         || forwardingMode == PlayerInfoForwarding.BUNGEEGUARD)) {
-      throw new RuntimeException("The forwarding-secret file must not be empty.");
+      throw new RuntimeException("The forwarding-secret file must exist and must not be empty.");
     }
 
     return new VelocityConfiguration(


### PR DESCRIPTION
#743 optimized the way the forwarding secret file is read. While the change is fine, it also introduced a small annoyance I stumbled upon. When the configured and default forwarding file are missing (for whatever reason) the proxy won't start and throw an exception even when using legacy or no forwarding where no forwarding secret is needed.

There is a check a bit further down which validates that the forwarding secret is present when using bungeeguard or modern forwarding, I just extended the error message by appending a hint about the missing file there.