### PR TITLE
Hide ip address in initial and legacy connections

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -235,7 +235,12 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
 
     @Override
     public String toString() {
-      return "[legacy connection] " + this.getRemoteAddress().toString();
+      boolean isPlayerAddressLoggingEnabled = connection.server.getConfiguration()
+          .isPlayerAddressLoggingEnabled();
+      String playerIp =
+          isPlayerAddressLoggingEnabled
+              ? this.getRemoteAddress().toString() : "<ip address withheld>";
+      return "[legacy connection] " + playerIp;
     }
 
     @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialInboundConnection.java
@@ -75,7 +75,12 @@ public final class InitialInboundConnection implements VelocityInboundConnection
 
   @Override
   public String toString() {
-    return "[initial connection] " + connection.getRemoteAddress().toString();
+    boolean isPlayerAddressLoggingEnabled = connection.server.getConfiguration()
+        .isPlayerAddressLoggingEnabled();
+    String playerIp =
+        isPlayerAddressLoggingEnabled
+            ? connection.getRemoteAddress().toString() : "<ip address withheld>";
+    return "[initial connection] " + playerIp;
   }
 
   @Override


### PR DESCRIPTION
Turns out cancelling an initial connection still logged the ip address in the console and so does a legacy connection. When specified in velocity.toml `enable-player-address-logging = false` all ip addresses should be hidden.
![image](https://github.com/PaperMC/Velocity/assets/78265483/07442fa1-3d03-45b9-be5a-200cd73aeb7c)

