### PR TITLE
Normalize logging patterns to always include logger name

### DIFF
--- a/proxy/src/main/resources/log4j2.xml
+++ b/proxy/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
     <TerminalConsole name="TerminalConsole">
       <PatternLayout>
         <LoggerNamePatternSelector
-          defaultPattern="%highlightError{[%d{HH:mm:ss} %level] [%logger]: %minecraftFormatting{%msg}%n%xEx}">
+          defaultPattern="%highlightError{[%d{HH:mm:ss} %level]: [%logger] %minecraftFormatting{%msg}%n%xEx}">
           <!-- Velocity doesn't need a prefix -->
           <PatternMatch key="com.velocitypowered."
             pattern="%highlightError{[%d{HH:mm:ss} %level]: %minecraftFormatting{%msg}%n%xEx}"/>
@@ -32,7 +32,7 @@
     <RollingRandomAccessFile name="File" fileName="logs/latest.log"
       filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz"
       immediateFlush="false">
-      <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %minecraftFormatting{%msg}{strip}%n"/>
+      <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: [%logger] %minecraftFormatting{%msg}{strip}%n"/>
       <Policies>
         <TimeBasedTriggeringPolicy/>
         <OnStartupTriggeringPolicy/>


### PR DESCRIPTION
Small PR to essentially normalize log4j logging patterns to match Paper (whose logging patterns look fine IMO). The current pattern Velocity uses omits logger (aka. plugin) names from file logs, making it harder to figure out which plugin logged a line.

Discord convo from a couple months back: https://discord.com/channels/289587909051416579/908507886420910101/1002610967835840512