### PR TITLE
Set project encoding to UTF-8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,20 @@ subprojects {
     apply<VelocityPublishPlugin>()
     apply<VelocitySpotlessPlugin>()
 
+    tasks.withType<JavaCompile> {
+        options.encoding = Charsets.UTF_8.name()
+        options.release.set(17)
+    }
+
+    tasks.withType<Javadoc> {
+        options.encoding = Charsets.UTF_8.name()
+    }
+
+    @Suppress("UnstableApiUsage")
+    tasks.withType<ProcessResources> {
+        filteringCharset = Charsets.UTF_8.name()
+    }
+
     java {
         toolchain {
             languageVersion.set(JavaLanguageVersion.of(11))


### PR DESCRIPTION
This commit updates the build script to specifically set the project encoding to UTF-8 for JavaCompile, Javadoc, and ProcessResources tasks to ensure consistent handling of characters across different environments.