### PR TITLE
Fix TitleTimes packet ID for Minecraft 1.19.3

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
@@ -340,7 +340,7 @@ public enum StateRegistry {
           map(0x5A, MINECRAFT_1_17, true),
           map(0x5B, MINECRAFT_1_18, true),
           map(0x5E, MINECRAFT_1_19_1, true),
-          map(0x5A, MINECRAFT_1_19_3, true));
+          map(0x5C, MINECRAFT_1_19_3, true));
       clientbound.register(TitleClearPacket.class, TitleClearPacket::new,
           map(0x10, MINECRAFT_1_17, true),
           map(0x0D, MINECRAFT_1_19, true),


### PR DESCRIPTION
Currently, TitleTimes uses ID 0x5A, which refers to the TimeUpdate packet, not TitleTimes. Correct TitleTimes ID is 0x5C