### PR TITLE
Allow closing active proxy listeners

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
@@ -42,6 +42,12 @@ public interface ProxyServer extends Audience {
   void shutdown();
 
   /**
+   * Closes all listening endpoints for this server.
+   * This includes the main minecraft listener and query channel.
+   */
+  void closeListeners();
+
+  /**
    * Retrieves the player currently connected to this proxy by their Minecraft username. The search
    * is case-insensitive.
    *

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -572,6 +572,11 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     shutdown(true);
   }
 
+  @Override
+  public void closeListeners() {
+    this.cm.closeEndpoints(false);
+  }
+
   public AsyncHttpClient getAsyncHttpClient() {
     return cm.getHttpClient();
   }


### PR DESCRIPTION
Bungeecord allows you to close active listeners, preventing connections from being established on the proxy. This PR is meant to expose that functionality to Velocity as well. 

Note:
I do not close the SeparatePoolInetNameResolver, as it is potentially possible for these endpoints to be re-established using reload.