### PR TITLE
Set proxy to build with Java 11 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,9 @@ allprojects {
     }
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(11)
+        }
     }
 
     repositories {

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -13,6 +13,11 @@ license {
     header = project.rootProject.file('HEADER.txt')
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 jar {
     manifest {
         def buildNumber = System.getenv("BUILD_NUMBER") ?: "unknown"

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -14,8 +14,9 @@ license {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
 }
 
 jar {


### PR DESCRIPTION
Not sure if this is the correct way to do it, but I use Java 18 on my system and building Velocity results in the proxy jar not being compatible with Java 17.