### PR TITLE
Fix command packet wrong mark as unsigned

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/PlayerCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/PlayerCommand.java
@@ -114,9 +114,6 @@ public class PlayerCommand implements MinecraftPacket {
     timestamp = Instant.ofEpochMilli(buf.readLong());
 
     salt = buf.readLong();
-    if (salt == 0L) {
-      unsigned = true;
-    }
 
     int mapSize = ProtocolUtils.readVarInt(buf);
     if (mapSize > MAX_NUM_ARGUMENTS) {
@@ -150,6 +147,10 @@ public class PlayerCommand implements MinecraftPacket {
       if (buf.readBoolean()) {
         lastMessage = new SignaturePair(ProtocolUtils.readUuid(buf), ProtocolUtils.readByteArray(buf));
       }
+    }
+
+    if (salt == 0L && previousMessages.length == 0) {
+      unsigned = true;
     }
 
   }


### PR DESCRIPTION
Fix player kick for `Chat message validation failure` when using F3+F4 switch game mode after sending some message.