### PR TITLE
Add option to disable authentication keys

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/KeyAuthenticationPolicy.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/KeyAuthenticationPolicy.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.config;
+
+public enum KeyAuthenticationPolicy {
+  DISABLED,
+  ENABLED,
+  ENFORCED
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/PlayerChat.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/PlayerChat.java
@@ -167,7 +167,7 @@ public class PlayerChat implements MinecraftPacket {
    *                                                                     is invalid.
    */
   public SignedChatMessage signedContainer(IdentifiedKey signer, UUID sender, boolean mustSign) {
-    if (unsigned) {
+    if (unsigned || signer == null) {
       if (mustSign) {
         throw EncryptionUtils.INVALID_SIGNATURE;
       }

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -15,8 +15,18 @@ show-max-players = 500
 # Should we authenticate players with Mojang? By default, this is on.
 online-mode = true
 
-# Should the proxy enforce the new public key security standard? By default, this is on.
-force-key-authentication = true
+# Should the proxy support secure profiles (and signed chat) for 1.19.1+ clients and servers?
+# This option only affects 1.19.1+ clients and servers.
+#
+# Available options:
+# - "disabled":    Secure profiles are not checked, all chat messages will appear unsigned to backend
+#                  servers. This option is not recommended as it may break compatibility with 1.19.1
+#                  servers, and it will cause newer clients to show a warning upon login.
+# - "enabled":     The proxy will support secure profiles for 1.19.1+ clients, but will also allow
+#                  insecure profiles. 1.19.1+ backend servers might reject insecure logins.
+# - "enforced":    (default) The proxy will only allow secure profiles to log in. This has the same effect
+#                  as the old "force-key-authentication" option.
+key-authentication-policy = "ENFORCED"
 
 # If client's ISP/AS sent from this proxy is different from the one from Mojang's
 # authentication server, the player is kicked. This disallows some VPN and proxy


### PR DESCRIPTION
As mentioned in #804 (which this PR is also a workaround for), Velocity's aim is to support as many setups as possible.

With the 1.19.1 update, it is no longer possible to cancel or edit the order of incoming messages, while still keeping support for signed chat and player reporting.  
However, Velocity currently lacks the option to forgo message signing (e.g., to freely cancel and transform everything into a system message) for 1.19.1 clients and servers.

This PR migrates the old `force-key-authentication` option into a three-variant enum (`key-authentication-policy`), with the default being the exact same behavior before this change. Additionally, if `force-key-authentication` was manually turned off, this falls back to the enabled state.

Disabling authentication keys is something the user must do manually via a config change, and it is discouraged in the option's comment.