### PR TITLE
[ci skip] Fixed build badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Velocity
 
-[![Build Status](https://img.shields.io/jenkins/s/https/ci.velocitypowered.com/job/velocity.svg)](https://ci.velocitypowered.com/job/velocity-3.0.0/)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/PaperMC/Velocity/gradle.yml)](https://papermc.io/downloads#Velocity)
 [![Join our Discord](https://img.shields.io/discord/289587909051416579.svg?logo=discord&label=)](https://discord.gg/papermc)
 
 A Minecraft server proxy with unparalleled server support, scalability,
@@ -15,7 +15,7 @@ Velocity is licensed under the GPLv3 license.
 * High performance: handle thousands of players on one proxy.
 * A new, refreshing API built from the ground up to be flexible and powerful
   whilst avoiding design mistakes and suboptimal designs from other proxies.
-* First-class support for Paper, Sponge, and Forge. (Other implementations
+* First-class support for Paper, Sponge, Fabric and Forge. (Other implementations
   may work, but we make every endeavor to support these server implementations
   specifically.)
   


### PR DESCRIPTION
Fixed the build badge in the README that referenced the old Jenkins instance of Velocity.

Also, added reference to Fabric support, which according to the [documentation](https://docs.papermc.io/velocity/server-compatibility#fabric), is better supported in Velocity than Forge

## Before
![](https://gyazo.com/a7a118fdffcc7822d37b6bbc0b24d27c.png) ![](https://gyazo.com/685f7dc2701bc6bf1846d8625b18039e.png)

## After 
![](https://gyazo.com/00eee4b694abdb64daafc715d67a4431.png) ![](https://gyazo.com/ebc6aba81888eac0c1386943c9941e1c.png)