### PR TITLE
Update Minecraft wiki reference

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/util/CharacterUtil.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/CharacterUtil.java
@@ -30,7 +30,7 @@ public final class CharacterUtil {
    */
   public static boolean isAllowedCharacter(char c) {
     // 167 = §, 127 = DEL
-    // https://minecraft.fandom.com/wiki/Multiplayer#Chat
+    // https://minecraft.wiki/w/Chat
     return c != 167 && c >= ' ' && c != 127;
   }
 


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the wiki reference accordingly.

Let me know if you want me to open this PR on other branches!