### PR TITLE
Implement a command and chat rate limit

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -167,6 +167,8 @@ public interface Player extends
    */
   TabList getTabList();
 
+  boolean chatRateLimit();
+
   /**
    * Disconnects the player with the specified reason. Once this method is called, further calls to
    * other {@link Player} methods will become undefined.

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -167,8 +167,6 @@ public interface Player extends
    */
   TabList getTabList();
 
-  boolean chatRateLimit();
-
   /**
    * Disconnects the player with the specified reason. Once this method is called, further calls to
    * other {@link Player} methods will become undefined.

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -550,23 +550,27 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   }
 
   @Override
-  public boolean chatRateLimit() {
-    boolean allowed = limiter.attempt(this);
-
-    if (!allowed) {
-      disconnect(Component.translatable("disconnect.spam", NamedTextColor.RED));
-    }
-
-    return allowed;
-  }
-
-  @Override
   public void disconnect(Component reason) {
     if (connection.eventLoop().inEventLoop()) {
       disconnect0(reason, false);
     } else {
       connection.eventLoop().execute(() -> disconnect0(reason, false));
     }
+  }
+
+  /**
+   * Checks and kicks the player when chat rate limit threshold has been reached.
+   *
+   * @return whether the message should be processed or not
+   */
+  public boolean isChatRateLimited() {
+    boolean allowed = limiter.attempt(this);
+
+    if (!allowed) {
+      disconnect(Component.translatable("disconnect.spam", NamedTextColor.RED));
+    }
+
+    return !allowed;
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/CommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/CommandHandler.java
@@ -18,26 +18,20 @@
 package com.velocitypowered.proxy.protocol.packet.chat;
 
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
-import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
-import com.velocitypowered.proxy.util.ratelimit.Ratelimiter;
-import com.velocitypowered.proxy.util.ratelimit.Ratelimiters;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.time.Instant;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
-
 public interface CommandHandler<T extends MinecraftPacket> {
 
   Logger logger = LogManager.getLogger(CommandHandler.class);
-
-  Ratelimiter<Player> limiter = Ratelimiters.createWithMaxHitLimit(4000, 10);
 
   Class<T> packetClass();
 
@@ -62,7 +56,7 @@ public interface CommandHandler<T extends MinecraftPacket> {
       Function<CommandExecuteEvent, CompletableFuture<MinecraftPacket>> futurePacketCreator,
       String message, Instant timestamp) {
 
-    if(!player.chatRateLimit())
+    if(player.isChatRateLimited())
       return;
 
     player.getChatQueue().queuePacket(

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedChatHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedChatHandler.java
@@ -66,7 +66,7 @@ public class KeyedChatHandler implements
 
   @Override
   public void handlePlayerChatInternal(KeyedPlayerChat packet) {
-    if (!player.chatRateLimit())
+    if (player.isChatRateLimited())
       return;
 
     ChatQueue chatQueue = this.player.getChatQueue();

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedChatHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedChatHandler.java
@@ -66,6 +66,9 @@ public class KeyedChatHandler implements
 
   @Override
   public void handlePlayerChatInternal(KeyedPlayerChat packet) {
+    if (!player.chatRateLimit())
+      return;
+
     ChatQueue chatQueue = this.player.getChatQueue();
     EventManager eventManager = this.server.getEventManager();
     PlayerChatEvent toSend = new PlayerChatEvent(player, packet.getMessage());

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyChatHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyChatHandler.java
@@ -40,7 +40,7 @@ public class LegacyChatHandler implements ChatHandler<LegacyChat> {
 
   @Override
   public void handlePlayerChatInternal(LegacyChat packet) {
-    if (!player.chatRateLimit())
+    if (player.isChatRateLimited())
       return;
 
     MinecraftConnection serverConnection = player.ensureAndGetCurrentServer().ensureConnected();

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyChatHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyChatHandler.java
@@ -40,6 +40,9 @@ public class LegacyChatHandler implements ChatHandler<LegacyChat> {
 
   @Override
   public void handlePlayerChatInternal(LegacyChat packet) {
+    if (!player.chatRateLimit())
+      return;
+
     MinecraftConnection serverConnection = player.ensureAndGetCurrentServer().ensureConnected();
     if (serverConnection == null) {
       return;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatHandler.java
@@ -48,6 +48,9 @@ public class SessionChatHandler implements ChatHandler<SessionPlayerChat> {
 
   @Override
   public void handlePlayerChatInternal(SessionPlayerChat packet) {
+    if(!player.chatRateLimit())
+      return;
+
     ChatQueue chatQueue = this.player.getChatQueue();
     EventManager eventManager = this.server.getEventManager();
     PlayerChatEvent toSend = new PlayerChatEvent(player, packet.getMessage());

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatHandler.java
@@ -48,7 +48,7 @@ public class SessionChatHandler implements ChatHandler<SessionPlayerChat> {
 
   @Override
   public void handlePlayerChatInternal(SessionPlayerChat packet) {
-    if(!player.chatRateLimit())
+    if(player.isChatRateLimited())
       return;
 
     ChatQueue chatQueue = this.player.getChatQueue();

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/NoopCacheRatelimiter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/NoopCacheRatelimiter.java
@@ -17,8 +17,6 @@
 
 package com.velocitypowered.proxy.util.ratelimit;
 
-import java.net.InetAddress;
-
 /**
  * A {@link Ratelimiter} that does no rate-limiting.
  */
@@ -26,7 +24,7 @@ enum NoopCacheRatelimiter implements Ratelimiter {
   INSTANCE;
 
   @Override
-  public boolean attempt(InetAddress address) {
+  public boolean attempt(Object address) {
     return true;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/Ratelimiter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/Ratelimiter.java
@@ -17,12 +17,10 @@
 
 package com.velocitypowered.proxy.util.ratelimit;
 
-import java.net.InetAddress;
-
 /**
  * Allows rate limiting of clients.
  */
-public interface Ratelimiter {
+public interface Ratelimiter<T> {
 
   /**
    * Determines whether or not to allow the connection.
@@ -30,5 +28,5 @@ public interface Ratelimiter {
    * @param address the address to rate limit
    * @return true if allowed, false if not
    */
-  boolean attempt(InetAddress address);
+  boolean attempt(T address);
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/Ratelimiters.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/Ratelimiters.java
@@ -28,8 +28,12 @@ public final class Ratelimiters {
     throw new AssertionError();
   }
 
-  public static Ratelimiter createWithMilliseconds(long ms) {
+  public static <T> Ratelimiter<T> createWithMilliseconds(long ms) {
     return ms <= 0 ? NoopCacheRatelimiter.INSTANCE : new CaffeineCacheRatelimiter(ms,
         TimeUnit.MILLISECONDS);
+  }
+
+  public static <T> Ratelimiter<T> createWithMaxHitLimit(long ms, int maxLimit) {
+    return new MaxHitRatelimiter(ms, maxLimit, TimeUnit.MILLISECONDS);
   }
 }

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-
 velocity.error.already-connected=You are already connected to this server!
 velocity.error.already-connected-proxy=You are already connected to this proxy!
 velocity.error.already-connecting=You are already trying to connect to a server!


### PR DESCRIPTION
## Abstract

In the last weeks [this exploit](https://github.com/LuckPerms/LuckPerms/issues/3546) affected a lot of proxies with great suffering from a lot of Minecraft server owners.

The exploit just works by creating a custom client that floods "heavy" commands in order to flood the proxy with tasks to crash it.

## The solution

I've implemented a simple command + chat rate limiter that works just like the Minecraft server does. If a user sends more than 10 commands in less than 4 seconds, gets kicked.

This fix will keep sure that things like this will never happena again

Clear and simple.