### PR TITLE
Decode ServerData packet

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
@@ -312,7 +312,7 @@ public enum StateRegistry {
       clientbound.register(SystemChat.class, SystemChat::new,
           map(0x5F, MINECRAFT_1_19, true));
       clientbound.register(ServerData.class, ServerData::new,
-          map(0x3F, MINECRAFT_1_19, true));
+          map(0x3F, MINECRAFT_1_19, false));
     }
   },
   LOGIN {


### PR DESCRIPTION
#771 implemented handling for the ServerData packet, but decoding was disabled, so the handler was never called and #769 still happened.