### PR TITLE
Include forwarding secret file name in error message

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -499,7 +499,7 @@ public class VelocityConfiguration implements ProxyConfig {
                 "The file " + forwardSecretFile + " is not a valid file or it is a directory.");
           }
         } else {
-          throw new RuntimeException("The forwarding-secret-file does not exist.");
+          throw new RuntimeException("The forwarding-secret-file (" + forwardSecretFile + ") does not exist.");
         }
       }
     }


### PR DESCRIPTION
Includes the configured forwarding secret file name in parentheses in the error message when the file doesn't exist