### PR TITLE
Added ServerUpdateTablistEvent to allow modifications of the player list

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/player/ServerUpdateTablistEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/ServerUpdateTablistEvent.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.event.player;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.event.annotation.AwaitingEvent;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.player.TabListEntry;
+import java.util.Set;
+
+/**
+ * This event is fired, when the tablist from velocity is updated. It can be
+ * used to identify changed tablist entries or updates. Updates can only be modified.
+ */
+@AwaitingEvent
+public class ServerUpdateTablistEvent {
+  private final Player owner;
+
+  private final Action action;
+
+  private final Set<TabListEntry> entries;
+
+  public ServerUpdateTablistEvent(Player owner, Action action, Set<TabListEntry> entries) {
+    this.owner = Preconditions.checkNotNull(owner, "owner");
+    this.action = Preconditions.checkNotNull(action, "action");
+    this.entries = Preconditions.checkNotNull(entries, "entries");
+  }
+
+  public Set<TabListEntry> getEntries() {
+    return entries;
+  }
+
+  public Action getAction() {
+    return action;
+  }
+
+  public Player getOwner() {
+    return owner;
+  }
+
+  @Override
+  public String toString() {
+    return "ProxyUpdateTablistEvent{"
+        + "owner=" + owner
+        + ", action=" + action
+        + ", entries=" + entries
+        + '}';
+  }
+
+  /**
+   * Represents the requested action for the player list.
+   */
+  public enum Action {
+    /**
+     * Add a new player to the player list.
+     */
+    ADD_PLAYER(0),
+    /**
+     * Update the gamemode for the specific entries.
+     */
+    UPDATE_GAMEMODE(1),
+    /**
+     * Update the latency for the specific entries.
+     */
+    UPDATE_LATENCY(2),
+    /**
+     * Update the display name for the specific entries.
+     */
+    UPDATE_DISPLAY_NAME(3),
+    /**
+     * Remove the player from the player list.
+     */
+    REMOVE_PLAYER(4);
+
+    private final int value;
+
+    Action(int value) {
+      this.value = value;
+    }
+
+    /**
+     * Get the action from the ordinal integer code from the packet.
+     *
+     * @param value the id of the action
+     * @return the action, null when no action could be found
+     */
+    public static Action of(int value) {
+      for (Action action : Action.values()) {
+        if (action.value == value) {
+          return action;
+        }
+      }
+      return null;
+    }
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -247,7 +247,7 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
   @Override
   public boolean handle(PlayerListItem packet) {
     serverConn.getPlayer().getTabList().processBackendPacket(packet);
-    return false;
+    return true;
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -18,7 +18,7 @@
 package com.velocitypowered.proxy.tablist;
 
 import com.google.common.base.Preconditions;
-import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.api.event.player.ServerUpdateTablistEvent;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.crypto.IdentifiedKey;
@@ -32,10 +32,12 @@ import com.velocitypowered.proxy.protocol.packet.PlayerListItem;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import net.kyori.adventure.text.Component;
@@ -148,6 +150,8 @@ public class VelocityTabList implements TabList {
    */
   public void processBackendPacket(PlayerListItem packet) {
     // Packets are already forwarded on, so no need to do that here
+    Set<TabListEntry> modifiedEntries = new HashSet<>();
+
     for (PlayerListItem.Item item : packet.getItems()) {
       UUID uuid = item.getUuid();
       assert uuid != null : "1.7 tab list entry given to modern tab list handler!";
@@ -182,23 +186,26 @@ public class VelocityTabList implements TabList {
             }
           }
 
-          entries.putIfAbsent(item.getUuid(), (VelocityTabListEntry) TabListEntry.builder()
-              .tabList(this)
-              .profile(new GameProfile(uuid, name, properties))
-              .displayName(item.getDisplayName())
-              .latency(item.getLatency())
-              .playerKey(providedKey)
-              .gameMode(item.getGameMode())
-              .build());
+          VelocityTabListEntry entry = (VelocityTabListEntry) TabListEntry.builder()
+                  .tabList(this)
+                  .profile(new GameProfile(uuid, name, properties))
+                  .displayName(item.getDisplayName())
+                  .latency(item.getLatency())
+                  .playerKey(providedKey)
+                  .gameMode(item.getGameMode())
+                  .build();
+          this.entries.putIfAbsent(entry.getProfile().getId(), entry);
+          modifiedEntries.add(entry);
           break;
         }
         case PlayerListItem.REMOVE_PLAYER:
-          entries.remove(uuid);
+          modifiedEntries.add(entries.remove(uuid));
           break;
         case PlayerListItem.UPDATE_DISPLAY_NAME: {
           VelocityTabListEntry entry = entries.get(uuid);
           if (entry != null) {
             entry.setDisplayNameInternal(item.getDisplayName());
+            modifiedEntries.add(entry);
           }
           break;
         }
@@ -206,6 +213,7 @@ public class VelocityTabList implements TabList {
           VelocityTabListEntry entry = entries.get(uuid);
           if (entry != null) {
             entry.setLatencyInternal(item.getLatency());
+            modifiedEntries.add(entry);
           }
           break;
         }
@@ -213,6 +221,7 @@ public class VelocityTabList implements TabList {
           VelocityTabListEntry entry = entries.get(uuid);
           if (entry != null) {
             entry.setGameModeInternal(item.getGameMode());
+            modifiedEntries.add(entry);
           }
           break;
         }
@@ -221,27 +230,38 @@ public class VelocityTabList implements TabList {
           break;
       }
     }
+    proxyServer.getEventManager().fire(new ServerUpdateTablistEvent(player,
+                    ServerUpdateTablistEvent.Action.of(packet.getAction()),
+                    Collections.unmodifiableSet(modifiedEntries))
+    ).thenAccept(event -> {
+      List<PlayerListItem.Item> items = event.getEntries().stream().map(this::convertToItem).toList();
+      connection.delayedWrite(new PlayerListItem(packet.getAction(), items));
+    });
   }
 
   void updateEntry(int action, TabListEntry entry) {
     if (entries.containsKey(entry.getProfile().getId())) {
-      PlayerListItem.Item packetItem = PlayerListItem.Item.from(entry);
-
-      IdentifiedKey selectedKey = packetItem.getPlayerKey();
-      Optional<Player> existing = proxyServer.getPlayer(entry.getProfile().getId());
-      if (existing.isPresent()) {
-        selectedKey = existing.get().getIdentifiedKey();
-      }
-
-      if (selectedKey != null
-              && selectedKey.getKeyRevision().getApplicableTo().contains(connection.getProtocolVersion())
-              && Objects.equals(selectedKey.getSignatureHolder(), entry.getProfile().getId())) {
-        packetItem.setPlayerKey(selectedKey);
-      } else {
-        packetItem.setPlayerKey(null);
-      }
-
+      PlayerListItem.Item packetItem = convertToItem(entry);
       connection.write(new PlayerListItem(action, Collections.singletonList(packetItem)));
     }
+  }
+
+  private PlayerListItem.Item convertToItem(TabListEntry entry) {
+    PlayerListItem.Item packetItem = PlayerListItem.Item.from(entry);
+
+    IdentifiedKey selectedKey = packetItem.getPlayerKey();
+    Optional<Player> existing = proxyServer.getPlayer(entry.getProfile().getId());
+    if (existing.isPresent()) {
+      selectedKey = existing.get().getIdentifiedKey();
+    }
+
+    if (selectedKey != null
+            && selectedKey.getKeyRevision().getApplicableTo().contains(connection.getProtocolVersion())
+            && Objects.equals(selectedKey.getSignatureHolder(), entry.getProfile().getId())) {
+      packetItem.setPlayerKey(selectedKey);
+    } else {
+      packetItem.setPlayerKey(null);
+    }
+    return packetItem;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -234,7 +235,8 @@ public class VelocityTabList implements TabList {
                     ServerUpdateTablistEvent.Action.of(packet.getAction()),
                     Collections.unmodifiableSet(modifiedEntries))
     ).thenAccept(event -> {
-      List<PlayerListItem.Item> items = event.getEntries().stream().map(this::convertToItem).toList();
+      List<PlayerListItem.Item> items = event.getEntries().stream()
+              .map(this::convertToItem).collect(Collectors.toList());
       connection.delayedWrite(new PlayerListItem(packet.getAction(), items));
     });
   }


### PR DESCRIPTION
This event is called when the backend server modifies the tablist entries. The entries can be modified but not removed or changed.

This merge request should fix my issue #870 .

Example code to use that event:
```java
@Subscribe
public void onUpdate(ServerUpdateTablistEvent event) {
  switch (event.getAction()) {
    case UPDATE_DISPLAY_NAME, ADD_PLAYER -> {
      event.getEntries().forEach(entry -> 
          entry.setDisplayName(Component.text(entry.getProfile().getName(), NamedTextColor.YELLOW)));
  }
}
```

It was necessary to change the logic and to not send the backend server's packet directly to the client. This should be no breaking change and it works with the enabled and disabled signing feature.