### PR TITLE
Opaque argument types

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
@@ -132,33 +132,32 @@ public interface CommandManager {
   // Opaque argument types
 
   /**
-   * Returns the argument type registered in a Minecraft ≤1.18 client with the given identifier.
+   * Returns a builder to create an {@link OpaqueArgumentType opaque argument type} with
+   * the given string identifier.
    *
-   * @param identifier the namespaced type identifier
-   * @return the opaque argument type, or {@code null} if unknown.
-   * @see #getOpaqueArgumentType(ProtocolVersion, int) to retrieve an argument type using a
-   *         Minecraft 1.19+ numeric identifier.
+   * @param identifier the namespaced type identifier used in Minecraft 1.18 and below.
+   * @return a builder to create an argument type.
+   * @throws IllegalArgumentException if an argument type with the given identifier
+   *                                  cannot be found.
    * @see <a href="https://wiki.vg/Command_Data#Parsers">the list of types</a> known by the client.
+   * @see #opaqueArgumentTypeBuilder(ProtocolVersion, int) to create a builder for a type
+   *         identified by a version-specific numeric identifier (for Minecraft 1.19 and
+   *         above).
    */
   // The ≤1.18 protocols use raw strings as identifiers; use `Key` for a more idiomatic API.
-  @Nullable
-  OpaqueArgumentType getOpaqueArgumentType(final Key identifier);
+  OpaqueArgumentType.Builder opaqueArgumentTypeBuilder(Key identifier);
 
   /**
-   * Returns the argument type registered in a Minecraft client at the given version with
-   * the specified identifier.
-   *
-   * <p>Numeric identifiers were introduced in Minecraft 1.19, hence calling this method with
-   * a lower version always returns {@code null}.
-   *
+   * Returns a builder to create an {@link OpaqueArgumentType opaque argument type} with
+   * the given version-specific numeric identifier.
    * @param version the protocol version for the identifier.
-   * @param identifier the numeric identifier used in {@code version} that refers to the
-   *                   requested argument type.
-   * @return the opaque argument type, or {@code null} if unknown.
-   * @see #getOpaqueArgumentType(Key) to retrieve an argument type using a Minecraft ≤1.18
-   *         namespaced identifier.
+   * @param identifier the numeric identifier used in Minecraft 1.19 and above.
+   * @return a builder to create an argument type.
+   * @throws IllegalArgumentException if an argument type with the given identifier
+   *                                  cannot be found.
    * @see <a href="https://wiki.vg/Command_Data#Parsers">the list of types</a> known by the client.
+   * @see #opaqueArgumentTypeBuilder(Key) to create a builder for a type identified by
+   *         a string identifier (for Minecraft 1.18 and below).
    */
-  @Nullable
-  OpaqueArgumentType getOpaqueArgumentType(final ProtocolVersion version, final int identifier);
+  OpaqueArgumentType.Builder opaqueArgumentTypeBuilder(ProtocolVersion version, int identifier);
 }

--- a/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
@@ -8,10 +8,9 @@
 package com.velocitypowered.api.command;
 
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
+import com.velocitypowered.api.network.ProtocolVersion;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
-
-import com.velocitypowered.api.network.ProtocolVersion;
 import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -137,8 +136,8 @@ public interface CommandManager {
    *
    * @param identifier the namespaced type identifier
    * @return the opaque argument type, or {@code null} if unknown.
-   * @see #getOpaqueArgumentType(ProtocolVersion, int) to retrieve an argument type using a Minecraft
-   *         1.19+ numeric identifier.
+   * @see #getOpaqueArgumentType(ProtocolVersion, int) to retrieve an argument type using a
+   *         Minecraft 1.19+ numeric identifier.
    * @see <a href="https://wiki.vg/Command_Data#Parsers">the list of types</a> known by the client.
    */
   // The ≤1.18 protocols use raw strings as identifiers; use `Key` for a more idiomatic API.
@@ -148,16 +147,16 @@ public interface CommandManager {
   /**
    * Returns the argument type registered in a Minecraft client at the given version with
    * the specified identifier.
-   * <p>
-   * Numeric identifiers were introduced in Minecraft 1.19, hence calling this method with
+   *
+   * <p>Numeric identifiers were introduced in Minecraft 1.19, hence calling this method with
    * a lower version always returns {@code null}.
    *
    * @param version the protocol version for the identifier.
    * @param identifier the numeric identifier used in {@code version} that refers to the
    *                   requested argument type.
    * @return the opaque argument type, or {@code null} if unknown.
-   * @see #getOpaqueArgumentType(Key) to retrieve an argument type using a Minecraft ≤1.18 namespaced
-   *         identifier.
+   * @see #getOpaqueArgumentType(Key) to retrieve an argument type using a Minecraft ≤1.18
+   *         namespaced identifier.
    * @see <a href="https://wiki.vg/Command_Data#Parsers">the list of types</a> known by the client.
    */
   @Nullable

--- a/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
@@ -8,7 +8,6 @@
 package com.velocitypowered.api.command;
 
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
-import com.velocitypowered.api.network.ProtocolVersion;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import net.kyori.adventure.key.Key;
@@ -135,30 +134,15 @@ public interface CommandManager {
    * Returns a builder to create an {@link OpaqueArgumentType opaque argument type} with
    * the given string identifier.
    *
-   * @param identifier the namespaced type identifier used in Minecraft 1.18 and below.
+   * @param identifier the namespaced type identifier (this is officially specified in
+   *                   Minecraft 1.18 and below; for newer versions, the names in the
+   *                   <a href="https://wiki.vg/Command_Data#Parsers">wiki.vg Command Data</a>
+   *                   page are used).
    * @return a builder to create an argument type.
    * @throws IllegalArgumentException if an argument type with the given identifier
    *                                  cannot be found.
    * @see <a href="https://wiki.vg/Command_Data#Parsers">the list of types</a> known by the client.
-   * @see #opaqueArgumentTypeBuilder(ProtocolVersion, int) to create a builder for a type
-   *         identified by a version-specific numeric identifier (for Minecraft 1.19 and
-   *         above).
    */
   // The ≤1.18 protocols use raw strings as identifiers; use `Key` for a more idiomatic API.
   OpaqueArgumentType.Builder opaqueArgumentTypeBuilder(Key identifier);
-
-  /**
-   * Returns a builder to create an {@link OpaqueArgumentType opaque argument type} with
-   * the given version-specific numeric identifier.
-   *
-   * @param version the protocol version for the identifier.
-   * @param identifier the numeric identifier used in Minecraft 1.19 and above.
-   * @return a builder to create an argument type.
-   * @throws IllegalArgumentException if an argument type with the given identifier
-   *                                  cannot be found.
-   * @see <a href="https://wiki.vg/Command_Data#Parsers">the list of types</a> known by the client.
-   * @see #opaqueArgumentTypeBuilder(Key) to create a builder for a type identified by
-   *         a string identifier (for Minecraft 1.18 and below).
-   */
-  OpaqueArgumentType.Builder opaqueArgumentTypeBuilder(ProtocolVersion version, int identifier);
 }

--- a/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
@@ -10,6 +10,9 @@ package com.velocitypowered.api.command;
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+
+import com.velocitypowered.api.network.ProtocolVersion;
+import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -126,4 +129,35 @@ public interface CommandManager {
    * @return true if the alias is registered; false otherwise
    */
   boolean hasCommand(String alias);
+
+  // Opaque argument types
+
+  /**
+   * Returns the argument type registered in a Minecraft ≤1.18 client with the given identifier.
+   *
+   * @param identifier the namespaced type identifier
+   * @return the opaque argument type, or {@code null} if unknown.
+   * @see #getOpaqueArgumentType(ProtocolVersion, int) to retrieve an argument type using a Minecraft
+   *         1.19+ numeric identifier.
+   */
+  // The ≤1.18 protocols use raw strings as identifiers; use `Key` for a more idiomatic API.
+  @Nullable
+  OpaqueArgumentType getOpaqueArgumentType(final Key identifier);
+
+  /**
+   * Returns the argument type registered in a Minecraft client at the given version with
+   * the specified identifier.
+   * <p>
+   * Numeric identifiers were introduced in Minecraft 1.19, hence calling this method with
+   * a lower version always returns {@code null}.
+   *
+   * @param version the protocol version for the identifier.
+   * @param identifier the numeric identifier used in {@code version} that refers to the
+   *                   requested argument type.
+   * @return the opaque argument type, or {@code null} if unknown.
+   * @see #getOpaqueArgumentType(Key) to retrieve an argument type using a Minecraft ≤1.18 namespaced
+   *         identifier.
+   */
+  @Nullable
+  OpaqueArgumentType getOpaqueArgumentType(final ProtocolVersion version, final int identifier);
 }

--- a/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
@@ -150,6 +150,7 @@ public interface CommandManager {
   /**
    * Returns a builder to create an {@link OpaqueArgumentType opaque argument type} with
    * the given version-specific numeric identifier.
+   *
    * @param version the protocol version for the identifier.
    * @param identifier the numeric identifier used in Minecraft 1.19 and above.
    * @return a builder to create an argument type.

--- a/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
@@ -139,6 +139,7 @@ public interface CommandManager {
    * @return the opaque argument type, or {@code null} if unknown.
    * @see #getOpaqueArgumentType(ProtocolVersion, int) to retrieve an argument type using a Minecraft
    *         1.19+ numeric identifier.
+   * @see <a href="https://wiki.vg/Command_Data#Parsers">the list of types</a> known by the client.
    */
   // The ≤1.18 protocols use raw strings as identifiers; use `Key` for a more idiomatic API.
   @Nullable
@@ -157,6 +158,7 @@ public interface CommandManager {
    * @return the opaque argument type, or {@code null} if unknown.
    * @see #getOpaqueArgumentType(Key) to retrieve an argument type using a Minecraft ≤1.18 namespaced
    *         identifier.
+   * @see <a href="https://wiki.vg/Command_Data#Parsers">the list of types</a> known by the client.
    */
   @Nullable
   OpaqueArgumentType getOpaqueArgumentType(final ProtocolVersion version, final int identifier);

--- a/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
+++ b/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
@@ -6,6 +6,8 @@ import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.tree.ArgumentCommandNode;
+import com.velocitypowered.api.network.ProtocolVersion;
+import net.kyori.adventure.key.Key;
 
 /**
  * A Brigadier {@link ArgumentType} recognized by a Minecraft client, but
@@ -13,8 +15,8 @@ import com.mojang.brigadier.tree.ArgumentCommandNode;
  * <p>
  * This class is useful when a plugin wants the client to parse the contents and
  * provide suggestions for an {@link ArgumentCommandNode} according to one of
- * the built-in argument parsers. The following example re-constructs the
- * {@code /give} command node:
+ * the built-in argument parsers. The following example constructs a simplified
+ * version of the {@code /give} command:
  * <pre>
  * CommandManager commandManager = ...;
  * OpaqueArgumentType itemType = commandManager.getOpaqueArgumentType(Key.key("item_stack"));
@@ -24,10 +26,9 @@ import com.mojang.brigadier.tree.ArgumentCommandNode;
  *         .build();
  * </pre>
  * <p>
- * The execution of an argument node of this type is automatically forwarded
- * to the backend server. Thus, any {@link com.mojang.brigadier.Command},
- * predicate, redirection, or {@link SuggestionProvider} on the corresponding
- * node is ignored.
+ * The execution of an {@link ArgumentCommandNode} of this type is automatically
+ * forwarded to the backend server. Thus, any {@link com.mojang.brigadier.Command},
+ * predicate, or {@link SuggestionProvider} on the corresponding node is ignored.
  * <p>
  * Parsing of a command by Brigadier ends whenever a node with an opaque type is
  * encountered. For this reason, any {@link ParseResults} containing an argument
@@ -36,6 +37,11 @@ import com.mojang.brigadier.tree.ArgumentCommandNode;
  * <p>
  * This type provides no suggestions nor examples. However, the client can often
  * provide rich suggestions for the represented argument type.
+ *
+ * @see CommandManager#getOpaqueArgumentType(Key) to obtain an argument type by
+ *        its string identifier (used in Minecraft 1.18 and below).
+ * @see CommandManager#getOpaqueArgumentType(ProtocolVersion, int) to obtain an argument
+ *        type by its version-dependent numeric identifier (used in Minecraft 1.19 and above).
  */
 public interface OpaqueArgumentType extends ArgumentType<Void> {
 

--- a/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
+++ b/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
@@ -10,30 +10,30 @@ import net.kyori.adventure.key.Key;
 /**
  * A Brigadier {@link ArgumentType} recognized by a Minecraft client, but
  * that provides no parsing nor suggestion provision logic in the proxy.
- * <p>
- * This class is useful when a plugin wants the client to parse the contents and
+ *
+ * <p>This class is useful when a plugin wants the client to parse the contents and
  * provide suggestions for an {@link ArgumentCommandNode} according to one of
  * the built-in argument parsers. The following example constructs a simplified
  * version of the {@code /give} command:
  * <pre>
  * CommandManager commandManager = ...;
  * OpaqueArgumentType itemType = commandManager.getOpaqueArgumentType(Key.key("item_stack"));
- * final LiteralCommandNode<CommandSource> literal = LiteralArgumentBuilder
- *         .<CommandSource>literal("give")
+ * final LiteralCommandNode&lt;CommandSource&gt; literal = LiteralArgumentBuilder
+ *         .&lt;CommandSource&gt;literal("give")
  *         .then(argument("item", itemType))
  *         .build();
  * </pre>
- * <p>
- * The execution of an {@link ArgumentCommandNode} of this type is automatically
+ *
+ * <p>The execution of an {@link ArgumentCommandNode} of this type is automatically
  * forwarded to the backend server. Thus, any {@link com.mojang.brigadier.Command},
  * predicate, or {@link SuggestionProvider} on the corresponding node is ignored.
- * <p>
- * Parsing of a command by Brigadier ends whenever a node with an opaque type is
+ *
+ * <p>Parsing of a command by Brigadier ends whenever a node with an opaque type is
  * encountered. For this reason, any {@link ParseResults} containing an argument
  * node with an opaque type may contain inaccurate data. This is a compromise
  * that must be made because the proxy does not know how to parse these types.
- * <p>
- * This type provides no suggestions nor examples. However, the client can often
+ *
+ * <p>This type provides no suggestions nor examples. However, the client can often
  * provide rich suggestions for the represented argument type.
  *
  * @see CommandManager#getOpaqueArgumentType(Key) to obtain an argument type by

--- a/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
+++ b/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
@@ -12,7 +12,6 @@ import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.tree.ArgumentCommandNode;
 import com.velocitypowered.api.network.ProtocolVersion;
-import javax.annotation.Nullable;
 import net.kyori.adventure.key.Key;
 
 /**
@@ -55,30 +54,16 @@ import net.kyori.adventure.key.Key;
  * removed in {@link ProtocolVersion#MINECRAFT_1_19_3}.
  *
  * @see CommandManager#opaqueArgumentTypeBuilder(Key) to construct an argument type from
- *        its string identifier (used in Minecraft 1.18 and below).
- * @see CommandManager#opaqueArgumentTypeBuilder(ProtocolVersion, int) to construct an argument
- *        type from its version-dependent numeric identifier (used in Minecraft 1.19 and above).
+ *        its string identifier.
  */
 public interface OpaqueArgumentType extends ArgumentType<Void> {
 
   /**
-   * Returns the argument parser identifier used in Minecraft 1.18 and below.
+   * Returns the argument parser identifier.
    *
-   * @return the string identifier, or {@code null} if the type was introduced in
-   *         Minecraft 1.19 or above (and so a string identifier has not been
-   *         specified for the parser).
+   * @return the string identifier.
    */
-  @Nullable String getIdentifier();
-
-  /**
-   * Returns the argument parser identifier used in the given version (for
-   * Minecraft 1.19 and above).
-   *
-   * @param version the protocol version for the parser identifier
-   * @return the numeric identifier used in the given version, or {@code null} if
-   *         no numeric identifier was assigned to the parser in that version.
-   */
-  @Nullable Integer getIdentifier(ProtocolVersion version);
+  String getIdentifier();
 
   /**
    * Returns the parser properties in serialized form, following the protocol

--- a/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
+++ b/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
@@ -1,16 +1,11 @@
 package com.velocitypowered.api.command;
 
+import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.arguments.ArgumentType;
-import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
-import com.mojang.brigadier.suggestion.Suggestions;
-import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import com.mojang.brigadier.tree.ArgumentCommandNode;
-
-import java.util.Collection;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * A Brigadier {@link ArgumentType} recognized by a Minecraft client, but
@@ -34,8 +29,13 @@ import java.util.concurrent.CompletableFuture;
  * predicate, redirection, or {@link SuggestionProvider} on the corresponding
  * node is ignored.
  * <p>
- * Executing any methods from the {@link ArgumentType} interface on this class
- * result in a {@link UnsupportedOperationException} being thrown.
+ * Parsing of a command by Brigadier ends whenever a node with an opaque type is
+ * encountered. For this reason, any {@link ParseResults} containing an argument
+ * node with an opaque type may contain inaccurate data. This is a compromise
+ * that must be made because the proxy does not know how to parse these types.
+ * <p>
+ * This type provides no suggestions nor examples. However, the client can often
+ * provide rich suggestions for the represented argument type.
  */
 public interface OpaqueArgumentType extends ArgumentType<Void> {
 
@@ -45,16 +45,8 @@ public interface OpaqueArgumentType extends ArgumentType<Void> {
 
   @Override
   default Void parse(StringReader reader) throws CommandSyntaxException {
-    throw new UnsupportedOperationException("Opaque type doesn't support argument parsing");
-  }
-
-  @Override
-  default <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) {
-    throw new UnsupportedOperationException("Opaque type doesn't support suggestion provision");
-  }
-
-  @Override
-  default Collection<String> getExamples() {
-    throw new UnsupportedOperationException("Opaque type doesn't have any examples");
+    // Consume all the input to halt parsing by Brigadier.
+    reader.setCursor(reader.getTotalLength());
+    return null;
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
+++ b/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
@@ -1,0 +1,60 @@
+package com.velocitypowered.api.command;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import com.mojang.brigadier.tree.ArgumentCommandNode;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A Brigadier {@link ArgumentType} recognized by a Minecraft client, but
+ * that provides no parsing nor suggestion provision logic in the proxy.
+ * <p>
+ * This class is useful when a plugin wants the client to parse the contents and
+ * provide suggestions for an {@link ArgumentCommandNode} according to one of
+ * the built-in argument parsers. The following example re-constructs the
+ * {@code /give} command node:
+ * <pre>
+ * CommandManager commandManager = ...;
+ * OpaqueArgumentType itemType = commandManager.getOpaqueArgumentType(Key.key("item_stack"));
+ * final LiteralCommandNode<CommandSource> literal = LiteralArgumentBuilder
+ *         .<CommandSource>literal("give")
+ *         .then(argument("item", itemType))
+ *         .build();
+ * </pre>
+ * <p>
+ * The execution of an argument node of this type is automatically forwarded
+ * to the backend server. Thus, any {@link com.mojang.brigadier.Command},
+ * predicate, redirection, or {@link SuggestionProvider} on the corresponding
+ * node is ignored.
+ * <p>
+ * Executing any methods from the {@link ArgumentType} interface on this class
+ * result in a {@link UnsupportedOperationException} being thrown.
+ */
+public interface OpaqueArgumentType extends ArgumentType<Void> {
+
+  // We don't provide a way to retrieve the identifiers, since these are version-dependent
+  // and their type has changed from a string to a numerical value in Minecraft 1.19.
+  // This prevents API breakage if Mojang were to change their format yet again.
+
+  @Override
+  default Void parse(StringReader reader) throws CommandSyntaxException {
+    throw new UnsupportedOperationException("Opaque type doesn't support argument parsing");
+  }
+
+  @Override
+  default <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) {
+    throw new UnsupportedOperationException("Opaque type doesn't support suggestion provision");
+  }
+
+  @Override
+  default Collection<String> getExamples() {
+    throw new UnsupportedOperationException("Opaque type doesn't have any examples");
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
+++ b/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2023 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
 package com.velocitypowered.api.command;
 
 import com.mojang.brigadier.ParseResults;

--- a/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
+++ b/api/src/main/java/com/velocitypowered/api/command/OpaqueArgumentType.java
@@ -1,9 +1,7 @@
 package com.velocitypowered.api.command;
 
 import com.mojang.brigadier.ParseResults;
-import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.arguments.ArgumentType;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.tree.ArgumentCommandNode;
 import com.velocitypowered.api.network.ProtocolVersion;
@@ -44,15 +42,7 @@ import net.kyori.adventure.key.Key;
  *        type by its version-dependent numeric identifier (used in Minecraft 1.19 and above).
  */
 public interface OpaqueArgumentType extends ArgumentType<Void> {
-
   // We don't provide a way to retrieve the identifiers, since these are version-dependent
   // and their type has changed from a string to a numerical value in Minecraft 1.19.
   // This prevents API breakage if Mojang were to change their format yet again.
-
-  @Override
-  default Void parse(StringReader reader) throws CommandSyntaxException {
-    // Consume all the input to halt parsing by Brigadier.
-    reader.setCursor(reader.getTotalLength());
-    return null;
-  }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/SuggestionsProvider.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/SuggestionsProvider.java
@@ -200,6 +200,9 @@ final class SuggestionsProvider<S> {
       reader.setCursor(0);
       final ParseResults<S> parse = this.dispatcher.parse(reader, source);
       try {
+        // We don't know how to provide suggestions for a command that
+        // contains an argument with an opaque type. However, the client
+        // will not ask the server for these types of suggestions.
         return this.dispatcher.getCompletionSuggestions(parse);
       } catch (final Throwable e) {
         // Ugly, ugly swallowing of everything Throwable, because plugins are naughty.

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -27,13 +27,10 @@ import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
-import com.velocitypowered.api.command.BrigadierCommand;
-import com.velocitypowered.api.command.Command;
-import com.velocitypowered.api.command.CommandManager;
-import com.velocitypowered.api.command.CommandMeta;
-import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.*;
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
 import com.velocitypowered.api.event.command.CommandExecuteEvent.CommandResult;
+import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.command.registrar.BrigadierCommandRegistrar;
 import com.velocitypowered.proxy.command.registrar.CommandRegistrar;
 import com.velocitypowered.proxy.command.registrar.RawCommandRegistrar;
@@ -47,7 +44,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentPropertyRegistry;
 import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.checkerframework.checker.lock.qual.GuardedBy;
@@ -330,5 +330,15 @@ public class VelocityCommandManager implements CommandManager {
 
   public CommandGraphInjector<CommandSource> getInjector() {
     return injector;
+  }
+
+  @Override
+  public @Nullable OpaqueArgumentType getOpaqueArgumentType(Key identifier) {
+    return ArgumentPropertyRegistry.getOldIdentifier(identifier.asString());
+  }
+
+  @Override
+  public @Nullable OpaqueArgumentType getOpaqueArgumentType(ProtocolVersion version, int identifier) {
+    return ArgumentPropertyRegistry.getNewIdentifier(version, identifier);
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -41,7 +41,7 @@ import com.velocitypowered.proxy.command.registrar.CommandRegistrar;
 import com.velocitypowered.proxy.command.registrar.RawCommandRegistrar;
 import com.velocitypowered.proxy.command.registrar.SimpleCommandRegistrar;
 import com.velocitypowered.proxy.event.VelocityEventManager;
-import com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentPropertyRegistry;
+import com.velocitypowered.proxy.protocol.packet.brigadier.OpaqueArgumentTypeImpl;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -346,12 +346,12 @@ public class VelocityCommandManager implements CommandManager {
 
   @Override
   public @Nullable OpaqueArgumentType getOpaqueArgumentType(Key identifier) {
-    return ArgumentPropertyRegistry.getOldIdentifier(identifier.asString());
+    return OpaqueArgumentTypeImpl.from(identifier.asString());
   }
 
   @Override
   public @Nullable OpaqueArgumentType getOpaqueArgumentType(ProtocolVersion version,
                                                             int identifier) {
-    return ArgumentPropertyRegistry.getNewIdentifier(version, identifier);
+    return OpaqueArgumentTypeImpl.from(version, identifier);
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -41,7 +41,9 @@ import com.velocitypowered.proxy.command.registrar.CommandRegistrar;
 import com.velocitypowered.proxy.command.registrar.RawCommandRegistrar;
 import com.velocitypowered.proxy.command.registrar.SimpleCommandRegistrar;
 import com.velocitypowered.proxy.event.VelocityEventManager;
-import com.velocitypowered.proxy.protocol.packet.brigadier.OpaqueArgumentTypeImpl;
+import com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentIdentifier;
+import com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentPropertyRegistry;
+import com.velocitypowered.proxy.protocol.packet.brigadier.OpaqueArgumentTypeBuilderImpl;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -345,13 +347,22 @@ public class VelocityCommandManager implements CommandManager {
   }
 
   @Override
-  public @Nullable OpaqueArgumentType getOpaqueArgumentType(Key identifier) {
-    return OpaqueArgumentTypeImpl.from(identifier.asString());
+  public OpaqueArgumentType.Builder opaqueArgumentTypeBuilder(final Key identifier) {
+    final ArgumentIdentifier id = ArgumentPropertyRegistry.getOldIdentifier(identifier.asString());
+    if (id == null) {
+      throw new IllegalArgumentException("Unknown vanilla parser \"" + identifier + "\"");
+    }
+    return new OpaqueArgumentTypeBuilderImpl(id);
   }
 
   @Override
-  public @Nullable OpaqueArgumentType getOpaqueArgumentType(ProtocolVersion version,
-                                                            int identifier) {
-    return OpaqueArgumentTypeImpl.from(version, identifier);
+  public OpaqueArgumentType.Builder opaqueArgumentTypeBuilder(final ProtocolVersion version,
+                                                              final int identifier) {
+    final ArgumentIdentifier id = ArgumentPropertyRegistry.getNewIdentifier(version, identifier);
+    if (id == null) {
+      throw new IllegalArgumentException("Unknown vanilla parser with ID " + identifier
+          + " at version " + version);
+    }
+    return new OpaqueArgumentTypeBuilderImpl(id);
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -25,7 +25,6 @@ import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.brigadier.suggestion.Suggestions;
-import com.mojang.brigadier.tree.ArgumentCommandNode;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
 import com.velocitypowered.api.command.BrigadierCommand;

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -35,7 +35,6 @@ import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.command.OpaqueArgumentType;
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
 import com.velocitypowered.api.event.command.CommandExecuteEvent.CommandResult;
-import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.command.registrar.BrigadierCommandRegistrar;
 import com.velocitypowered.proxy.command.registrar.CommandRegistrar;
 import com.velocitypowered.proxy.command.registrar.RawCommandRegistrar;
@@ -348,20 +347,9 @@ public class VelocityCommandManager implements CommandManager {
 
   @Override
   public OpaqueArgumentType.Builder opaqueArgumentTypeBuilder(final Key identifier) {
-    final ArgumentIdentifier id = ArgumentPropertyRegistry.getOldIdentifier(identifier.asString());
+    final ArgumentIdentifier id = ArgumentPropertyRegistry.getIdentifier(identifier.asString());
     if (id == null) {
       throw new IllegalArgumentException("Unknown vanilla parser \"" + identifier + "\"");
-    }
-    return new OpaqueArgumentTypeBuilderImpl(id);
-  }
-
-  @Override
-  public OpaqueArgumentType.Builder opaqueArgumentTypeBuilder(final ProtocolVersion version,
-                                                              final int identifier) {
-    final ArgumentIdentifier id = ArgumentPropertyRegistry.getNewIdentifier(version, identifier);
-    if (id == null) {
-      throw new IllegalArgumentException("Unknown vanilla parser with ID " + identifier
-          + " at version " + version);
     }
     return new OpaqueArgumentTypeBuilderImpl(id);
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommands.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommands.java
@@ -19,11 +19,13 @@ package com.velocitypowered.proxy.command;
 
 import com.google.common.base.Preconditions;
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.CommandContextBuilder;
 import com.mojang.brigadier.context.ParsedArgument;
 import com.mojang.brigadier.context.ParsedCommandNode;
+import com.mojang.brigadier.tree.ArgumentCommandNode;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
@@ -31,6 +33,7 @@ import com.velocitypowered.api.command.Command;
 import com.velocitypowered.api.command.CommandManager;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.command.InvocableCommand;
+import com.velocitypowered.api.command.OpaqueArgumentType;
 import com.velocitypowered.proxy.command.brigadier.VelocityArgumentCommandNode;
 import java.util.List;
 import java.util.Locale;
@@ -183,6 +186,26 @@ public final class VelocityCommands {
    */
   public static boolean isArgumentsNode(final CommandNode<?> node) {
     return node instanceof VelocityArgumentCommandNode && node.getName().equals(ARGS_NODE_NAME);
+  }
+
+  /**
+   * Returns whether the given parse results contain a parsed argument node whose
+   * type is {@link OpaqueArgumentType opaque}. The contents of such node cannot
+   * be parsed in the proxy.
+   *
+   * @param parse the parse results
+   * @return {@code true} if and only if the results contain an argument node whose type
+   *         is opaque.
+   */
+  static boolean containsArgumentWithOpaqueType(final ParseResults<?> parse) {
+    for (final var node : parse.getContext().getNodes()) {
+      if (node.getNode() instanceof ArgumentCommandNode<?, ?>) {
+        if (((ArgumentCommandNode<?, ?>) node.getNode()).getType() instanceof OpaqueArgumentType) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private VelocityCommands() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentIdentifier.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentIdentifier.java
@@ -19,12 +19,13 @@ package com.velocitypowered.proxy.protocol.packet.brigadier;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.velocitypowered.api.command.OpaqueArgumentType;
 import com.velocitypowered.api.network.ProtocolVersion;
 import java.util.HashMap;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class ArgumentIdentifier {
+public class ArgumentIdentifier implements OpaqueArgumentType {
 
   private final String identifier;
   private final Map<ProtocolVersion, Integer> versionById;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentIdentifier.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentIdentifier.java
@@ -19,13 +19,12 @@ package com.velocitypowered.proxy.protocol.packet.brigadier;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.velocitypowered.api.command.OpaqueArgumentType;
 import com.velocitypowered.api.network.ProtocolVersion;
 import java.util.HashMap;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class ArgumentIdentifier implements OpaqueArgumentType {
+public class ArgumentIdentifier {
 
   private final String identifier;
   private final Map<ProtocolVersion, Integer> versionById;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
@@ -117,6 +117,7 @@ public class ArgumentPropertyRegistry {
     } else if (type instanceof OpaqueArgumentTypeImpl) {
       OpaqueArgumentTypeImpl opaqueType = (OpaqueArgumentTypeImpl) type;
       writeIdentifier(buf, opaqueType.getIdentifier(), protocolVersion);
+      // todo: serialize properties
     } else {
       ArgumentPropertySerializer serializer = byClass.get(type.getClass());
       ArgumentIdentifier id = classToId.get(type.getClass());

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
@@ -114,6 +114,9 @@ public class ArgumentPropertyRegistry {
       ModArgumentProperty property = (ModArgumentProperty) type;
       writeIdentifier(buf, property.getIdentifier(), protocolVersion);
       buf.writeBytes(property.getData());
+    } else if (type instanceof OpaqueArgumentTypeImpl) {
+      OpaqueArgumentTypeImpl opaqueType = (OpaqueArgumentTypeImpl) type;
+      writeIdentifier(buf, opaqueType.getIdentifier(), protocolVersion);
     } else {
       ArgumentPropertySerializer serializer = byClass.get(type.getClass());
       ArgumentIdentifier id = classToId.get(type.getClass());

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
@@ -150,34 +150,17 @@ public class ArgumentPropertyRegistry {
 
   }
 
-
-  /**
-   * Returns the identifier with the given numeric identifier at the specified version.
-   *
-   * @param version the version for the identifier.
-   * @param id the numeric identifier used in {@code version}.
-   * @return the identifier, or {@code null} if unknown.
-   */
-  public static @Nullable ArgumentIdentifier getNewIdentifier(final ProtocolVersion version, final int id) {
-    for (ArgumentIdentifier i : byIdentifier.keySet()) {
-      Integer v = i.getIdByProtocolVersion(version);
-      if (v != null && v == id) {
-        return i;
-      }
-    }
-    return null;
-  }
-
   /**
    * Returns the identifier with the given string identifier.
    *
    * @param raw the string identifier.
    * @return the identifier, or {@code null} if unknown.
    */
-  public static @Nullable ArgumentIdentifier getOldIdentifier(final String raw) {
+  public static @Nullable ArgumentIdentifier getIdentifier(final String raw) {
     for (ArgumentIdentifier i : byIdentifier.keySet()) {
-      // 1.19+ identifiers might not have a string form.
-      if (raw.equals(i.getIdentifier())) {
+      // Even if 1.19+ identifiers don't have an official string form,
+      // we follow the names given in https://wiki.vg/Command_Data#Parsers.
+      if (i.getIdentifier().equals(raw)) {
         return i;
       }
     }
@@ -194,10 +177,16 @@ public class ArgumentPropertyRegistry {
   public static ArgumentIdentifier readIdentifier(ByteBuf buf, ProtocolVersion protocolVersion) {
     if (protocolVersion.compareTo(MINECRAFT_1_19) >= 0) {
       int id = ProtocolUtils.readVarInt(buf);
-      return getNewIdentifier(protocolVersion, id);
+      for (ArgumentIdentifier i : byIdentifier.keySet()) {
+        Integer v = i.getIdByProtocolVersion(protocolVersion);
+        if (v != null && v == id) {
+          return i;
+        }
+      }
+      return null;
     } else {
       String identifier = ProtocolUtils.readString(buf);
-      return getOldIdentifier(identifier);
+      return getIdentifier(identifier);
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
@@ -116,8 +116,8 @@ public class ArgumentPropertyRegistry {
       buf.writeBytes(property.getData());
     } else if (type instanceof OpaqueArgumentTypeImpl) {
       OpaqueArgumentTypeImpl opaqueType = (OpaqueArgumentTypeImpl) type;
-      writeIdentifier(buf, opaqueType.getIdentifier(), protocolVersion);
-      // todo: serialize properties
+      writeIdentifier(buf, opaqueType.identifier(), protocolVersion);
+      buf.writeBytes(opaqueType.getProperties(protocolVersion));
     } else {
       ArgumentPropertySerializer serializer = byClass.get(type.getClass());
       ArgumentIdentifier id = classToId.get(type.getClass());

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/OpaqueArgumentTypeBuilderImpl.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/OpaqueArgumentTypeBuilderImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2018-2023 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.protocol.packet.brigadier;
+
+import static java.util.Objects.requireNonNull;
+
+import com.velocitypowered.api.command.OpaqueArgumentType;
+
+public final class OpaqueArgumentTypeBuilderImpl implements OpaqueArgumentType.Builder {
+
+  private static final OpaqueArgumentType.PropertySerializer PROPERTY_LESS = version -> new byte[0];
+
+  private final ArgumentIdentifier identifier;
+  private OpaqueArgumentType.PropertySerializer propSerializer;
+
+  public OpaqueArgumentTypeBuilderImpl(final ArgumentIdentifier identifier) {
+    this.identifier = requireNonNull(identifier);
+  }
+
+  @Override
+  public OpaqueArgumentType.Builder withProperties(OpaqueArgumentType.PropertySerializer serializer) {
+    this.propSerializer = requireNonNull(serializer);
+    return this;
+  }
+
+  @Override
+  public OpaqueArgumentType build() {
+    return new OpaqueArgumentTypeImpl(
+        this.identifier, this.propSerializer != null ? this.propSerializer : PROPERTY_LESS);
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/OpaqueArgumentTypeImpl.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/OpaqueArgumentTypeImpl.java
@@ -24,7 +24,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.velocitypowered.api.command.OpaqueArgumentType;
 import com.velocitypowered.api.network.ProtocolVersion;
 import java.util.Objects;
-import org.jetbrains.annotations.Nullable;
 
 class OpaqueArgumentTypeImpl implements OpaqueArgumentType {
 
@@ -55,16 +54,9 @@ class OpaqueArgumentTypeImpl implements OpaqueArgumentType {
     return this.identifier;
   }
 
-  @Nullable
   @Override
   public String getIdentifier() {
     return this.identifier.getIdentifier();
-  }
-
-  @Nullable
-  @Override
-  public Integer getIdentifier(final ProtocolVersion version) {
-    return this.identifier.getIdByProtocolVersion(version);
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/OpaqueArgumentTypeImpl.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/OpaqueArgumentTypeImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2021-2023 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.protocol.packet.brigadier;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.velocitypowered.api.command.OpaqueArgumentType;
+import com.velocitypowered.api.network.ProtocolVersion;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+public final class OpaqueArgumentTypeImpl implements OpaqueArgumentType {
+
+  public static @Nullable OpaqueArgumentType from(final String identifier) {
+    final ArgumentIdentifier id = ArgumentPropertyRegistry.getOldIdentifier(identifier);
+    if (id != null) {
+      return new OpaqueArgumentTypeImpl(id);
+    }
+    return null;
+  }
+
+  public static @Nullable OpaqueArgumentType from(final ProtocolVersion version, final int identifier) {
+    final ArgumentIdentifier id = ArgumentPropertyRegistry.getNewIdentifier(version, identifier);
+    if (id != null) {
+      return new OpaqueArgumentTypeImpl(id);
+    }
+    return null;
+  }
+
+  private final ArgumentIdentifier identifier;
+
+  private OpaqueArgumentTypeImpl(final ArgumentIdentifier identifier) {
+    this.identifier = identifier;
+  }
+
+  @Override
+  public Void parse(StringReader reader) throws CommandSyntaxException {
+    // Consume all the input to halt parsing by Brigadier.
+    reader.setCursor(reader.getTotalLength());
+    return null;
+  }
+
+  ArgumentIdentifier getIdentifier() {
+    return identifier;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    OpaqueArgumentTypeImpl that = (OpaqueArgumentTypeImpl) o;
+    return Objects.equals(identifier, that.identifier);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(identifier);
+  }
+
+  @Override
+  public String toString() {
+    return "OpaqueArgumentTypeImpl{" + identifier + '}';
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/OpaqueArgumentTypeImpl.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/OpaqueArgumentTypeImpl.java
@@ -40,6 +40,13 @@ class OpaqueArgumentTypeImpl implements OpaqueArgumentType {
   @Override
   public Void parse(StringReader reader) throws CommandSyntaxException {
     // Consume all the input to halt parsing by Brigadier.
+    // We could instead throw an `UnsupportedOperationException`, but this is
+    // much more expensive since Brigadier constructs custom error types, fills
+    // in the stack trace, and wraps the message in a `Message` class. We could
+    // then search for the exception in VelocityCommandManager. It is easier to
+    // consume all the input so Brigadier returns parse results containing the
+    // node with this argument type, which we can search for iterating over
+    // the nodes of the parse results (see VelocityCommands#containsArgumentWithOpaqueType).
     reader.setCursor(reader.getTotalLength());
     return null;
   }

--- a/proxy/src/test/java/com/velocitypowered/proxy/command/BrigadierCommandTests.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/command/BrigadierCommandTests.java
@@ -29,9 +29,11 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.velocitypowered.api.command.BrigadierCommand;
 import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.OpaqueArgumentType;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import net.kyori.adventure.key.Key;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -348,5 +350,44 @@ public class BrigadierCommandTests extends CommandTestSuite {
 
     assertThrows(CompletionException.class, () ->
         manager.offerSuggestions(source, "parent ").join());
+  }
+
+  // Opaque argument types
+
+  @Test
+  void testExecuteIsForwardedIfArgumentHasOpaqueType() {
+    final OpaqueArgumentType itemType = manager.getOpaqueArgumentType(Key.key("item_stack"));
+    final var node = LiteralArgumentBuilder
+        .<CommandSource>literal("give")
+        .then(RequiredArgumentBuilder.argument("give", itemType))
+        .build();
+    manager.register(new BrigadierCommand(node));
+
+    assertForwarded("give minecraft:grass");
+  }
+
+  @Test
+  void testCommandIsNotCalledIfItHasOpaqueType() {
+    final OpaqueArgumentType posType = manager.getOpaqueArgumentType(Key.key("block_pos"));
+    final var node = LiteralArgumentBuilder
+        .<CommandSource>literal("teleport")
+        .then(RequiredArgumentBuilder.<CommandSource, Void>argument("block", posType)
+            .executes(context -> fail()))
+        .build();
+    manager.register(new BrigadierCommand(node));
+
+    assertForwarded("teleport 0.25 2 -5");
+  }
+
+  @Test
+  void testDoesNotSuggestIfArgumentHasOpaqueType() {
+    final OpaqueArgumentType colorType = manager.getOpaqueArgumentType(Key.key("minecraft:color"));
+    final var node = LiteralArgumentBuilder
+        .<CommandSource>literal("paint")
+        .then(RequiredArgumentBuilder.argument("paint", colorType))
+        .build();
+    manager.register(new BrigadierCommand(node));
+
+    assertSuggestions("paint ");
   }
 }

--- a/proxy/src/test/java/com/velocitypowered/proxy/command/BrigadierCommandTests.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/command/BrigadierCommandTests.java
@@ -356,7 +356,8 @@ public class BrigadierCommandTests extends CommandTestSuite {
 
   @Test
   void testExecuteIsForwardedIfArgumentHasOpaqueType() {
-    final OpaqueArgumentType itemType = manager.getOpaqueArgumentType(Key.key("item_stack"));
+    final OpaqueArgumentType itemType =
+        manager.opaqueArgumentTypeBuilder(Key.key("item_stack")).build();
     final var node = LiteralArgumentBuilder
         .<CommandSource>literal("give")
         .then(RequiredArgumentBuilder.argument("give", itemType))
@@ -368,7 +369,8 @@ public class BrigadierCommandTests extends CommandTestSuite {
 
   @Test
   void testCommandIsNotCalledIfItHasOpaqueType() {
-    final OpaqueArgumentType posType = manager.getOpaqueArgumentType(Key.key("block_pos"));
+    final OpaqueArgumentType posType =
+        manager.opaqueArgumentTypeBuilder(Key.key("block_pos")).build();
     final var node = LiteralArgumentBuilder
         .<CommandSource>literal("teleport")
         .then(RequiredArgumentBuilder.<CommandSource, Void>argument("block", posType)
@@ -376,18 +378,28 @@ public class BrigadierCommandTests extends CommandTestSuite {
         .build();
     manager.register(new BrigadierCommand(node));
 
-    assertForwarded("teleport 0.25 2 -5");
+    assertForwarded("teleport 0 2 -5");
   }
 
   @Test
   void testDoesNotSuggestIfArgumentHasOpaqueType() {
-    final OpaqueArgumentType colorType = manager.getOpaqueArgumentType(Key.key("minecraft:color"));
+    final OpaqueArgumentType colorType =
+        manager.opaqueArgumentTypeBuilder(Key.key("color")).build();
     final var node = LiteralArgumentBuilder
         .<CommandSource>literal("paint")
-        .then(RequiredArgumentBuilder.argument("paint", colorType))
+        .then(RequiredArgumentBuilder.argument("color", colorType))
         .build();
     manager.register(new BrigadierCommand(node));
 
     assertSuggestions("paint ");
+
+    final var otherNode = LiteralArgumentBuilder
+        .<CommandSource>literal("paintWithSuggestionProvider")
+        .then(RequiredArgumentBuilder.<CommandSource, Void>argument("color", colorType)
+            .suggests((context, builder) -> fail()))
+        .build();
+    manager.register(new BrigadierCommand(otherNode));
+
+    assertSuggestions("paintWithSuggestionProvider ");
   }
 }

--- a/proxy/src/test/java/com/velocitypowered/proxy/command/CommandManagerTests.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/command/CommandManagerTests.java
@@ -241,24 +241,12 @@ public class CommandManagerTests extends CommandTestSuite {
   // Opaque argument types
 
   @Test
-  void testCreateOpaqueArgumentTypeByOldId() {
+  void testCreateOpaqueArgumentType() {
     final var type = manager.opaqueArgumentTypeBuilder(Key.key("item_stack")).build();
 
     assertEquals("minecraft:item_stack", type.getIdentifier());
-    assertEquals(14, type.getIdentifier(ProtocolVersion.MINECRAFT_1_19_3));
     assertEquals(0, type.getProperties(ProtocolVersion.MINECRAFT_1_18_2).length);
     assertEquals(0, type.getProperties(ProtocolVersion.MINECRAFT_1_19_3).length);
-  }
-
-  @Test
-  void testCreateOpaqueArgumentTypeByNewId() {
-    final var type = manager.opaqueArgumentTypeBuilder(ProtocolVersion.MINECRAFT_1_19_3, 26)
-        .build();
-
-    assertEquals("minecraft:angle", type.getIdentifier());
-    assertEquals(26, type.getIdentifier(ProtocolVersion.MINECRAFT_1_19_3));
-    assertEquals(0, type.getProperties(ProtocolVersion.MINECRAFT_1_19_3).length);
-    assertEquals(0, type.getProperties(ProtocolVersion.MINECRAFT_1_18_2).length);
   }
 
   @Test

--- a/proxy/src/test/java/com/velocitypowered/proxy/command/CommandManagerTests.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/command/CommandManagerTests.java
@@ -19,6 +19,7 @@ package com.velocitypowered.proxy.command;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,8 +30,10 @@ import com.velocitypowered.api.command.BrigadierCommand;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.command.RawCommand;
 import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.network.ProtocolVersion;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import net.kyori.adventure.key.Key;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -233,5 +236,25 @@ public class CommandManagerTests extends CommandTestSuite {
     public boolean hasPermission(final Invocation invocation) {
       return fail();
     }
+  }
+
+  // Opaque argument types
+
+  @Test
+  void testGetOpaqueArgumentTypeByOldId() {
+    assertNotNull(manager.getOpaqueArgumentType(Key.key("item_stack")),
+        "Retrieve the minecraft:item_stack parser type");
+    assertNull(manager.getOpaqueArgumentType(Key.key("unknown_type")),
+        "Returns null for unassigned string identifier");
+  }
+
+  @Test
+  void testGetOpaqueArgumentTypeByNewId() {
+    assertNotNull(manager.getOpaqueArgumentType(ProtocolVersion.MINECRAFT_1_19, 6),
+        "Retrieve the minecraft:entity parser type");
+    assertNull(manager.getOpaqueArgumentType(ProtocolVersion.MINECRAFT_1_7_2, 1),
+        "Protocols <=1.18 use string identifiers");
+    assertNull(manager.getOpaqueArgumentType(ProtocolVersion.MINECRAFT_1_19_1, 100),
+        "Returns null for unassigned numeric identifier");
   }
 }


### PR DESCRIPTION
This introduces the `OpaqueArgumentType` interface, that is useful when a plugin wants the client to parse the contents and provide suggestions for an `ArgumentCommandNode` according to one of the [built-in argument parsers](https://wiki.vg/Command_Data#Parsers). The following example constructs a simplified version of the `/give` command:
```java
CommandManager commandManager = ...;
OpaqueArgumentType itemType = commandManager.getOpaqueArgumentType(Key.key("item_stack"));
final LiteralCommandNode<CommandSource> literal = LiteralArgumentBuilder
        .<CommandSource>literal("give")
        .then(argument("item", itemType))
        .build();
```

The execution of a command whose parse results contain an argument node with an opaque type is automatically forwarded to the backend server (since the proxy doesn't know how to actually parse the argument). This is done by forcing an opaque type to consume all of the remaining input. `VelocityCommandManager` then checks if the parse results contain such a node, and if so returns `false` in `executeCommand`. The suggestion provider needs no changes, since the suggestions of an opaque argument type are already provided by the client, which doesn't ask the server.

We provide ~~two~~ one way to obtain an `OpaqueArgumentType`: ~~either~~ by its Minecraft <=1.18 string identifier, ~~or by its Minecraft >=1.19 version-dependent numeric identifier~~. The registration on the `ArgumentPropertyRegistry` class is reused. ~~The `OpaqueArgumentType` provides no methods to retrieve the string nor numeric identifiers directly; it is unlikely for a plugin to need access to these methods, and it prevents breaking the API if Mojang decides to change the identifier format yet again.~~

## ~~Remaining work~~
~~We only handle property-less parser types for now; We could unify opaque types with `ModArgumentProperty` once we figure out how we want API users to specify these properties. Perhaps a builder with `writeVarint/Double/String/etc.` methods could work? This might be going too far, however. At which point are we just rewriting buffer accessors? The API doesn't have access to Netty `ByteBuf`s, but regular `byte[]`s or `ByteBuffer`s could do the job. This is further motivated by the small size of the properties for all vanilla parser types.~~ The `OpaqueArgumentType` interface now has a `PropertySerializer` sub-interface that can be used to produce a byte array containing the serialized form of the properties for a specific `ProtocolVersion`. This has been checked both through unit tests and in-game. The javadoc notes that users are discouraged from implementing the `PropertySerializer` for vanilla parser types directly; although it makes no explicit mention about any library, I've released [opaque-argument-types](https://github.com/hugmanrique/opaque-argument-types), soon to be available in Maven Central [Update: already published to Maven Central]. 

You might be wondering what's the reason for not providing these directly in Velocity. The property serialized form and the string identifiers may change between Minecraft versions, so they would constitute API breakage. Publishing these as a separate library published as snapshots in a Maven repo allows us/me to introduce breaking changes freely. In addition, this is yet another aspect of the game Velocity must update on each update. Of course, plugin authors can use the methods in Velocity to construct their own `PropertySerializer`s; it's just that maintaining these across versions might become painful in the future. I'm open to moving these to API if you believe otherwise.