### PR TITLE
regression: fix legacy chat cancelling on < 1.19

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyChatHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyChatHandler.java
@@ -45,7 +45,7 @@ public class LegacyChatHandler implements ChatHandler<LegacyChat> {
     }
     this.server.getEventManager().fire(new PlayerChatEvent(this.player, packet.getMessage()))
         .whenComplete((chatEvent, throwable) -> {
-          if (chatEvent.getResult().isAllowed()) {
+          if (!chatEvent.getResult().isAllowed()) {
             return;
           }
 


### PR DESCRIPTION
After the 1.19.3 update, cancelling chat events would no longer work for legacy chat (messages would just go through).  
Additionally, uncancelled messages would appear twice.

Oddly enough, this fixes both issues.