### PR TITLE
Handle deprecated custom bungeecord subchannels

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -93,7 +93,7 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
     }
     this.playerSessionHandler = (ClientPlaySessionHandler) psh;
 
-    this.bungeecordMessageResponder = new BungeeCordMessageResponder(server,
+    this.bungeecordMessageResponder = new BungeeCordMessageResponder(server, this,
         serverConn.getPlayer());
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BungeeCordMessageResponder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BungeeCordMessageResponder.java
@@ -378,7 +378,7 @@ public class BungeeCordMessageResponder {
         this.processKick(in);
         break;
       default:
-        // Probably a sub channel of another plugin.
+        // Probably a custom sub channel of another plugin.
         PluginMessage pluginMessage = new PluginMessage(subChannel, in.unwrap().slice());
         pluginMessage.handle(this.minecraftSessionHandler);
         break;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BungeeCordMessageResponder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BungeeCordMessageResponder.java
@@ -27,6 +27,7 @@ import com.velocitypowered.api.proxy.server.ServerInfo;
 import com.velocitypowered.api.util.UuidUtils;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
+import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.protocol.packet.PluginMessage;
 import com.velocitypowered.proxy.protocol.util.ByteBufDataInput;
@@ -61,10 +62,12 @@ public class BungeeCordMessageResponder {
       new LegacyChannelIdentifier("BungeeCord");
 
   private final VelocityServer proxy;
+  private final MinecraftSessionHandler minecraftSessionHandler;
   private final ConnectedPlayer player;
 
-  BungeeCordMessageResponder(VelocityServer proxy, ConnectedPlayer player) {
+  BungeeCordMessageResponder(VelocityServer proxy, MinecraftSessionHandler minecraftSessionHandler, ConnectedPlayer player) {
     this.proxy = proxy;
+    this.minecraftSessionHandler = minecraftSessionHandler;
     this.player = player;
   }
 
@@ -375,7 +378,9 @@ public class BungeeCordMessageResponder {
         this.processKick(in);
         break;
       default:
-        // Do nothing, unknown command
+        // Probably a sub channel of another plugin.
+        PluginMessage pluginMessage = new PluginMessage(subChannel, in.unwrap().slice());
+        pluginMessage.handle(this.minecraftSessionHandler);
         break;
     }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -67,7 +67,7 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
     this.server = server;
     this.serverConn = serverConn;
     this.resultFuture = resultFuture;
-    this.bungeecordMessageResponder = new BungeeCordMessageResponder(server,
+    this.bungeecordMessageResponder = new BungeeCordMessageResponder(server, this,
         serverConn.getPlayer());
   }
 


### PR DESCRIPTION
Some old plugins are still using `BungeeCord` channel for comunicating with proxy <-> subserver. I wanted to support these plugins on velocity but they can't be really updated to use their own channel.