### PR TITLE
Add ModernForgeConnectionType to supports Forge-1.20.2+

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/ConnectionTypes.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/ConnectionTypes.java
@@ -21,7 +21,6 @@ import com.velocitypowered.proxy.connection.backend.BackendConnectionPhases;
 import com.velocitypowered.proxy.connection.client.ClientConnectionPhases;
 import com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConnectionType;
 import com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeHandshakeClientPhase;
-import com.velocitypowered.proxy.connection.forge.modern.ModernForgeConnectionType;
 import com.velocitypowered.proxy.connection.util.ConnectionTypeImpl;
 
 /**
@@ -49,11 +48,6 @@ public final class ConnectionTypes {
    * Indicates that the connection is a 1.8-1.12 Forge connection.
    */
   public static final ConnectionType LEGACY_FORGE = new LegacyForgeConnectionType();
-
-  /**
-   * Indicates that the connection is a 1.20.2+ Forge connection.
-   */
-  public static final ConnectionType MODERN_FORGE = new ModernForgeConnectionType();
 
   private ConnectionTypes() {
     throw new AssertionError();

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/ConnectionTypes.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/ConnectionTypes.java
@@ -21,6 +21,7 @@ import com.velocitypowered.proxy.connection.backend.BackendConnectionPhases;
 import com.velocitypowered.proxy.connection.client.ClientConnectionPhases;
 import com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConnectionType;
 import com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeHandshakeClientPhase;
+import com.velocitypowered.proxy.connection.forge.modern.ModernForgeConnectionType;
 import com.velocitypowered.proxy.connection.util.ConnectionTypeImpl;
 
 /**
@@ -48,6 +49,11 @@ public final class ConnectionTypes {
    * Indicates that the connection is a 1.8-1.12 Forge connection.
    */
   public static final ConnectionType LEGACY_FORGE = new LegacyForgeConnectionType();
+
+  /**
+   * Indicates that the connection is a 1.20.2+ Forge connection.
+   */
+  public static final ConnectionType MODERN_FORGE = new ModernForgeConnectionType();
 
   private ConnectionTypes() {
     throw new AssertionError();

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -19,6 +19,7 @@ package com.velocitypowered.proxy.connection.backend;
 
 import static com.velocitypowered.proxy.VelocityServer.GENERAL_GSON;
 import static com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConstants.HANDSHAKE_HOSTNAME_TOKEN;
+import com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants;
 import static com.velocitypowered.proxy.network.Connections.HANDLER;
 
 import com.google.common.base.Preconditions;
@@ -188,6 +189,8 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
       handshake.setServerAddress(createBungeeGuardForwardingAddress(secret));
     } else if (proxyPlayer.getConnection().getType() == ConnectionTypes.LEGACY_FORGE) {
       handshake.setServerAddress(playerVhost + HANDSHAKE_HOSTNAME_TOKEN);
+    } else if (proxyPlayer.getConnection().getType() == ConnectionTypes.MODERN_FORGE) {
+      handshake.setServerAddress(playerVhost + ModernForgeConstants.MARKER);
     } else {
       handshake.setServerAddress(playerVhost);
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -19,7 +19,6 @@ package com.velocitypowered.proxy.connection.backend;
 
 import static com.velocitypowered.proxy.VelocityServer.GENERAL_GSON;
 import static com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConstants.HANDSHAKE_HOSTNAME_TOKEN;
-import static com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants.MODERN_HANDSHAKE_HOSTNAME_TOKEN;
 import static com.velocitypowered.proxy.network.Connections.HANDLER;
 
 import com.google.common.base.Preconditions;
@@ -37,6 +36,7 @@ import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftConnectionAssociation;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
+import com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants;
 import com.velocitypowered.proxy.connection.util.ConnectionRequestResults.Impl;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.packet.Handshake;
@@ -190,7 +190,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
     } else if (proxyPlayer.getConnection().getType() == ConnectionTypes.LEGACY_FORGE) {
       handshake.setServerAddress(playerVhost + HANDSHAKE_HOSTNAME_TOKEN);
     } else if (proxyPlayer.getConnection().getType() == ConnectionTypes.MODERN_FORGE) {
-      handshake.setServerAddress(playerVhost + MODERN_HANDSHAKE_HOSTNAME_TOKEN);
+      handshake.setServerAddress(playerVhost + ModernForgeConstants.getModernForgeHostnameToken());
     } else {
       handshake.setServerAddress(playerVhost);
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -36,7 +36,7 @@ import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftConnectionAssociation;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
-import com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants;
+import com.velocitypowered.proxy.connection.forge.modern.ModernForgeConnectionType;
 import com.velocitypowered.proxy.connection.util.ConnectionRequestResults.Impl;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.packet.Handshake;
@@ -189,8 +189,9 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
       handshake.setServerAddress(createBungeeGuardForwardingAddress(secret));
     } else if (proxyPlayer.getConnection().getType() == ConnectionTypes.LEGACY_FORGE) {
       handshake.setServerAddress(playerVhost + HANDSHAKE_HOSTNAME_TOKEN);
-    } else if (proxyPlayer.getConnection().getType() == ConnectionTypes.MODERN_FORGE) {
-      handshake.setServerAddress(playerVhost + ModernForgeConstants.getModernForgeHostnameToken());
+    } else if (proxyPlayer.getConnection().getType() instanceof ModernForgeConnectionType) {
+      handshake.setServerAddress(playerVhost + ((ModernForgeConnectionType) proxyPlayer
+              .getConnection().getType()).getModernToken());
     } else {
       handshake.setServerAddress(playerVhost);
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -19,7 +19,7 @@ package com.velocitypowered.proxy.connection.backend;
 
 import static com.velocitypowered.proxy.VelocityServer.GENERAL_GSON;
 import static com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConstants.HANDSHAKE_HOSTNAME_TOKEN;
-import com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants;
+import static com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants.MARKER;
 import static com.velocitypowered.proxy.network.Connections.HANDLER;
 
 import com.google.common.base.Preconditions;
@@ -190,7 +190,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
     } else if (proxyPlayer.getConnection().getType() == ConnectionTypes.LEGACY_FORGE) {
       handshake.setServerAddress(playerVhost + HANDSHAKE_HOSTNAME_TOKEN);
     } else if (proxyPlayer.getConnection().getType() == ConnectionTypes.MODERN_FORGE) {
-      handshake.setServerAddress(playerVhost + ModernForgeConstants.MARKER);
+      handshake.setServerAddress(playerVhost + MARKER);
     } else {
       handshake.setServerAddress(playerVhost);
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -19,7 +19,7 @@ package com.velocitypowered.proxy.connection.backend;
 
 import static com.velocitypowered.proxy.VelocityServer.GENERAL_GSON;
 import static com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConstants.HANDSHAKE_HOSTNAME_TOKEN;
-import static com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants.MARKER;
+import static com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants.MODERN_HANDSHAKE_HOSTNAME_TOKEN;
 import static com.velocitypowered.proxy.network.Connections.HANDLER;
 
 import com.google.common.base.Preconditions;
@@ -190,7 +190,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
     } else if (proxyPlayer.getConnection().getType() == ConnectionTypes.LEGACY_FORGE) {
       handshake.setServerAddress(playerVhost + HANDSHAKE_HOSTNAME_TOKEN);
     } else if (proxyPlayer.getConnection().getType() == ConnectionTypes.MODERN_FORGE) {
-      handshake.setServerAddress(playerVhost + MARKER);
+      handshake.setServerAddress(playerVhost + MODERN_HANDSHAKE_HOSTNAME_TOKEN);
     } else {
       handshake.setServerAddress(playerVhost);
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -155,9 +155,7 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
   private ConnectionType getHandshakeConnectionType(Handshake handshake) {
     if (handshake.getServerAddress().contains(ModernForgeConstants.MODERN_FORGE_TOKEN)
             && handshake.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_20_2) >= 0) {
-      String host = handshake.getServerAddress();
-      String[] split = host.split("\0", 2);
-      ModernForgeConstants.MODERN_FORGE_HOSTNAME_TOKEN = "\0" + split[1];
+      ModernForgeConstants.initNatVersion(handshake.getServerAddress());
       return ConnectionTypes.MODERN_FORGE;
     }
     // Determine if we're using Forge (1.8 to 1.12, may not be the case in 1.13).

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -28,6 +28,7 @@ import com.velocitypowered.proxy.connection.ConnectionTypes;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConstants;
+import com.velocitypowered.proxy.connection.forge.modern.ModernForgeConnectionType;
 import com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants;
 import com.velocitypowered.proxy.connection.util.VelocityInboundConnection;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
@@ -155,8 +156,7 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
   private ConnectionType getHandshakeConnectionType(Handshake handshake) {
     if (handshake.getServerAddress().contains(ModernForgeConstants.MODERN_FORGE_TOKEN)
             && handshake.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_20_2) >= 0) {
-      ModernForgeConstants.initNatVersion(handshake.getServerAddress());
-      return ConnectionTypes.MODERN_FORGE;
+      return new ModernForgeConnectionType(handshake.getServerAddress());
     }
     // Determine if we're using Forge (1.8 to 1.12, may not be the case in 1.13).
     if (handshake.getServerAddress().endsWith(LegacyForgeConstants.HANDSHAKE_HOSTNAME_TOKEN)

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -153,7 +153,7 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
   }
 
   private ConnectionType getHandshakeConnectionType(Handshake handshake) {
-    if (handshake.getServerAddress().endsWith(ModernForgeConstants.MARKER)
+    if (handshake.getServerAddress().endsWith(ModernForgeConstants.MODERN_HANDSHAKE_HOSTNAME_TOKEN)
             && handshake.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_20_2) >= 0) {
       return ConnectionTypes.MODERN_FORGE;
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -28,6 +28,7 @@ import com.velocitypowered.proxy.connection.ConnectionTypes;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConstants;
+import com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants;
 import com.velocitypowered.proxy.connection.util.VelocityInboundConnection;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.StateRegistry;
@@ -152,6 +153,10 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
   }
 
   private ConnectionType getHandshakeConnectionType(Handshake handshake) {
+    if (handshake.getServerAddress().endsWith(ModernForgeConstants.MARKER)
+            && handshake.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_20_2) >= 0) {
+      return ConnectionTypes.MODERN_FORGE;
+    }
     // Determine if we're using Forge (1.8 to 1.12, may not be the case in 1.13).
     if (handshake.getServerAddress().endsWith(LegacyForgeConstants.HANDSHAKE_HOSTNAME_TOKEN)
         && handshake.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_13) < 0) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -153,8 +153,11 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
   }
 
   private ConnectionType getHandshakeConnectionType(Handshake handshake) {
-    if (handshake.getServerAddress().endsWith(ModernForgeConstants.MODERN_HANDSHAKE_HOSTNAME_TOKEN)
+    if (handshake.getServerAddress().contains(ModernForgeConstants.MODERN_FORGE_TOKEN)
             && handshake.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_20_2) >= 0) {
+      String host = handshake.getServerAddress();
+      String[] split = host.split("\0", 2);
+      ModernForgeConstants.MODERN_FORGE_HOSTNAME_TOKEN = "\0" + split[1];
       return ConnectionTypes.MODERN_FORGE;
     }
     // Determine if we're using Forge (1.8 to 1.12, may not be the case in 1.13).

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
@@ -17,33 +17,49 @@
 
 package com.velocitypowered.proxy.connection.forge.modern;
 
-import com.velocitypowered.api.util.GameProfile;
-import com.velocitypowered.proxy.config.PlayerInfoForwarding;
-import com.velocitypowered.proxy.connection.ConnectionTypes;
+import static com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants.MODERN_FORGE_TOKEN;
+
 import com.velocitypowered.proxy.connection.backend.BackendConnectionPhases;
 import com.velocitypowered.proxy.connection.client.ClientConnectionPhases;
 import com.velocitypowered.proxy.connection.util.ConnectionTypeImpl;
 
 /**
- * Contains extra logic for {@link ConnectionTypes#MODERN_FORGE}.
+ * Contains extra logic.
  */
 public class ModernForgeConnectionType extends ConnectionTypeImpl {
 
-  private static final GameProfile.Property IS_FORGE_CLIENT_PROPERTY =
-      new GameProfile.Property("forgeClient", "true", "");
+  public final String hostName;
 
-  public ModernForgeConnectionType() {
+  /**
+   * initialize the host name into an internal variable.
+   *
+   * @param hostName address from the client
+   */
+  public ModernForgeConnectionType(String hostName) {
     super(ClientConnectionPhases.VANILLA,
         BackendConnectionPhases.VANILLA);
+    this.hostName = hostName;
   }
 
-  @Override
-  public GameProfile addGameProfileTokensIfRequired(GameProfile original,
-      PlayerInfoForwarding forwardingType) {
-    if (forwardingType == PlayerInfoForwarding.MODERN) {
-      return original.addProperty(IS_FORGE_CLIENT_PROPERTY);
+  /**
+   * Align the acquisition logic with the internal code of Forge.
+   *
+   * @return returns the final correct hostname
+   */
+  public String getModernToken() {
+    int natVersion = 0;
+    int idx = hostName.indexOf('\0');
+    if (idx != -1) {
+      for (var pt : hostName.split("\0")) {
+        if (pt.startsWith(MODERN_FORGE_TOKEN)) {
+          if (pt.length() > MODERN_FORGE_TOKEN.length()) {
+            natVersion = Integer.parseInt(
+                    pt.substring(MODERN_FORGE_TOKEN.length()));
+          }
+        }
+      }
     }
-
-    return original;
+    return natVersion == 0 ? "\0" + MODERN_FORGE_TOKEN : "\0"
+            + MODERN_FORGE_TOKEN + natVersion;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
@@ -29,18 +29,21 @@ import com.velocitypowered.proxy.connection.util.ConnectionTypeImpl;
  */
 public class ModernForgeConnectionType extends ConnectionTypeImpl {
 
-    private static final GameProfile.Property IS_FORGE_CLIENT_PROPERTY =
-            new GameProfile.Property("forgeClient", "true", "");
+  private static final GameProfile.Property IS_FORGE_CLIENT_PROPERTY =
+      new GameProfile.Property("forgeClient", "true", "");
 
-    public ModernForgeConnectionType() {
-        super(ClientConnectionPhases.VANILLA, BackendConnectionPhases.VANILLA);
+  public ModernForgeConnectionType() {
+    super(ClientConnectionPhases.VANILLA,
+        BackendConnectionPhases.VANILLA);
+  }
+
+  @Override
+  public GameProfile addGameProfileTokensIfRequired(GameProfile original,
+      PlayerInfoForwarding forwardingType) {
+    if (forwardingType == PlayerInfoForwarding.MODERN) {
+      return original.addProperty(IS_FORGE_CLIENT_PROPERTY);
     }
 
-    @Override
-    public GameProfile addGameProfileTokensIfRequired(GameProfile original,PlayerInfoForwarding forwardingType) {
-        if (forwardingType == PlayerInfoForwarding.MODERN) {
-            original.addProperty(IS_FORGE_CLIENT_PROPERTY);
-        }
-        return original;
-    }
+    return original;
+  }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2018-2023 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.connection.forge.modern;
+
+import com.velocitypowered.api.util.GameProfile;
+import com.velocitypowered.proxy.config.PlayerInfoForwarding;
+import com.velocitypowered.proxy.connection.ConnectionTypes;
+import com.velocitypowered.proxy.connection.backend.BackendConnectionPhases;
+import com.velocitypowered.proxy.connection.client.ClientConnectionPhases;
+import com.velocitypowered.proxy.connection.util.ConnectionTypeImpl;
+
+/**
+ * Contains extra logic for {@link ConnectionTypes#MODERN_FORGE}.
+ */
+public class ModernForgeConnectionType extends ConnectionTypeImpl {
+
+    private static final GameProfile.Property IS_FORGE_CLIENT_PROPERTY =
+            new GameProfile.Property("forgeClient", "true", "");
+
+    public ModernForgeConnectionType() {
+        super(ClientConnectionPhases.VANILLA, BackendConnectionPhases.VANILLA);
+    }
+
+    @Override
+    public GameProfile addGameProfileTokensIfRequired(GameProfile original,PlayerInfoForwarding forwardingType) {
+        if (forwardingType == PlayerInfoForwarding.MODERN) {
+            original.addProperty(IS_FORGE_CLIENT_PROPERTY);
+        }
+        return original;
+    }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
@@ -21,10 +21,29 @@ package com.velocitypowered.proxy.connection.forge.modern;
  * Constants for use with Modern Forge systems.
  */
 public class ModernForgeConstants {
-  public static final String MODERN_FORGE_TOKEN = "\0FORGE";
-  public static String MODERN_FORGE_HOSTNAME_TOKEN = "";
+  public static final String MODERN_FORGE_TOKEN = "FORGE";
+  public static int MODERN_FORGE_NAT_VERSION = 0;
 
   public static String getModernForgeHostnameToken() {
-    return MODERN_FORGE_HOSTNAME_TOKEN.isEmpty() ? MODERN_FORGE_TOKEN : MODERN_FORGE_HOSTNAME_TOKEN;
+    return MODERN_FORGE_NAT_VERSION == 0 ? MODERN_FORGE_TOKEN : "\0"
+            + MODERN_FORGE_TOKEN + MODERN_FORGE_NAT_VERSION;
+  }
+
+  /**
+   * Align the acquisition logic with the internal code of Forge.
+   *
+   * @param hostName address from the client
+   */
+  public static void initNatVersion(String hostName) {
+    int idx = hostName.indexOf('\0');
+    if (idx != -1) {
+      for (var pt : hostName.split("\0")) {
+        if (pt.startsWith(MODERN_FORGE_TOKEN)) {
+          if (pt.length() > MODERN_FORGE_TOKEN.length()) {
+            MODERN_FORGE_NAT_VERSION = Integer.parseInt(pt.substring(MODERN_FORGE_TOKEN.length()));
+          }
+        }
+      }
+    }
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
@@ -25,7 +25,7 @@ public class ModernForgeConstants {
   public static int MODERN_FORGE_NAT_VERSION = 0;
 
   public static String getModernForgeHostnameToken() {
-    return MODERN_FORGE_NAT_VERSION == 0 ? MODERN_FORGE_TOKEN : "\0"
+    return MODERN_FORGE_NAT_VERSION == 0 ? "\0" + MODERN_FORGE_TOKEN : "\0"
             + MODERN_FORGE_TOKEN + MODERN_FORGE_NAT_VERSION;
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
@@ -21,5 +21,10 @@ package com.velocitypowered.proxy.connection.forge.modern;
  * Constants for use with Modern Forge systems.
  */
 public class ModernForgeConstants {
-  public static final String MODERN_HANDSHAKE_HOSTNAME_TOKEN = "\0FORGE";
+  public static final String MODERN_FORGE_TOKEN = "\0FORGE";
+  public static String MODERN_FORGE_HOSTNAME_TOKEN = "";
+
+  public static String getModernForgeHostnameToken() {
+    return MODERN_FORGE_HOSTNAME_TOKEN.isEmpty() ? MODERN_FORGE_TOKEN : MODERN_FORGE_HOSTNAME_TOKEN;
+  }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2018-2023 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.connection.forge.modern;
+
+/**
+ * Constants for use with Modern Forge systems.
+ */
+public class ModernForgeConstants {
+
+    public static final String MARKER = "\0FORGE";
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
@@ -21,5 +21,5 @@ package com.velocitypowered.proxy.connection.forge.modern;
  * Constants for use with Modern Forge systems.
  */
 public class ModernForgeConstants {
-  public static final String MARKER = "\0FORGE";
+  public static final String MODERN_HANDSHAKE_HOSTNAME_TOKEN = "\0FORGE";
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
@@ -22,28 +22,4 @@ package com.velocitypowered.proxy.connection.forge.modern;
  */
 public class ModernForgeConstants {
   public static final String MODERN_FORGE_TOKEN = "FORGE";
-  public static int MODERN_FORGE_NAT_VERSION = 0;
-
-  public static String getModernForgeHostnameToken() {
-    return MODERN_FORGE_NAT_VERSION == 0 ? "\0" + MODERN_FORGE_TOKEN : "\0"
-            + MODERN_FORGE_TOKEN + MODERN_FORGE_NAT_VERSION;
-  }
-
-  /**
-   * Align the acquisition logic with the internal code of Forge.
-   *
-   * @param hostName address from the client
-   */
-  public static void initNatVersion(String hostName) {
-    int idx = hostName.indexOf('\0');
-    if (idx != -1) {
-      for (var pt : hostName.split("\0")) {
-        if (pt.startsWith(MODERN_FORGE_TOKEN)) {
-          if (pt.length() > MODERN_FORGE_TOKEN.length()) {
-            MODERN_FORGE_NAT_VERSION = Integer.parseInt(pt.substring(MODERN_FORGE_TOKEN.length()));
-          }
-        }
-      }
-    }
-  }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
@@ -21,6 +21,5 @@ package com.velocitypowered.proxy.connection.forge.modern;
  * Constants for use with Modern Forge systems.
  */
 public class ModernForgeConstants {
-
-    public static final String MARKER = "\0FORGE";
+  public static final String MARKER = "\0FORGE";
 }


### PR DESCRIPTION
~~This is incomplete support. Although it can correctly identify Forge as a Forge client, there was a Packets error that I couldn't solve, which is also the reason why I sent the PR. I hope more people can solve this problem~~
This PR is fully working^_^

Testing environment:
* mohist-1.20.2 Latest Build
* velocity-3.3.0 Latest Build
* Pixelmon-1.20.2-9.2.5-universal

![image](https://github.com/PaperMC/Velocity/assets/23317456/45f5e38a-6822-4152-ace2-05641f0c2340)
From Mohist logs, it can be seen that it has been successfully identified as ConnectionType MODDED and connect to the server

~~The final result is that the server cannot be accessed:  exception encountered in com.velocitypowered.proxy.connection.backend.BackendPlaySessionHandler@ee2fab1
com.velocitypowered.proxy.util.except.QuietRuntimeException: A packet did not decode successfully (invalid data). For more information, launch Velocity with -Dvelocity.packet-decode-logging=true to see more.
https://haste.mohistmc.com/emarutavac.css~~

This PR is different from most fix plugins and mods:
They are using legacy mode
But we forwarded FORGE directly in modern mode