### PR TITLE
Switch to using a ConcurrentMap for storing TabListEntries

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -62,7 +62,7 @@ public class VelocityTabList implements InternalTabList {
   public VelocityTabList(ConnectedPlayer player) {
     this.player = player;
     this.connection = player.getConnection();
-    this.entries = Maps.newHashMap();
+    this.entries = Maps.newConcurrentMap();
   }
 
   @Override


### PR DESCRIPTION
Fixes #1002 

Uses [`Maps#newConcurrentMap()`](https://guava.dev/releases/19.0/api/docs/src-html/com/google/common/collect/Maps.html#line.283) which creates an implementing ConcurrentMap through MapMaker, which fixes issues adding/removing entries from VelocityTabLists concurrently.