### PR TITLE
Fix grammar in obscure error message

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -496,7 +496,7 @@ public class VelocityConfiguration implements ProxyConfig {
             throw new RuntimeException("The file " + forwardSecretFile + " is not a valid file or it is a directory.");
           }
         } else {
-          throw new RuntimeException("The forwarding-secret-file does not exists.");
+          throw new RuntimeException("The forwarding-secret-file does not exist.");
         }
       }
     }


### PR DESCRIPTION
The title really says it all. Change ``The forwarding-secret-file does not exists.`` to ``The forwarding-secret-file does not exist.``