### PR TITLE
Added static methods to create ArgumentBuilders directly in the BrigadierCommand class

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/BrigadierCommand.java
+++ b/api/src/main/java/com/velocitypowered/api/command/BrigadierCommand.java
@@ -8,8 +8,11 @@
 package com.velocitypowered.api.command;
 
 import com.google.common.base.Preconditions;
+import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A command that uses Brigadier for parsing the command and
@@ -31,7 +34,7 @@ public final class BrigadierCommand implements Command {
    *
    * @param builder the {@link LiteralCommandNode} builder
    */
-  public BrigadierCommand(final LiteralArgumentBuilder<CommandSource> builder) {
+  public BrigadierCommand(final @NotNull LiteralArgumentBuilder<CommandSource> builder) {
     this(Preconditions.checkNotNull(builder, "builder").build());
   }
 
@@ -40,7 +43,7 @@ public final class BrigadierCommand implements Command {
    *
    * @param node the command node
    */
-  public BrigadierCommand(final LiteralCommandNode<CommandSource> node) {
+  public BrigadierCommand(final @NotNull LiteralCommandNode<CommandSource> node) {
     this.node = Preconditions.checkNotNull(node, "node");
   }
 
@@ -51,5 +54,35 @@ public final class BrigadierCommand implements Command {
    */
   public LiteralCommandNode<CommandSource> getNode() {
     return node;
+  }
+
+  /**
+   * Creates a new LiteralArgumentBuilder of the required name.
+   *
+   * @param name the literal name.
+   * @return a new LiteralArgumentBuilder.
+   */
+  public static LiteralArgumentBuilder<CommandSource> literalArgumentBuilder(
+          final @NotNull String name) {
+    Preconditions.checkNotNull(name, "name");
+    // Validation to avoid beginner's errors in case someone includes a space in the argument name
+    Preconditions.checkArgument(name.indexOf(' ') == -1, "the argument name cannot contain spaces");
+    return LiteralArgumentBuilder.literal(name);
+  }
+
+  /**
+   * Creates a new RequiredArgumentBuilder of the required name and type.
+   *
+   * @param name the argument name
+   * @param argumentType the argument type required
+   * @param <T> the ArgumentType required type
+   * @return a new RequiredArgumentBuilder
+   */
+  public static <T> RequiredArgumentBuilder<CommandSource, T> requiredArgumentBuilder(
+          final @NotNull String name, @NotNull final ArgumentType<T> argumentType) {
+    Preconditions.checkNotNull(name, "name");
+    Preconditions.checkNotNull(argumentType, "argument type");
+
+    return RequiredArgumentBuilder.argument(name, argumentType);
   }
 }

--- a/proxy/src/test/java/com/velocitypowered/proxy/command/BrigadierCommandTests.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/command/BrigadierCommandTests.java
@@ -20,11 +20,13 @@ package com.velocitypowered.proxy.command;
 import static com.mojang.brigadier.arguments.IntegerArgumentType.getInteger;
 import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
 import static com.mojang.brigadier.arguments.StringArgumentType.word;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.velocitypowered.api.command.BrigadierCommand;
@@ -348,5 +350,15 @@ public class BrigadierCommandTests extends CommandTestSuite {
 
     assertThrows(CompletionException.class, () ->
         manager.offerSuggestions(source, "parent ").join());
+  }
+
+  @Test
+  void testArgumentBuilderCreationUsingStaticFactory() {
+    assertDoesNotThrow(() -> BrigadierCommand.literalArgumentBuilder("someCommand"));
+    assertThrows(IllegalArgumentException.class,
+            () -> BrigadierCommand.literalArgumentBuilder("some random command"));
+    assertDoesNotThrow(
+            () -> BrigadierCommand.requiredArgumentBuilder(
+                    "someRequiredArgument", StringArgumentType.word()));
   }
 }


### PR DESCRIPTION
Until now, to create a command with several brigadier nodes required a lot of boilerplate, otherwise, a compilation error arises
```java
final LiteralCommandNode<CommandSource> rootNode = LiteralArgumentBuilder.<CommandSource>literal("command")
  .then(RequiredArgumentBuilder.<CommandSource, String>argument("argument", StringArgumentType.word())
    .executes(context -> {
      // command execution
      return Command.SINGLE_SUCCESS;
   })
  ).build();
```

With this pull request, the creation of a brigadier command would be significantly simplified, eliminating the unnecessary use of generics

```java
final LiteralCommandNode<CommandSource> rootNode = BrigadierCommand.literalArgumentBuilder("command")
  .then(BrigadierCommand.requiredArgumentBuilder("argument", StringArgumentType.word())
    .executes(context -> {
      // command execution
      return Command.SINGLE_SUCCESS;
   })
  ).build();
```

In addition, it adds extra validations that Brigadier does not perform, such as improper use of spaces in the name of a LiteralCommandNode.

These methods may seem unnecessary, but for a complex node with several subnodes, it would be quite useful since normally one would do a static method doing exactly the same thing.