### PR TITLE
Pass-through impermissible commands.

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
@@ -125,4 +125,13 @@ public interface CommandManager {
    * @return true if the alias is registered; false otherwise
    */
   boolean hasCommand(String alias);
+
+  /**
+   * Determines whether a player has the command in their "permissible scope".
+   *
+   * @param alias the command alias to check
+   * @param source the source to check the permissibility against
+   * @return true if the alias is registered - and accessible by the source; false otherwise
+   */
+  boolean hasPermissibleCommand(String alias, CommandSource source);
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -78,6 +78,7 @@ import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Supplier;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.apache.logging.log4j.LogManager;
@@ -610,7 +611,7 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
     }
 
     String commandLabel = command.substring(0, commandEndPosition);
-    if (!server.getCommandManager().hasCommand(commandLabel)) {
+    if (!server.getCommandManager().hasPermissibleCommand(commandLabel, player)) {
       if (player.getProtocolVersion().compareTo(MINECRAFT_1_13) < 0) {
         // Outstanding tab completes are recorded for use with 1.12 clients and below to provide
         // additional tab completion support.
@@ -756,7 +757,18 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
     }
 
     String commandToRun = result.getCommand().orElse(originalCommand);
-    if (result.isForwardToServer()) {
+
+    Supplier<Boolean> permissible = () -> { // lazy, if it's already forwarding we don't care
+      int commandEndPosition = commandToRun.indexOf(' ');
+      if (commandEndPosition == -1) {
+        commandEndPosition = commandToRun.length();
+      }
+
+      String commandLabel = commandToRun.substring(0, commandEndPosition);
+      return server.getCommandManager().hasPermissibleCommand(commandLabel, player);
+    };
+
+    if (result.isForwardToServer() || !permissible.get()) {
       ChatBuilder write = ChatBuilder
           .builder(player.getProtocolVersion())
           .timestamp(passedTimestamp)


### PR DESCRIPTION
**The Problem**
Currently if you have a setup such as:
```
proxy A declares command `/hello <string list>` under permission `example`
server A declares command `/hello [<literal x>] <string list>` under no permission

player without permission `example` joins proxy A and gets forwarded to server A

Expected:
the tab completion for `/hello` along with command execution should forward to the backend server

Actual:
Parsing fails at the location of `hello <==` and it refuses to pass anything including command execution along.
```

**Soltuion:**
We should be checking permissibility before running the dispatcher parse/executor - if we know the user doesn't have permission we can simply pass through the request. This also goes for command result executors and parsers.