### PR TITLE
Improving incorrect namespace/name error

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/messages/MinecraftChannelIdentifier.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/messages/MinecraftChannelIdentifier.java
@@ -52,10 +52,10 @@ public final class MinecraftChannelIdentifier implements ChannelIdentifier {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(namespace), "namespace is null or empty");
     Preconditions.checkArgument(name != null, "namespace is null or empty");
     Preconditions.checkArgument(VALID_IDENTIFIER_REGEX.matcher(namespace).matches(),
-        String.format("namespace is not valid, must match: %s got %s", VALID_IDENTIFIER_REGEX.toString(), namespace));
+        "namespace is not valid, must match: %s got %s", VALID_IDENTIFIER_REGEX.toString(), namespace);
     Preconditions
         .checkArgument(VALID_IDENTIFIER_REGEX.matcher(name).matches(),
-          String.format("name is not valid, must match: %s got %s", VALID_IDENTIFIER_REGEX.toString(), name));
+          "name is not valid, must match: %s got %s", VALID_IDENTIFIER_REGEX.toString(), name);
     return new MinecraftChannelIdentifier(namespace, name);
   }
 

--- a/api/src/main/java/com/velocitypowered/api/proxy/messages/MinecraftChannelIdentifier.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/messages/MinecraftChannelIdentifier.java
@@ -52,9 +52,10 @@ public final class MinecraftChannelIdentifier implements ChannelIdentifier {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(namespace), "namespace is null or empty");
     Preconditions.checkArgument(name != null, "namespace is null or empty");
     Preconditions.checkArgument(VALID_IDENTIFIER_REGEX.matcher(namespace).matches(),
-        "namespace is not valid");
+        String.format("namespace is not valid, must match: %s got %s", VALID_IDENTIFIER_REGEX.toString(), namespace));
     Preconditions
-        .checkArgument(VALID_IDENTIFIER_REGEX.matcher(name).matches(), "name is not valid");
+        .checkArgument(VALID_IDENTIFIER_REGEX.matcher(name).matches(),
+          String.format("name is not valid, must match: %s got %s", VALID_IDENTIFIER_REGEX.toString(), name));
     return new MinecraftChannelIdentifier(namespace, name);
   }
 


### PR DESCRIPTION
Rather than getting the following:
`namespace is not valid`
or
`name is not valid`

You now get:

`namespace is not valid, must match: [a-z0-9/\\-_]* got your:namespace`
`name is not valid, must match: [a-z0-9/\\-_]* got your:name`