### PR TITLE
Update snakeyaml to version 2.0 in api/build.gradle.kts

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     api("net.kyori:adventure-text-serializer-plain")
     api("net.kyori:adventure-text-minimessage")
 
+    api("org.yaml:snakeyaml:2.0")
+
     api(libs.slf4j)
     api(libs.guice)
     api(libs.checker.qual)


### PR DESCRIPTION
I was getting error java.lang.NoSuchMethodError: 'void org.yaml.snakeyaml.LoaderOptions.setCodePointLimit(int)' using snakeyaml 2.0 in my plugin. I learned that the Velocity core contains the snakeyaml version 1.33 library. I suggest replacing the version with 2.0 because of the large number of vulnerabilities in the older version