### PR TITLE
Fix unsigned commands detected as signed

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/LastSeenMessages.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/LastSeenMessages.java
@@ -49,4 +49,12 @@ public class LastSeenMessages {
   public boolean isEmpty() {
     return acknowledged.isEmpty();
   }
+
+  @Override
+  public String toString() {
+    return "LastSeenMessages{" +
+            "offset=" + offset +
+            ", acknowledged=" + acknowledged +
+            '}';
+  }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedCommandHandler.java
@@ -52,7 +52,7 @@ public class KeyedCommandHandler implements CommandHandler<KeyedPlayerCommand> {
               && playerKey.getKeyRevision().compareTo(IdentifiedKey.Revision.LINKED_V2) >= 0) {
             logger.fatal("A plugin tried to deny a command with signable component(s). "
                 + "This is not supported. "
-                + "Disconnecting player " + player.getUsername());
+                + "Disconnecting player " + player.getUsername() + ". Command packet: " + packet);
             player.disconnect(Component.text(
                 "A proxy plugin caused an illegal protocol state. "
                     + "Contact your network administrator."));
@@ -75,7 +75,7 @@ public class KeyedCommandHandler implements CommandHandler<KeyedPlayerCommand> {
               && playerKey.getKeyRevision().compareTo(IdentifiedKey.Revision.LINKED_V2) >= 0) {
             logger.fatal("A plugin tried to change a command with signed component(s). "
                 + "This is not supported. "
-                + "Disconnecting player " + player.getUsername());
+                + "Disconnecting player " + player.getUsername() + ". Command packet: " + packet);
             player.disconnect(Component.text(
                 "A proxy plugin caused an illegal protocol state. "
                     + "Contact your network administrator."));
@@ -95,7 +95,7 @@ public class KeyedCommandHandler implements CommandHandler<KeyedPlayerCommand> {
               && playerKey.getKeyRevision().compareTo(IdentifiedKey.Revision.LINKED_V2) >= 0) {
             logger.fatal("A plugin tried to change a command with signed component(s). "
                 + "This is not supported. "
-                + "Disconnecting player " + player.getUsername());
+                + "Disconnecting player " + player.getUsername() + ". Command packet: " + packet);
             player.disconnect(Component.text(
                 "A proxy plugin caused an illegal protocol state. "
                     + "Contact your network administrator."));

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
@@ -47,7 +47,7 @@ public class SessionCommandHandler implements CommandHandler<SessionPlayerComman
         if (packet.isSigned()) {
           logger.fatal("A plugin tried to deny a command with signable component(s). "
               + "This is not supported. "
-              + "Disconnecting player " + player.getUsername());
+              + "Disconnecting player " + player.getUsername() + ". Command packet: " + packet);
           player.disconnect(Component.text(
               "A proxy plugin caused an illegal protocol state. "
                   + "Contact your network administrator."));
@@ -63,7 +63,7 @@ public class SessionCommandHandler implements CommandHandler<SessionPlayerComman
           if (packet.isSigned()) {
             logger.fatal("A plugin tried to change a command with signed component(s). "
                 + "This is not supported. "
-                + "Disconnecting player " + player.getUsername());
+                + "Disconnecting player " + player.getUsername() + ". Command packet: " + packet);
             player.disconnect(Component.text(
                 "A proxy plugin caused an illegal protocol state. "
                     + "Contact your network administrator."));
@@ -87,7 +87,7 @@ public class SessionCommandHandler implements CommandHandler<SessionPlayerComman
             if (packet.isSigned()) {
               logger.fatal("A plugin tried to change a command with signed component(s). "
                   + "This is not supported. "
-                  + "Disconnecting player " + player.getUsername());
+                  + "Disconnecting player " + player.getUsername() + ". Command packet: " + packet);
               player.disconnect(Component.text(
                   "A proxy plugin caused an illegal protocol state. "
                       + "Contact your network administrator."));

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionPlayerCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionPlayerCommand.java
@@ -65,7 +65,8 @@ public class SessionPlayerCommand implements MinecraftPacket {
   }
 
   public boolean isSigned() {
-    return salt != 0 || !lastSeenMessages.isEmpty() || !argumentSignatures.isEmpty();
+    if (salt == 0) return false;
+    return !lastSeenMessages.isEmpty() || !argumentSignatures.isEmpty();
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionPlayerCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionPlayerCommand.java
@@ -74,6 +74,17 @@ public class SessionPlayerCommand implements MinecraftPacket {
     return handler.handle(this);
   }
 
+  @Override
+  public String toString() {
+    return "SessionPlayerCommand{" +
+            "command='" + command + '\'' +
+            ", timeStamp=" + timeStamp +
+            ", salt=" + salt +
+            ", argumentSignatures=" + argumentSignatures +
+            ", lastSeenMessages=" + lastSeenMessages +
+            '}';
+  }
+
   public static class ArgumentSignatures {
 
     private final List<ArgumentSignature> entries;
@@ -105,6 +116,12 @@ public class SessionPlayerCommand implements MinecraftPacket {
         entry.encode(buf);
       }
     }
+    @Override
+    public String toString() {
+      return "ArgumentSignatures{" +
+              "entries=" + entries +
+              '}';
+    }
   }
 
   public static class ArgumentSignature {
@@ -120,6 +137,13 @@ public class SessionPlayerCommand implements MinecraftPacket {
     public void encode(ByteBuf buf) {
       ProtocolUtils.writeString(buf, name);
       buf.writeBytes(signature);
+    }
+
+    @Override
+    public String toString() {
+      return "ArgumentSignature{" +
+              "name='" + name + '\'' +
+              '}';
     }
   }
 }


### PR DESCRIPTION
# The problem

Using the proxy to intercept commands is sometimes required and should work with the api and the CommandExecuteEvent.

Currently every denied command will result into a disconnect with the message of a invalid protocol state. Even if the command is not signed and only has none or unsigned arguments.

# The solution

To solve this problem I debugged the issue and found the reason: The salt is set for unsigned commands even if the command itself is not signed. This will cause a wrong return value for `SessionPlayerCommand#isSigned` and the `SessionCommandHandler` will not cancel the event correctly.

I changed the implmentation of `isSigned`and added some useful debug information in case of denied signed messages.