### PR TITLE
Implement Documented javadoc annotation on AwaitingEvent

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/annotation/AwaitingEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/annotation/AwaitingEvent.java
@@ -7,6 +7,7 @@
 
 package com.velocitypowered.api.event.annotation;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
@@ -17,6 +18,7 @@ import java.lang.annotation.Target;
  * operations in a non-blocking matter.
  */
 @Target(ElementType.TYPE)
+@Documented
 public @interface AwaitingEvent {
 
 }


### PR DESCRIPTION
Currently the `@AwaitingEvent` annotation is not visible in the javadocs since it does not have the `@Documented` annotation, being that its reason to exist is to give the AwaitingEvent category to an event in the javadocs
![before-vs-now](https://i.imgur.com/C0cX17Y.png)