### PR TITLE
Fix NPE on chat decoding for < 1.19 versions

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -180,13 +180,14 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
     return server.getEventManager().fire(event)
         .thenApply(pme -> {
           PlayerChatEvent.ChatResult chatResult = pme.getResult();
+          IdentifiedKey playerKey = player.getIdentifiedKey();
           if (chatResult.isAllowed()) {
             Optional<String> eventMsg = pme.getResult().getMessage();
             if (eventMsg.isPresent()) {
               String messageNew = eventMsg.get();
-              if (player.getIdentifiedKey() != null) {
+              if (playerKey != null) {
                 if (signedMessage != null && !messageNew.equals(signedMessage.getMessage())) {
-                  if (player.getIdentifiedKey().getKeyRevision().compareTo(IdentifiedKey.Revision.LINKED_V2) >= 0) {
+                  if (playerKey.getKeyRevision().compareTo(IdentifiedKey.Revision.LINKED_V2) >= 0) {
                     // Bad, very bad.
                     logger.fatal("A plugin tried to change a signed chat message. "
                         + "This is no longer possible in 1.19.1 and newer. "
@@ -209,7 +210,7 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
               return original;
             }
           } else {
-            if (player.getIdentifiedKey().getKeyRevision().compareTo(IdentifiedKey.Revision.LINKED_V2) >= 0) {
+            if (playerKey != null && playerKey.getKeyRevision().compareTo(IdentifiedKey.Revision.LINKED_V2) >= 0) {
               logger.fatal("A plugin tried to cancel a signed chat message."
                   + " This is no longer possible in 1.19.1 and newer. "
                   + "Disconnecting player " + player.getUsername());


### PR DESCRIPTION
This fixes an NPE caused by sending messages from legacy versions, which do not have support for cryptographic keys.