### PR TITLE
feat: player displaynames

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -51,6 +51,20 @@ public interface Player extends
   String getUsername();
 
   /**
+   * Returns the player's display name.
+   *
+   * @return the display name
+   */
+  Component getDisplayName();
+
+  /**
+   * Sets the player's display name.
+   *
+   * @param displayName the display name
+   */
+  void setDisplayName(Component displayName);
+
+  /**
    * Returns the locale the proxy will use to send messages translated via the Adventure global
    * translator. By default, the value of {@link PlayerSettings#getLocale()} is used.
    *

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -152,6 +152,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   private @Nullable ModInfo modInfo;
   private Component playerListHeader = Component.empty();
   private Component playerListFooter = Component.empty();
+  private Component displayName;
   private final InternalTabList tabList;
   private final VelocityServer server;
   private ClientConnectionPhase connectionPhase;
@@ -165,7 +166,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   private final @NotNull Pointers pointers = Player.super.pointers().toBuilder()
       .withDynamic(Identity.UUID, this::getUniqueId)
       .withDynamic(Identity.NAME, this::getUsername)
-      .withDynamic(Identity.DISPLAY_NAME, () -> Component.text(this.getUsername()))
+      .withDynamic(Identity.DISPLAY_NAME, this::getDisplayName)
       .withDynamic(Identity.LOCALE, this::getEffectiveLocale)
       .withStatic(PermissionChecker.POINTER, getPermissionChecker())
       .withStatic(FacetPointers.TYPE, Type.PLAYER)
@@ -187,6 +188,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     this.connectionPhase = connection.getType().getInitialClientPhase();
     this.knownChannels = CappedSet.create(MAX_PLUGIN_CHANNELS);
     this.onlineMode = onlineMode;
+    this.displayName = Component.text(profile.getName());
 
     if (connection.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_19_3) >= 0) {
       this.tabList = new VelocityTabList(this);
@@ -216,6 +218,16 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   @Override
   public String getUsername() {
     return profile.getName();
+  }
+
+  @Override
+  public Component getDisplayName() {
+    return displayName;
+  }
+
+  @Override
+  public void setDisplayName(final Component displayName) {
+    this.displayName = displayName;
   }
 
   @Override


### PR DESCRIPTION
Closes #993 

Something to consider, should `/glist` use the player's name or displayname?