### PR TITLE
Test config and secret file creation

### DIFF
--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -88,6 +88,7 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+    testImplementation "org.junit-pioneer:junit-pioneer:1.7.1"
     testImplementation "org.mockito:mockito-core:3.+"
 }
 

--- a/proxy/src/test/java/com/velocitypowered/proxy/config/VelocityConfigTests.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/config/VelocityConfigTests.java
@@ -1,25 +1,30 @@
 package com.velocitypowered.proxy.config;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VelocityConfigTests {
 
-  // Test file creation
   private static final Path CONFIG_PATH = Path.of("velocity.toml");
   private static final Path SECRET_PATH = Path.of("forwarding.secret");
 
   @AfterEach
   void tearDown() throws IOException {
-    Files.delete(CONFIG_PATH);
-    Files.delete(SECRET_PATH);
+    Files.deleteIfExists(CONFIG_PATH);
+    Files.deleteIfExists(SECRET_PATH);
   }
+
+  // Test file creation on first startup
 
   @Test
   void createsFilesOnFirstStartup() throws IOException {
@@ -27,30 +32,46 @@ public class VelocityConfigTests {
 
     assertTrue(Files.exists(CONFIG_PATH));
     assertTrue(Files.exists(SECRET_PATH));
+    assertTrue(config.getForwardingSecret().length > 0);
     assertArrayEquals(Files.readAllBytes(SECRET_PATH), config.getForwardingSecret());
   }
+
+  @Test
+  void respectsSecretFileOnFirstStartup() throws IOException {
+    Files.writeString(SECRET_PATH, "foo");
+    final var config = VelocityConfiguration.read(CONFIG_PATH);
+
+    assertArrayEquals("foo".getBytes(StandardCharsets.UTF_8), config.getForwardingSecret());
+  }
+
+  @Test
+  @SetEnvironmentVariable(key = "VELOCITY_FORWARDING_SECRET", value = "baz")
+  void doesNotCreateSecretFileWhenEnvVarIsSet() throws IOException {
+    final var config = VelocityConfiguration.read(CONFIG_PATH);
+
+    assertFalse(Files.exists(SECRET_PATH));
+    assertArrayEquals("baz".getBytes(StandardCharsets.UTF_8), config.getForwardingSecret());
+  }
+
+  // Test file creation on subsequent startups
 
   @Test
   void createsSecretFileWhenMissing() throws IOException {
     VelocityConfiguration.read(CONFIG_PATH);
     Files.delete(SECRET_PATH);
-
     final var config = VelocityConfiguration.read(CONFIG_PATH);
-    assertTrue(Files.exists(SECRET_PATH));
-    assertArrayEquals(Files.readAllBytes(SECRET_PATH), config.getForwardingSecret());
-  }
 
-  @Test
-  void doesNotCreateSecretFileWhenEnvVarIsSet() {
-    // todo: include junit-pioneer or system-stubs
+    assertTrue(Files.exists(SECRET_PATH));
+    assertTrue(config.getForwardingSecret().length > 0);
+    assertArrayEquals(Files.readAllBytes(SECRET_PATH), config.getForwardingSecret());
   }
 
   @Test
   void recreatesSecretFileWhenEmpty() throws IOException {
     VelocityConfiguration.read(CONFIG_PATH);
-    Files.writeString(SECRET_PATH, "");
-
+    Files.writeString(SECRET_PATH, ""); // truncates existing
     final var config = VelocityConfiguration.read(CONFIG_PATH);
+
     assertTrue(config.getForwardingSecret().length > 0);
     assertArrayEquals(Files.readAllBytes(SECRET_PATH), config.getForwardingSecret());
   }

--- a/proxy/src/test/java/com/velocitypowered/proxy/config/VelocityConfigTests.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/config/VelocityConfigTests.java
@@ -1,0 +1,64 @@
+package com.velocitypowered.proxy.config;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VelocityConfigTests {
+
+  // Test file creation
+  private static final Path CONFIG_PATH = Path.of("velocity.toml");
+  private static final Path SECRET_PATH = Path.of("forwarding.secret");
+
+  @AfterEach
+  void tearDown() throws IOException {
+    Files.delete(CONFIG_PATH);
+    Files.delete(SECRET_PATH);
+  }
+
+  @Test
+  void createsFilesOnFirstStartup() throws IOException {
+    final var config = VelocityConfiguration.read(CONFIG_PATH);
+
+    assertTrue(Files.exists(CONFIG_PATH));
+    assertTrue(Files.exists(SECRET_PATH));
+    assertArrayEquals(Files.readAllBytes(SECRET_PATH), config.getForwardingSecret());
+  }
+
+  @Test
+  void createsSecretFileWhenMissing() throws IOException {
+    VelocityConfiguration.read(CONFIG_PATH);
+    Files.delete(SECRET_PATH);
+
+    final var config = VelocityConfiguration.read(CONFIG_PATH);
+    assertTrue(Files.exists(SECRET_PATH));
+    assertArrayEquals(Files.readAllBytes(SECRET_PATH), config.getForwardingSecret());
+  }
+
+  @Test
+  void doesNotCreateSecretFileWhenEnvVarIsSet() {
+    // todo: include junit-pioneer or system-stubs
+  }
+
+  @Test
+  void recreatesSecretFileWhenEmpty() throws IOException {
+    VelocityConfiguration.read(CONFIG_PATH);
+    Files.writeString(SECRET_PATH, "");
+
+    final var config = VelocityConfiguration.read(CONFIG_PATH);
+    assertTrue(config.getForwardingSecret().length > 0);
+    assertArrayEquals(Files.readAllBytes(SECRET_PATH), config.getForwardingSecret());
+  }
+
+  @Test
+  void throwsWhenSecretFileIsInvalid() throws IOException {
+    Files.createDirectory(SECRET_PATH);
+
+    assertThrows(RuntimeException.class, () -> VelocityConfiguration.read(CONFIG_PATH));
+  }
+}

--- a/proxy/src/test/java/com/velocitypowered/proxy/config/VelocityConfigTests.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/config/VelocityConfigTests.java
@@ -1,4 +1,26 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.velocitypowered.proxy.config;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -7,11 +29,6 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VelocityConfigTests {
 


### PR DESCRIPTION
Per the discussion on #798, I believe these test for the expected behavior by users.

Right now the following are failing
- `doesNotCreateSecretFileWhenEnvVarIsSet`: Velocity creates the secret file even if unused.
- `recreatesSecretFileWhenEmpty`: the secret used is the empty array, instead of creating a new secret.
- `createsSecretFileWhenMissing`: Velocity throws the exception "The forwarding-secret-file does not exist".

I found two libraries for overriding environment variables with junit, system-stubs and junit-pioneer. They are both maintained, but even if the latter includes other unrelated utilities, the former requires mockito-inline (not core) and I couldn't get it to work reliably. Once #798 is merged, I will re-test and make another PR with fixes if some of the above still fail.