### PR TITLE
Catch throwables when loading plugins

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/plugin/VelocityPluginManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/plugin/VelocityPluginManager.java
@@ -94,7 +94,7 @@ public class VelocityPluginManager implements PluginManager {
       for (Path path : stream) {
         try {
           found.add(loader.loadCandidate(path));
-        } catch (Exception e) {
+        } catch (Throwable e) {
           logger.error("Unable to load plugin {}", path, e);
         }
       }
@@ -126,7 +126,7 @@ public class VelocityPluginManager implements PluginManager {
         VelocityPluginContainer container = new VelocityPluginContainer(realPlugin);
         pluginContainers.put(container, loader.createModule(container));
         loadedPluginsById.add(realPlugin.getId());
-      } catch (Exception e) {
+      } catch (Throwable e) {
         logger.error("Can't create module for plugin {}", candidate.getId(), e);
       }
     }
@@ -153,7 +153,7 @@ public class VelocityPluginManager implements PluginManager {
 
       try {
         loader.createPlugin(container, plugin.getValue(), commonModule);
-      } catch (Exception e) {
+      } catch (Throwable e) {
         logger.error("Can't create plugin {}", description.getId(), e);
         continue;
       }


### PR DESCRIPTION
While developing a plugin I forgot to use the shaded plugin and found a NoClassDefFoundError.

This error is a Throwable but not an Exception, so the current implementation in Velocity doesn't print the correct warning message.

Before:
```
[17:13:14 INFO]: Booting up Velocity 3.2.0-SNAPSHOT (git-2bd2c692-b269)...
[17:13:14 INFO]: Loading localizations...
[17:13:14 INFO]: Connections will use epoll channels, libdeflate (Linux x86_64) compression, OpenSSL 3.0.x (Linux x86_64) ciphers
[17:13:14 INFO]: Loading plugins...
[17:13:14 INFO]: Loaded plugin luckperms 5.4.104 by Luck
[17:13:14 ERROR]: Exception in thread "main" java.lang.NoClassDefFoundError: org/bstats/charts/CustomChart
-- stacktrace --
-- no further messages, velocity is stucked in startup --
```

After:
```
[17:14:06 INFO]: Booting up Velocity 3.2.0-SNAPSHOT (git-768ecdb0)...
[17:14:06 INFO]: Loading localizations...
[17:14:06 INFO]: Connections will use epoll channels, libdeflate (Linux x86_64) compression, OpenSSL 3.0.x (Linux x86_64) ciphers
[17:14:06 INFO]: Loading plugins...
[17:14:06 INFO]: Loaded plugin luckperms 5.4.104 by Luck
[17:14:06 ERROR]: Can't create plugin myname
java.lang.NoClassDefFoundError: org/bstats/charts/CustomChart
-- stacktrace --
[17:14:06 INFO]: Loaded 1 plugins
[17:14:07 INFO]: Listening on /[0:0:0:0:0:0:0:0%0]:25577
[17:14:07 INFO]: Done (1,24s)!

```