### PR TITLE
Updated Guice to 6.0.0 and manually include updated ASM

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ spotless = "com.diffplug.spotless:6.12.0"
 [libraries]
 adventure-bom = "net.kyori:adventure-bom:4.13.1"
 adventure-facet = "net.kyori:adventure-platform-facet:4.3.0"
+asm = "org.ow2.asm:asm:9.5"
 asynchttpclient = "org.asynchttpclient:async-http-client:2.12.3"
 brigadier = "com.velocitypowered:velocity-brigadier:1.0.0-SNAPSHOT"
 bstats = "org.bstats:bstats-base:3.0.1"
@@ -30,7 +31,7 @@ jopt = "net.sf.jopt-simple:jopt-simple:5.0.4"
 junit = "org.junit.jupiter:junit-jupiter:5.9.0"
 guava = "com.google.guava:guava:25.1-jre"
 gson = "com.google.code.gson:gson:2.10.1"
-guice = "com.google.inject:guice:5.1.0"
+guice = "com.google.inject:guice:6.0.0"
 lmbda = "org.lanternpowered:lmbda:2.0.0"
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }

--- a/proxy/build.gradle.kts
+++ b/proxy/build.gradle.kts
@@ -114,6 +114,7 @@ dependencies {
     implementation(libs.nightconfig)
     implementation(libs.bstats)
     implementation(libs.lmbda)
+    implementation(libs.asm)
     implementation(libs.bundles.flare)
     compileOnly(libs.spotbugs.annotations)
     testImplementation(libs.mockito)

--- a/proxy/src/main/java/com/velocitypowered/proxy/event/VelocityEventManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/event/VelocityEventManager.java
@@ -306,8 +306,7 @@ public class VelocityEventManager implements EventManager {
         if (returnType != void.class && continuationType == Continuation.class) {
           errors.add("method return type must be void if a continuation parameter is provided");
         } else if (returnType != void.class && returnType != EventTask.class) {
-          errors.add("method return type must be void, AsyncTask, "
-              + "AsyncTask.Basic or AsyncTask.WithContinuation");
+          errors.add("method return type must be void or EventTask");
         }
       }
       final short order = (short) subscribe.order().ordinal();


### PR DESCRIPTION
In this pull request, Guice was upgraded to version 6.0.0, which has no breaking changes from version 5.1.0. This version adds support for jakarta.inject as a future replacement for javax.inject (as of Guice 7.0.0 support for javax.inject is removed), and also updates its ASM dependency to support Java 21.
In addition, the ASM dependency is now manually included in Velocity, since according to a dependency analysis, Lmbda was including ASM version 7.1 while Guice declared version 9.5 (which has Java 21 support) as an optional dependency, so the Lmbda version was included.

This change has been tested with several plugins that use Guice in a basic way (a single use of the `@Inject` annotation in the main class), as well as in a more complete way (declaring custom Guice AbstractModules) and with other plugins that use both ways of declaring listeners as with the `@Subscribe` annotation (which uses Lmbda and ASM) and the functional way

![VelocityGuice600](https://github.com/PaperMC/Velocity/assets/68704415/c1457de1-0bba-4eb7-ac51-64e23f699fdb)

_also fixed an incorrect mention to the EventTask class in the error that arises when trying to register a listener by means of a method that has neither a void nor an EventTask as return type_