### PR TITLE
Add ServerHandshakeEvent

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/connection/ServerHandshakeEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/connection/ServerHandshakeEvent.java
@@ -19,6 +19,7 @@ package com.velocitypowered.api.event.connection;
 
 import com.google.common.base.Preconditions;
 import com.velocitypowered.api.event.annotation.AwaitingEvent;
+import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.player.ServerHandshake;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
@@ -38,24 +39,32 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ServerHandshakeEvent {
   private final Player player;
   private final RegisteredServer server;
+  private final ProtocolVersion protocolVersion;
+  private final int nextStatus;
   private final ServerHandshake originalHandshake;
   private @Nullable ServerHandshake handshake;
 
   /**
    * Creates a new instance.
    *
-   * @param player the player connecting to the server
-   * @param server the server the player is connecting to
+   * @param player            the player connecting to the server
+   * @param server            the server the player is connecting to
+   * @param protocolVersion   the protocol version to send to the server
+   * @param nextStatus        the next status to send to the server
    * @param originalHandshake the original {@link ServerHandshake} to send to the server
    */
-  public ServerHandshakeEvent(Player player, RegisteredServer server, ServerHandshake originalHandshake) {
-    this.player = player;
-    this.server = server;
+  public ServerHandshakeEvent(Player player, RegisteredServer server,
+      ProtocolVersion protocolVersion, int nextStatus, ServerHandshake originalHandshake) {
+    this.player = Preconditions.checkNotNull(player, "player");
+    this.server = Preconditions.checkNotNull(server, "server");
+    this.protocolVersion = Preconditions.checkNotNull(protocolVersion, "protocolVersion");
+    this.nextStatus = nextStatus;
     this.originalHandshake = Preconditions.checkNotNull(originalHandshake);
   }
 
   /**
    * Returns the player connecting to the server.
+   *
    * @return the player connecting to the server
    */
   public Player getPlayer() {
@@ -64,10 +73,29 @@ public final class ServerHandshakeEvent {
 
   /**
    * Returns the server the player is connecting to.
+   *
    * @return the server the player is connecting to
    */
   public RegisteredServer getServer() {
     return server;
+  }
+
+  /**
+   * Returns the protocol version to send to the server.
+   *
+   * @return the protocol version
+   */
+  public ProtocolVersion getProtocolVersion() {
+    return protocolVersion;
+  }
+
+  /**
+   * Returns the next status to send to the server.
+   *
+   * @return the next status
+   */
+  public int getNextStatus() {
+    return nextStatus;
   }
 
   public ServerHandshake getOriginalHandshake() {

--- a/api/src/main/java/com/velocitypowered/api/event/connection/ServerHandshakeEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/connection/ServerHandshakeEvent.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.api.event.connection;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.event.annotation.AwaitingEvent;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.player.ServerHandshake;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * This event is fired after the {@link com.velocitypowered.api.event.player.ServerPreConnectEvent}
+ * to enable plugins modifying the handshake sent to the server.
+ *
+ * <p>
+ *   Velocity will wait for this event to finish firing before proceeding with the rest of the login
+ *   process, but you should try to limit the work done in any event that fires during the login
+ *   process.
+ * </p>
+ */
+@AwaitingEvent
+public final class ServerHandshakeEvent {
+  private final Player player;
+  private final RegisteredServer server;
+  private final ServerHandshake originalHandshake;
+  private @Nullable ServerHandshake handshake;
+
+  /**
+   * Creates a new instance.
+   *
+   * @param player the player connecting to the server
+   * @param server the server the player is connecting to
+   * @param originalHandshake the original {@link ServerHandshake} to send to the server
+   */
+  public ServerHandshakeEvent(Player player, RegisteredServer server, ServerHandshake originalHandshake) {
+    this.player = player;
+    this.server = server;
+    this.originalHandshake = Preconditions.checkNotNull(originalHandshake);
+  }
+
+  /**
+   * Returns the player connecting to the server.
+   * @return the player connecting to the server
+   */
+  public Player getPlayer() {
+    return player;
+  }
+
+  /**
+   * Returns the server the player is connecting to.
+   * @return the server the player is connecting to
+   */
+  public RegisteredServer getServer() {
+    return server;
+  }
+
+  public ServerHandshake getOriginalHandshake() {
+    return originalHandshake;
+  }
+
+  /**
+   * Returns the handshake to send to the server.
+   *
+   * @return the {@link ServerHandshakeEvent}
+   */
+  public ServerHandshake getHandshake() {
+    return handshake == null ? originalHandshake : handshake;
+  }
+
+  /**
+   * Sets the handshake to send to the server.
+   *
+   * @param handshake the handshake to send to the server, {@code null} uses the original handshake
+   */
+  public void setHandshake(@Nullable ServerHandshake handshake) {
+    this.handshake = handshake;
+  }
+
+  @Override
+  public String toString() {
+    return "ServerHandshakeEvent{"
+        + "handshake=" + handshake
+        + '}';
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/proxy/player/ServerHandshake.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/ServerHandshake.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.api.proxy.player;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.network.ProtocolVersion;
+
+/**
+ * Represents the handshake sent from the proxy to a server. This class is immutable.
+ */
+public final class ServerHandshake {
+
+  private final ProtocolVersion protocolVersion;
+  private final String serverAddress;
+  private final int port;
+  private final int nextStatus;
+
+  /**
+   * Creates a new server handshake.
+   * @param protocolVersion the protocol version
+   * @param serverAddress the server address
+   * @param port the server port
+   * @param nextStatus the next status
+   */
+  public ServerHandshake(ProtocolVersion protocolVersion, String serverAddress, int port,
+      int nextStatus) {
+    this.protocolVersion = Preconditions.checkNotNull(protocolVersion, "protocolVersion");
+    this.serverAddress = Preconditions.checkNotNull(serverAddress, "serverAddress");
+    this.port = port;
+    this.nextStatus = nextStatus;
+  }
+
+  /**
+   * Returns the protocol version to send to the server.
+   * @return the protocol version
+   */
+  public ProtocolVersion getProtocolVersion() {
+    return protocolVersion;
+  }
+
+  /**
+   * Returns the connection address to send to the server.
+   * @return the server address
+   */
+  public String getServerAddress() {
+    return serverAddress;
+  }
+
+  /**
+   * Returns the connection port to send to the server.
+   * @return the port
+   */
+  public int getPort() {
+    return port;
+  }
+
+  /**
+   * Returns the next status to send to the server.
+   * @return the next status
+   */
+  public int getNextStatus() {
+    return nextStatus;
+  }
+
+  /**
+   * Creates a new {@code ServerHandshake} with the specified server address.
+   *
+   * @param serverAddress the new server address
+   * @return the new {@code ServerHandshake}
+   */
+  public ServerHandshake withAddress(String serverAddress) {
+    return new ServerHandshake(protocolVersion, serverAddress, port, nextStatus);
+  }
+
+  /**
+   * Creates a new {@code ServerHandshake} with the specified port.
+   *
+   * @param port the new port
+   * @return the new {@code ServerHandshake}
+   */
+  public ServerHandshake withPort(int port) {
+    return new ServerHandshake(protocolVersion, serverAddress, port, nextStatus);
+  }
+
+  @Override
+  public String toString() {
+    return "ServerHandshake{"
+        + "protocolVersion=" + protocolVersion
+        + ", serverAddress='" + serverAddress + '\''
+        + ", port=" + port
+        + ", nextStatus=" + nextStatus
+        + '}';
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/proxy/player/ServerHandshake.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/ServerHandshake.java
@@ -18,39 +18,23 @@
 package com.velocitypowered.api.proxy.player;
 
 import com.google.common.base.Preconditions;
-import com.velocitypowered.api.network.ProtocolVersion;
 
 /**
  * Represents the handshake sent from the proxy to a server. This class is immutable.
  */
 public final class ServerHandshake {
 
-  private final ProtocolVersion protocolVersion;
   private final String serverAddress;
   private final int port;
-  private final int nextStatus;
 
   /**
    * Creates a new server handshake.
-   * @param protocolVersion the protocol version
    * @param serverAddress the server address
    * @param port the server port
-   * @param nextStatus the next status
    */
-  public ServerHandshake(ProtocolVersion protocolVersion, String serverAddress, int port,
-      int nextStatus) {
-    this.protocolVersion = Preconditions.checkNotNull(protocolVersion, "protocolVersion");
+  public ServerHandshake(String serverAddress, int port) {
     this.serverAddress = Preconditions.checkNotNull(serverAddress, "serverAddress");
     this.port = port;
-    this.nextStatus = nextStatus;
-  }
-
-  /**
-   * Returns the protocol version to send to the server.
-   * @return the protocol version
-   */
-  public ProtocolVersion getProtocolVersion() {
-    return protocolVersion;
   }
 
   /**
@@ -70,21 +54,13 @@ public final class ServerHandshake {
   }
 
   /**
-   * Returns the next status to send to the server.
-   * @return the next status
-   */
-  public int getNextStatus() {
-    return nextStatus;
-  }
-
-  /**
    * Creates a new {@code ServerHandshake} with the specified server address.
    *
    * @param serverAddress the new server address
    * @return the new {@code ServerHandshake}
    */
   public ServerHandshake withAddress(String serverAddress) {
-    return new ServerHandshake(protocolVersion, serverAddress, port, nextStatus);
+    return new ServerHandshake(serverAddress, port);
   }
 
   /**
@@ -94,16 +70,14 @@ public final class ServerHandshake {
    * @return the new {@code ServerHandshake}
    */
   public ServerHandshake withPort(int port) {
-    return new ServerHandshake(protocolVersion, serverAddress, port, nextStatus);
+    return new ServerHandshake(serverAddress, port);
   }
 
   @Override
   public String toString() {
     return "ServerHandshake{"
-        + "protocolVersion=" + protocolVersion
-        + ", serverAddress='" + serverAddress + '\''
+        + "serverAddress='" + serverAddress + '\''
         + ", port=" + port
-        + ", nextStatus=" + nextStatus
         + '}';
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -188,19 +188,19 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
       serverAddress = playerVhost;
     }
 
-    ServerHandshake serverHandshake = new ServerHandshake(protocolVersion, serverAddress,
-        registeredServer.getServerInfo().getAddress().getPort(), StateRegistry.LOGIN_ID);
+    ServerHandshake serverHandshake = new ServerHandshake(serverAddress,
+        registeredServer.getServerInfo().getAddress().getPort());
 
     ServerHandshakeEvent event = new ServerHandshakeEvent(proxyPlayer, registeredServer,
-        serverHandshake);
+        protocolVersion, StateRegistry.LOGIN_ID, serverHandshake);
     server.getEventManager().fire(event).thenAcceptAsync(newEvent -> {
       if (mc.isClosed()) {
         return;
       }
       ServerHandshake handshakeData = newEvent.getHandshake();
       Handshake handshake = new Handshake();
-      handshake.setNextStatus(handshakeData.getNextStatus());
-      handshake.setProtocolVersion(handshakeData.getProtocolVersion());
+      handshake.setNextStatus(event.getNextStatus());
+      handshake.setProtocolVersion(event.getProtocolVersion());
       handshake.setServerAddress(handshakeData.getServerAddress());
       handshake.setPort(handshakeData.getPort());
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -23,9 +23,11 @@ import static com.velocitypowered.proxy.network.Connections.HANDLER;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.velocitypowered.api.event.connection.ServerHandshakeEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.ServerConnection;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
+import com.velocitypowered.api.proxy.player.ServerHandshake;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
 import com.velocitypowered.api.util.GameProfile.Property;
@@ -34,6 +36,7 @@ import com.velocitypowered.proxy.config.PlayerInfoForwarding;
 import com.velocitypowered.proxy.connection.ConnectionTypes;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftConnectionAssociation;
+import com.velocitypowered.proxy.connection.client.AuthSessionHandler;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.connection.registry.DimensionRegistry;
 import com.velocitypowered.proxy.connection.util.ConnectionRequestResults.Impl;
@@ -45,7 +48,6 @@ import com.velocitypowered.proxy.server.VelocityRegisteredServer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
-import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
@@ -53,11 +55,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class VelocityServerConnection implements MinecraftConnectionAssociation, ServerConnection {
 
+  private static final Logger logger = LogManager.getLogger(AuthSessionHandler.class);
   private final VelocityRegisteredServer registeredServer;
   private final @Nullable VelocityRegisteredServer previousServer;
   private final ConnectedPlayer proxyPlayer;
@@ -171,32 +176,50 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
         .orElseGet(() -> registeredServer.getServerInfo().getAddress())
         .getHostString();
 
-    Handshake handshake = new Handshake();
-    handshake.setNextStatus(StateRegistry.LOGIN_ID);
-    handshake.setProtocolVersion(protocolVersion);
+    String serverAddress;
     if (forwardingMode == PlayerInfoForwarding.LEGACY) {
-      handshake.setServerAddress(createLegacyForwardingAddress());
+      serverAddress = createLegacyForwardingAddress();
     } else if (forwardingMode == PlayerInfoForwarding.BUNGEEGUARD) {
       byte[] secret = server.getConfiguration().getForwardingSecret();
-      handshake.setServerAddress(createBungeeGuardForwardingAddress(secret));
+      serverAddress = createBungeeGuardForwardingAddress(secret);
     } else if (proxyPlayer.getConnection().getType() == ConnectionTypes.LEGACY_FORGE) {
-      handshake.setServerAddress(playerVhost + HANDSHAKE_HOSTNAME_TOKEN);
+      serverAddress = playerVhost + HANDSHAKE_HOSTNAME_TOKEN;
     } else {
-      handshake.setServerAddress(playerVhost);
+      serverAddress = playerVhost;
     }
 
-    handshake.setPort(registeredServer.getServerInfo().getAddress().getPort());
-    mc.delayedWrite(handshake);
+    ServerHandshake serverHandshake = new ServerHandshake(protocolVersion, serverAddress,
+        registeredServer.getServerInfo().getAddress().getPort(), StateRegistry.LOGIN_ID);
 
-    mc.setProtocolVersion(protocolVersion);
-    mc.setState(StateRegistry.LOGIN);
-    if (proxyPlayer.getIdentifiedKey() == null
-        && proxyPlayer.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_19_3) >= 0) {
-      mc.delayedWrite(new ServerLogin(proxyPlayer.getUsername(), proxyPlayer.getUniqueId()));
-    } else {
-      mc.delayedWrite(new ServerLogin(proxyPlayer.getUsername(), proxyPlayer.getIdentifiedKey()));
-    }
-    mc.flush();
+    ServerHandshakeEvent event = new ServerHandshakeEvent(proxyPlayer, registeredServer,
+        serverHandshake);
+    server.getEventManager().fire(event).thenAcceptAsync(newEvent -> {
+      if (mc.isClosed()) {
+        return;
+      }
+      ServerHandshake handshakeData = newEvent.getHandshake();
+      Handshake handshake = new Handshake();
+      handshake.setNextStatus(handshakeData.getNextStatus());
+      handshake.setProtocolVersion(handshakeData.getProtocolVersion());
+      handshake.setServerAddress(handshakeData.getServerAddress());
+      handshake.setPort(handshakeData.getPort());
+
+      mc.delayedWrite(handshake);
+
+      mc.setProtocolVersion(protocolVersion);
+      mc.setState(StateRegistry.LOGIN);
+      if (proxyPlayer.getIdentifiedKey() == null
+          && proxyPlayer.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_19_3) >= 0) {
+        mc.delayedWrite(new ServerLogin(proxyPlayer.getUsername(), proxyPlayer.getUniqueId()));
+      } else {
+        mc.delayedWrite(new ServerLogin(proxyPlayer.getUsername(), proxyPlayer.getIdentifiedKey()));
+      }
+      mc.flush();
+    }, mc.eventLoop()).exceptionally((ex) -> {
+      logger.error("Exception during serverbound handshake of {}",
+          proxyPlayer.getGameProfile(), ex);
+      return null;
+    });
   }
 
   public @Nullable MinecraftConnection getConnection() {


### PR DESCRIPTION
The ServerHandshakeEvent hooks before the login handshake packet is sent and enables the values to be modified (after the various forwarding mode and connection type rules are applied).

This is useful to me for changing the address sent to the server as an early means of sending custom data from velocity->paper without sending additional packets. This was previously possible with BungeeCord and is an impediment to porting plugins.

I have not previously contributed to Velocity and I am unsure if this is the proper approach for implementing this behavior. Changes are welcome.