### PR TITLE
Pin libdeflate version

### DIFF
--- a/native/compile-linux.sh
+++ b/native/compile-linux.sh
@@ -8,7 +8,7 @@ fi
 
 if [ ! -d libdeflate ]; then
   echo "Cloning libdeflate..."
-  git clone https://github.com/ebiggers/libdeflate.git
+  git clone -b v1.14 https://github.com/ebiggers/libdeflate.git
 fi
 
 echo "Compiling libdeflate..."

--- a/native/compile-macos.sh
+++ b/native/compile-macos.sh
@@ -6,7 +6,7 @@ fi
 
 if [ ! -d libdeflate ]; then
   echo "Cloning libdeflate..."
-  git clone https://github.com/ebiggers/libdeflate.git
+  git clone -b v1.14 https://github.com/ebiggers/libdeflate.git
 fi
 
 echo "Compiling libdeflate..."


### PR DESCRIPTION
Libdeflate changed to cmake which prevents compile-linux.sh from running as is. Instead of compiling against head, let's compile against a tag at least.