### PR TITLE
MEDIUM: Use of AccessController.doPrivileged() in Public Method of Public Class

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -536,16 +536,20 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
       shutdown = true;
 
       if (explicitExit) {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-          @Override
-          @SuppressFBWarnings("DM_EXIT")
-          public Void run() {
-            System.exit(0);
-            return null;
-          }
-        });
+        exitWithPrivilege();
       }
     };
+
+    private void exitWithPrivilege() {
+      AccessController.doPrivileged(new PrivilegedAction<Void>() {
+        @Override
+        @SuppressFBWarnings("DM_EXIT")
+        public Void run() {
+          System.exit(0);
+          return null;
+        }
+      });
+    }
 
     if (explicitExit) {
       Thread thread = new Thread(shutdownProcess);


### PR DESCRIPTION
issue：https://github.com/PaperMC/Velocity/issues/1134#issue-1967025499

In this change, I created a new method for private exitWithPrivilege (), and the AccessController. The doPrivileged () call mobile to this method. The new method is then called in shutdownProcess. So you can avoid the common methods of directly using the AccessController. The doPrivileged (), so as to improve the security of the code.