### PR TITLE
Add getEntry to TabList.java

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/player/TabList.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/TabList.java
@@ -62,6 +62,15 @@ public interface TabList {
   boolean containsEntry(UUID uuid);
 
   /**
+   * Retrieves the tab list entry associated with the given uuid.
+   *
+   * @param uuid The player's {@link UUID} the {@link TabListEntry} is in reference to.
+   * @return {@code Optional.empty()} if the player is not present in the provided player's
+   *     {@link TabList} otherwise a present {@link TabListEntry} in relation to the player.
+   */
+  Optional<TabListEntry> getEntry(UUID uuid);
+
+  /**
    * Returns an immutable {@link Collection} of the {@link TabListEntry}s in the tab list.
    *
    * @return immutable {@link Collection} of tab list entries

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/KeyedVelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/KeyedVelocityTabList.java
@@ -111,6 +111,11 @@ public class KeyedVelocityTabList implements InternalTabList {
     return entries.containsKey(uuid);
   }
 
+  @Override
+  public Optional<TabListEntry> getEntry(UUID uuid) {
+    return Optional.ofNullable(this.entries.get(uuid));
+  }
+
   /**
    * Clears all entries from the tab list. Note that the entries are written with
    * {@link MinecraftConnection#delayedWrite(Object)}, so make sure to do an explicit

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -163,6 +163,11 @@ public class VelocityTabList implements InternalTabList {
   }
 
   @Override
+  public Optional<TabListEntry> getEntry(UUID uuid) {
+    return Optional.ofNullable(this.entries.get(uuid));
+  }
+
+  @Override
   public Collection<TabListEntry> getEntries() {
     return this.entries.values().stream().map(e -> (TabListEntry) e).collect(Collectors.toList());
   }


### PR DESCRIPTION
This adds a simple `getter` into the tab list to retrieve individual entries quickly. This should provide a way for users to pull out a specific entry and modify it as necessary without removing or adding. This could return a nullable instead of an Optional but to remain consistent with the rest of the class it currently returns an Optional