### PR TITLE
Bump netty to 4.1.86.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
         junitVersion = '5.9.0'
         slf4jVersion = '1.7.30'
         log4jVersion = '2.19.0'
-        nettyVersion = '4.1.85.Final'
+        nettyVersion = '4.1.86.Final'
         guavaVersion = '25.1-jre'
         checkerFrameworkVersion = '3.6.1'
         configurateVersion = '3.7.3'


### PR DESCRIPTION
Bump netty to 4.1.86.Final
https://netty.io/news/2022/12/12/4-1-86-Final.html

HAProxyMessageDecoder Stack Exhaustion DoS (CVE-2022-41881)
HTTP Response splitting from assigning header value iterator (CVE-2022-41915)
Revert #12888 for potential task scheduling problems in HashedWheelTimer (#13021)
Deprecate ObjectEncoder/ObjectDecoder (#12990)
HPACK dynamic table size update must happen at the beginning of the header block (#12988)