### PR TITLE
Update Configurate to 3.7.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ allprojects {
         nettyVersion = '4.1.77.Final'
         guavaVersion = '25.1-jre'
         checkerFrameworkVersion = '3.6.1'
-        configurateVersion = '3.7.2'
+        configurateVersion = '3.7.3'
 
         getCurrentShortRevision = {
             new ByteArrayOutputStream().withStream { os ->


### PR DESCRIPTION
Before this change it was impossible to use the version of Configurate that is included in Velocity in a modular project, because until version 3.7.3 the automatic modules were applied in Configurate 3, while Velocity contains Configurate 3.7.2

![module-not-found-error](https://i.imgur.com/8af4EBc.png)

https://github.com/SpongePowered/Configurate/releases/tag/3.7.3