### PR TITLE
chat: fix encoding for changed unsigned messages

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatBuilder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatBuilder.java
@@ -54,6 +54,7 @@ public class SessionChatBuilder extends ChatBuilderV2 {
       chat.signature = new byte[0];
       chat.timestamp = timestamp;
       chat.salt = 0L;
+      chat.lastSeenMessages = new LastSeenMessages();
       return chat;
     }
   }


### PR DESCRIPTION
I think you forgot to initialise `lastSeenMessages` when converting unsigned "session" (the new format from 1.19.3) chat messages for backend servers.  
Looking at the code flow, it appears that a NPE should always be triggered for unsigned messages that were changed.

I could reproduce it locally, but I apologise if this is something that can never happen in a real scenario, as I'm using a fork with chat signing disabled for legacy support.