### PR TITLE
Bump netty to 4.1.90.Final

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ guiceVersion=5.1.0
 
 # Proxy dependencies.
 log4jVersion=2.19.0
-nettyVersion=4.1.89.Final
+nettyVersion=4.1.90.Final
 flareVersion=2.0.1
 asyncHttpClientVersion=2.12.3
 bstatsVersion=3.0.0


### PR DESCRIPTION
https://netty.io/news/2023/03/14/4-1-90-Final.html
> We are happy to announce the release of netty 4.1.90.Final. This is a bug-fix release, but also includes some performance improvements. Please consider upgrading as soon as possible.