### PR TITLE
Fix cancellation of PlayerChatEvent for key revision GENERIC_V1

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedChatHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedChatHandler.java
@@ -104,9 +104,11 @@ public class KeyedChatHandler implements
     assert playerKey != null;
     return pme -> {
       PlayerChatEvent.ChatResult chatResult = pme.getResult();
-      if (!chatResult.isAllowed()
-          && playerKey.getKeyRevision().compareTo(IdentifiedKey.Revision.LINKED_V2) >= 0) {
-        invalidCancel(logger, player);
+      if (!chatResult.isAllowed()) {
+        if (playerKey.getKeyRevision().compareTo(IdentifiedKey.Revision.LINKED_V2) >= 0) {
+          // Bad, very bad.
+          invalidCancel(logger, player);
+        }
         return null;
       }
 


### PR DESCRIPTION
The cancellation of a PlayerChatEvent is currently ignored for 1.19.0 users.