### PR TITLE
Clean up JavaPluginLoader and VelocityPluginModule

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/plugin/loader/java/JavaPluginLoader.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/plugin/loader/java/JavaPluginLoader.java
@@ -81,11 +81,9 @@ public class JavaPluginLoader implements PluginLoader {
       throw new IllegalArgumentException("Description provided isn't of the Java plugin loader");
     }
 
-    if (candidate.getSource().isEmpty()) {
-      throw new InvalidPluginException("Description provided does not have a source path");
-    }
-
-    URL pluginJarUrl = candidate.getSource().get().toUri().toURL();
+    URL pluginJarUrl = candidate.getSource().orElseThrow(
+        () -> new InvalidPluginException("Description provided does not have a source path")
+    ).toUri().toURL();
     PluginClassLoader loader = AccessController.doPrivileged(
         (PrivilegedAction<PluginClassLoader>) () -> new PluginClassLoader(new URL[]{pluginJarUrl}));
     loader.addToClassloaders();

--- a/proxy/src/main/java/com/velocitypowered/proxy/plugin/loader/java/VelocityPluginModule.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/plugin/loader/java/VelocityPluginModule.java
@@ -23,7 +23,6 @@ import com.google.inject.Scopes;
 import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.PluginDescription;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
-import com.velocitypowered.api.proxy.ProxyServer;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
@@ -32,14 +31,12 @@ import org.slf4j.LoggerFactory;
 
 class VelocityPluginModule implements Module {
 
-  private final ProxyServer server;
   private final JavaVelocityPluginDescription description;
   private final PluginContainer pluginContainer;
   private final Path basePluginPath;
 
-  VelocityPluginModule(ProxyServer server, JavaVelocityPluginDescription description,
-      PluginContainer pluginContainer, Path basePluginPath) {
-    this.server = server;
+  VelocityPluginModule(JavaVelocityPluginDescription description, PluginContainer pluginContainer,
+      Path basePluginPath) {
     this.description = description;
     this.pluginContainer = pluginContainer;
     this.basePluginPath = basePluginPath;


### PR DESCRIPTION
This PR cleans up some small issues I noticed while browsing in the `JavaPluginLoader` and `VelocityPluginModule` classes:

- Use `Optional#isEmpty` instead of negation of `isPresent`
- Add missing optional check for `candidate.getSource()`
- Replace raw types with wildcards
- Remove redundant `throws Exception`
- Remove redundant `ProxyServer` parameter from `VelocityPluginModule`
