### PR TITLE
Log console command executions

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
@@ -136,6 +136,10 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
       if (!this.server.getCommandManager().executeAsync(this, command).join()) {
         sendMessage(Component.translatable("velocity.command.command-does-not-exist",
             NamedTextColor.RED));
+        return;
+      }
+      if (server.getConfiguration().isLogCommandExecutions()) {
+        logger.info("CONSOLE -> executed command /{}", command);
       }
     } catch (Exception e) {
       logger.error("An error occurred while running this command.", e);


### PR DESCRIPTION
Currently command executions are only logged for players. Imo this config option should include the console because not every command has a sender feedback and it could be nice to see it in the logs.