### PR TITLE
Upgradle to v8.1 and remove now-redundant warnings in buildscripts

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // fixed in Gradle 8.1
 plugins {
     `kotlin-dsl`
     checkstyle

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/proxy/build.gradle.kts
+++ b/proxy/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
 
-@Suppress("DSL_SCOPE_VIOLATION") // fixed in Gradle 8.1
 plugins {
     application
     `set-manifest-impl-version`


### PR DESCRIPTION
As of Gradle v8.1, the following error is fixed: https://youtrack.jetbrains.com/issue/KTIJ-19369

Suppressions here are no longer required to hide incorrect IDE warnings.