### PR TITLE
Fix decoding of unsigned messages on 1.19.1

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/PlayerChat.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/PlayerChat.java
@@ -99,7 +99,8 @@ public class PlayerChat implements MinecraftPacket {
       salt = Longs.toByteArray(saltLong);
       signature = signatureBytes;
       expiry = Instant.ofEpochMilli(expiresAt);
-    } else if (saltLong == 0L && signatureBytes.length == 0) {
+    } else if ((protocolVersion.compareTo(ProtocolVersion.MINECRAFT_1_19_1) >= 0
+        || saltLong == 0L) && signatureBytes.length == 0) {
       unsigned = true;
     } else {
       throw EncryptionUtils.INVALID_SIGNATURE;


### PR DESCRIPTION
Some clients may send unsigned messages with a non-zero salt on 1.19.1 (#812, #806)

1.19.1:
![image](https://user-images.githubusercontent.com/45935949/182607901-6ac072a9-5bc6-4c6e-a70c-ffd05e99d977.png)

1.19:
![image](https://user-images.githubusercontent.com/45935949/182607937-0ac22067-2507-4557-9448-11030892879f.png)
