### PR TITLE
Reduce Spam from the TabList by not sending every package multiple times

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/player/TabList.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/TabList.java
@@ -84,8 +84,10 @@ public interface TabList {
    * @deprecated Internal usage. Use {@link TabListEntry.Builder} instead.
    */
   @Deprecated
-  TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency,
-                          int gameMode);
+  default TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency,
+                          int gameMode) {
+    return buildEntry(profile, displayName, latency, gameMode, null, true);
+  }
 
   /**
    * Builds a tab list entry.
@@ -99,8 +101,10 @@ public interface TabList {
    * @deprecated Internal usage. Use {@link TabListEntry.Builder} instead.
    */
   @Deprecated
-  TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency,
-                          int gameMode, @Nullable IdentifiedKey key);
+  default TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency,
+                          int gameMode, @Nullable IdentifiedKey key) {
+    return buildEntry(profile, displayName, latency, gameMode, null, true);
+  }
 
 
   /**
@@ -115,6 +119,24 @@ public interface TabList {
    * @deprecated Internal usage. Use {@link TabListEntry.Builder} instead.
    */
   @Deprecated
+  default TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency,
+                          int gameMode, @Nullable ChatSession chatSession) {
+    return buildEntry(profile, displayName, latency, gameMode, chatSession, true);
+  }
+
+  /**
+   * Represents an entry in a {@link Player}'s tab list.
+   *
+   * @param profile     the profile
+   * @param displayName the display name
+   * @param latency     the latency
+   * @param gameMode    the game mode
+   * @param chatSession the chat session
+   * @param listed      the visible status of entry
+   * @return the entry
+   * @deprecated Internal usage. Use {@link TabListEntry.Builder} instead.
+   */
+  @Deprecated
   TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency,
-                          int gameMode, @Nullable ChatSession chatSession);
+                          int gameMode, @Nullable ChatSession chatSession, boolean listed);
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/player/TabListEntry.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/TabListEntry.java
@@ -160,6 +160,7 @@ public interface TabListEntry extends KeyIdentifiable {
     private @Nullable Component displayName;
     private int latency = 0;
     private int gameMode = 0;
+    private boolean listed = true;
 
     private @Nullable ChatSession chatSession;
 
@@ -242,6 +243,18 @@ public interface TabListEntry extends KeyIdentifiable {
     }
 
     /**
+     * Sets wether this entry should be visible.
+     *
+     * @param listed to set
+     * @return ${code this}, for chaining
+     * @see TabListEntry#isListed()
+     */
+    public Builder listed(boolean listed) {
+      this.listed = listed;
+      return this;
+    }
+
+    /**
      * Constructs the {@link TabListEntry} specified by {@code this} {@link Builder}.
      *
      * @return the constructed {@link TabListEntry}
@@ -253,7 +266,7 @@ public interface TabListEntry extends KeyIdentifiable {
       if (profile == null) {
         throw new IllegalStateException("The GameProfile must be set when building a TabListEntry");
       }
-      return tabList.buildEntry(profile, displayName, latency, gameMode, chatSession);
+      return tabList.buildEntry(profile, displayName, latency, gameMode, chatSession, listed);
     }
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/KeyedVelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/KeyedVelocityTabList.java
@@ -132,11 +132,6 @@ public class KeyedVelocityTabList implements InternalTabList {
   }
 
   @Override
-  public TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency, int gameMode) {
-    return buildEntry(profile, displayName, latency, gameMode, (ChatSession) null);
-  }
-
-  @Override
   public TabListEntry buildEntry(GameProfile profile,
                                  net.kyori.adventure.text.@Nullable Component displayName,
                                  int latency, int gameMode, @Nullable IdentifiedKey key) {
@@ -145,7 +140,7 @@ public class KeyedVelocityTabList implements InternalTabList {
 
   @Override
   public TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency, int gameMode,
-                                 @Nullable ChatSession chatSession) {
+                                 @Nullable ChatSession chatSession, boolean listed) {
     return new KeyedVelocityTabListEntry(this, profile, displayName, latency, gameMode,
         chatSession == null ? null : chatSession.getIdentifiedKey());
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -163,20 +163,9 @@ public class VelocityTabList implements InternalTabList {
   }
 
   @Override
-  public TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency, int gameMode) {
-    return new VelocityTabListEntry(this, profile, displayName, latency, gameMode, null, true);
-  }
-
-  @Override
   public TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency, int gameMode,
-                                 @Nullable IdentifiedKey key) {
-    return new VelocityTabListEntry(this, profile, displayName, latency, gameMode, null, true);
-  }
-
-  @Override
-  public TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency, int gameMode,
-                                 @Nullable ChatSession chatSession) {
-    return new VelocityTabListEntry(this, profile, displayName, latency, gameMode, chatSession, true);
+                                 @Nullable ChatSession chatSession, boolean listed) {
+    return new VelocityTabListEntry(this, profile, displayName, latency, gameMode, chatSession, listed);
   }
 
   @Override
@@ -211,7 +200,7 @@ public class VelocityTabList implements InternalTabList {
                 0,
                 -1,
                 null,
-                true
+                false
             )
         );
       } else {

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -223,19 +223,19 @@ public class VelocityTabList implements InternalTabList {
       return;
     }
     if (actions.contains(UpsertPlayerInfo.Action.UPDATE_GAME_MODE)) {
-      currentEntry.setGameMode(entry.getGameMode());
+      currentEntry.setGameModeWithoutUpdate(entry.getGameMode());
     }
     if (actions.contains(UpsertPlayerInfo.Action.UPDATE_LATENCY)) {
-      currentEntry.setLatency(entry.getLatency());
+      currentEntry.setLatencyWithoutUpdate(entry.getLatency());
     }
     if (actions.contains(UpsertPlayerInfo.Action.UPDATE_DISPLAY_NAME)) {
-      currentEntry.setDisplayName(entry.getDisplayName());
+      currentEntry.setDisplayNameWithoutUpdate(entry.getDisplayName());
     }
     if (actions.contains(UpsertPlayerInfo.Action.INITIALIZE_CHAT)) {
       currentEntry.setChatSession(entry.getChatSession());
     }
     if (actions.contains(UpsertPlayerInfo.Action.UPDATE_LISTED)) {
-      currentEntry.setListed(entry.isListed());
+      currentEntry.setListedWithoutUpdate(entry.isListed());
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListEntry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListEntry.java
@@ -76,6 +76,10 @@ public class VelocityTabListEntry implements TabListEntry {
     return this;
   }
 
+  void setDisplayNameWithoutUpdate(@Nullable Component displayName) {
+    this.displayName = displayName;
+  }
+
   @Override
   public int getLatency() {
     return this.latency;
@@ -90,6 +94,10 @@ public class VelocityTabListEntry implements TabListEntry {
     return this;
   }
 
+  void setLatencyWithoutUpdate(int latency) {
+    this.latency = latency;
+  }
+
   @Override
   public int getGameMode() {
     return this.gameMode;
@@ -102,6 +110,10 @@ public class VelocityTabListEntry implements TabListEntry {
     upsertEntry.setGameMode(gameMode);
     this.tabList.emitActionRaw(UpsertPlayerInfo.Action.UPDATE_GAME_MODE, upsertEntry);
     return this;
+  }
+
+  void setGameModeWithoutUpdate(int gameMode) {
+    this.gameMode = gameMode;
   }
 
   protected void setChatSession(@Nullable ChatSession session) {
@@ -120,5 +132,9 @@ public class VelocityTabListEntry implements TabListEntry {
     upsertEntry.setListed(listed);
     this.tabList.emitActionRaw(UpsertPlayerInfo.Action.UPDATE_LISTED, upsertEntry);
     return this;
+  }
+
+  void setListedWithoutUpdate(boolean listed) {
+    this.listed = listed;
   }
 }


### PR DESCRIPTION
VelocityTabList#processUpsert called entry.setX which will create a package and send it to the client. 

BackendPlaySessionHandler doesn't return true for those packages, therefore the package for tab list updates will be send two times.