### PR TITLE
Revert "Handle exceptions in ConnectionRequestBuilderImpl#fireAndForget"

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1244,10 +1244,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
 
     @Override
     public void fireAndForget() {
-      connectWithIndication().exceptionally((ex) -> {
-        logger.error("Exception while connecting with indication", ex);
-        return null;
-      });
+      connectWithIndication();
     }
   }
 }


### PR DESCRIPTION
Reverts PaperMC/Velocity#875

This causes duplicate messages in "normal" operation. I need to figure out an alternative.