### PR TITLE
Log exceptions instead of just kicking the player (ClientPlaySessionHandler)

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -418,6 +418,9 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
 
   @Override
   public void exception(Throwable throwable) {
+    logger.error("{}: An error occurred in the client-sided play handler: ",
+            player.getConnection().getRemoteAddress(), throwable);
+
     player.disconnect(
         Component.translatable("velocity.error.player-connection-error", NamedTextColor.RED));
   }


### PR DESCRIPTION
This commit is build-able using the script. 

While debugging a connection problem i noticed that these errors do not get printed.
This would really help my workflow.