### PR TITLE
Use TCP_NODELAY only when netty don't enable it by default

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
@@ -122,7 +122,7 @@ public final class ConnectionManager {
         .childHandler(this.serverChannelInitializer.get())
         .childOption(ChannelOption.IP_TOS, 0x18)
         .localAddress(address);
-    if(!PlatformDependent.canEnableTcpNoDelayByDefault()) {
+    if (!PlatformDependent.canEnableTcpNoDelayByDefault()) {
       bootstrap.childOption(ChannelOption.TCP_NODELAY, true);
     }
 
@@ -188,7 +188,7 @@ public final class ConnectionManager {
             this.server.getConfiguration().getConnectTimeout())
         .group(group == null ? this.workerGroup : group)
         .resolver(this.resolver.asGroup());
-    if(!PlatformDependent.canEnableTcpNoDelayByDefault()) {
+    if (!PlatformDependent.canEnableTcpNoDelayByDefault()) {
       bootstrap.option(ChannelOption.TCP_NODELAY, true);
     }
 


### PR DESCRIPTION
By default netty already enable TCP_NODELAY, so enabling it twice leads to unnecessary syscall
https://github.com/netty/netty/blob/netty-4.1.86.Final/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java#L50-L52
https://github.com/netty/netty/blob/netty-4.1.86.Final/transport/src/main/java/io/netty/channel/socket/DefaultSocketChannelConfig.java#L50-L57