### PR TITLE
Added API support for modifying command suggestions

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/player/CommandTabCompleteEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/CommandTabCompleteEvent.java
@@ -1,0 +1,108 @@
+package com.velocitypowered.api.event.player;
+
+import com.velocitypowered.api.event.annotation.AwaitingEvent;
+import com.velocitypowered.api.proxy.Player;
+import net.kyori.adventure.text.Component;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * This event is fired after a command tab complete response is sent by the remote server. The
+ * plugin that owns this command then suggests tab completions. Here, this event provides you the
+ * opportunity to modify the command tab completions suggested by the plugin. Velocity will wait
+ * for this event to finish firing before sending the tab complete results to the client. Be sure
+ * to be as fast as possible, since the client will freeze while it waits for the tab complete
+ * results.
+ */
+@AwaitingEvent
+public class CommandTabCompleteEvent {
+    private final Player player;
+    private final String command;
+    private List<CommandSuggestion> suggestions;
+
+    /**
+     * Constructs a new TabCompleteCommandEvent instance.
+     *
+     * @param player the player
+     * @param command the command prompt that the player is attempting to tab complete
+     * @param suggestions the initial list of suggestions
+     */
+    public CommandTabCompleteEvent(Player player, String command, List<CommandSuggestion> suggestions) {
+        this.player = checkNotNull(player, "player");
+        this.command = checkNotNull(command, "command");
+        this.suggestions = suggestions;
+    }
+
+    /**
+     * Returns the player requesting the tab completion.
+     *
+     * @return the requesting player
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Returns the command being completed.
+     *
+     * @return the command message
+     */
+    public String getCommand() {
+        return command;
+    }
+
+    /**
+     * Returns all the suggestions provided to the user, as a mutable list.
+     *
+     * @return the suggestions
+     */
+    public List<CommandSuggestion> getSuggestions() {
+        return suggestions;
+    }
+
+    /**
+     * Set the suggestions provided to the user.
+     *
+     * @param suggestions the suggestions
+     */
+    public void setSuggestions(List<CommandSuggestion> suggestions) {
+        this.suggestions = suggestions;
+    }
+
+    @Override
+    public String toString() {
+        return "TabCompleteEvent{"
+                + "player=" + player
+                + ", partialMessage='" + command + '\''
+                + ", suggestions=" + suggestions
+                + '}';
+    }
+
+    public static class CommandSuggestion {
+        private final String text;
+        private final Component tooltip;
+
+        public CommandSuggestion(String text, Component tooltip) {
+            this.text = text;
+            this.tooltip = tooltip;
+        }
+
+        public Component getTooltip() {
+            return tooltip;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        @Override
+        public String toString() {
+            return "CommandSuggestion{"
+                    + "text='" + text + '\''
+                    + ", tooltip='" + tooltip + '\''
+                    + '}';
+        }
+    }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -575,7 +575,13 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
               List<CommandTabCompleteEvent.CommandSuggestion> eventSuggestions = new ArrayList<>(suggestions.getList().size());
               for (Suggestion suggestion : suggestions.getList()) {
                 Message tooltip = suggestion.getTooltip();
-                eventSuggestions.add(new CommandTabCompleteEvent.CommandSuggestion(suggestion.getText(), tooltip == null ? null : tooltip instanceof VelocityBrigadierMessage ? ((VelocityBrigadierMessage) tooltip).asComponent() : Component.text(tooltip.getString())));
+                Component componentTooltip = null;
+                if (tooltip != null) {
+                  componentTooltip = tooltip instanceof VelocityBrigadierMessage ?
+                          ((VelocityBrigadierMessage) tooltip).asComponent() :
+                          Component.text(tooltip.getString());
+                }
+                eventSuggestions.add(new CommandTabCompleteEvent.CommandSuggestion(suggestion.getText(), componentTooltip));
               }
 
               server.getEventManager()

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -572,24 +572,29 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
               }
 
               // convert to command suggestions
-              List<CommandTabCompleteEvent.CommandSuggestion> eventSuggestions = new ArrayList<>(suggestions.getList().size());
+              List<CommandTabCompleteEvent.CommandSuggestion> eventSuggestions = new ArrayList<>(
+                      suggestions.getList().size()
+              );
               for (Suggestion suggestion : suggestions.getList()) {
                 Message tooltip = suggestion.getTooltip();
                 Component componentTooltip = null;
-                if (tooltip != null) {
-                  componentTooltip = tooltip instanceof VelocityBrigadierMessage ?
-                          ((VelocityBrigadierMessage) tooltip).asComponent() :
-                          Component.text(tooltip.getString());
+                if (tooltip instanceof VelocityBrigadierMessage) {
+                  componentTooltip = ((VelocityBrigadierMessage) tooltip).asComponent();
+                } else if (tooltip != null) {
+                  componentTooltip = Component.text(tooltip.getString());
                 }
-                eventSuggestions.add(new CommandTabCompleteEvent.CommandSuggestion(suggestion.getText(), componentTooltip));
+                eventSuggestions.add(new CommandTabCompleteEvent.CommandSuggestion(
+                        suggestion.getText(),
+                        componentTooltip
+                ));
               }
 
               server.getEventManager()
                       .fire(new CommandTabCompleteEvent(player, command, eventSuggestions))
                       .thenAcceptAsync(e -> {
-                        List<CommandTabCompleteEvent.CommandSuggestion> eventOffers = e.getSuggestions();
+                        List<CommandTabCompleteEvent.CommandSuggestion> newOffers = e.getSuggestions();
                         List<Offer> offers = new ArrayList<>();
-                        for (CommandTabCompleteEvent.CommandSuggestion suggestion : eventOffers) {
+                        for (CommandTabCompleteEvent.CommandSuggestion suggestion : newOffers) {
                           String offer = suggestion.getText();
                           Component tooltip = null;
                           if (suggestion.getTooltip() != null) {


### PR DESCRIPTION
This pull request adds a new event called 'CommandTabCompleteEvent'. Currently, velocity does not support modifying tab complete suggestions for command arguments.

For example, if you attempt to Tab complete the following command, no event will be fired:
`/ban Asee`

**Motivation**
I have a multi-proxy setup using RedisBungee. Naturally, most plugins do not support such setups. Tab completions for commands for plugins on velocity do not return the full list of players on the network. Particularly, if I am attempting to ban a player 'Aseef' on the server, but, the player is on a different proxy than me, then the tab completion for the command `/ban Asee` will not autocomplete `Asee` to `Aseef`.

This issue creates the need to allow me to modify command tab completions for other plugins via my own plugins. And that precisely is what this new 'CommandTabCompleteEvent' attempts to solve.