### PR TITLE
bump adventure to 4.14.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ shadow = "com.github.johnrengelman.shadow:8.1.0"
 spotless = "com.diffplug.spotless:6.12.0"
 
 [libraries]
-adventure-bom = "net.kyori:adventure-bom:4.13.1"
+adventure-bom = "net.kyori:adventure-bom:4.14.0"
 adventure-facet = "net.kyori:adventure-platform-facet:4.3.0"
 asm = "org.ow2.asm:asm:9.5"
 asynchttpclient = "org.asynchttpclient:async-http-client:2.12.3"


### PR DESCRIPTION
Adventure 4.14.0 released a few weeks ago - https://github.com/KyoriPowered/adventure/releases/tag/v4.14.0, and e.g. Geyser depends on a few features (namely; 1.19.4 introduced fallback translations or legacy color serialization iirc); so it would be cool to have the latest version available.
 