### PR TITLE
Fixed Legacy Ping handling

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -362,8 +362,17 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
     ensureInEventLoop();
 
     this.state = state;
-    this.channel.pipeline().get(MinecraftEncoder.class).setState(state);
-    this.channel.pipeline().get(MinecraftDecoder.class).setState(state);
+    // If the connection is LEGACY (<1.6), the decoder and encoder are not set.
+    final MinecraftEncoder minecraftEncoder = this.channel.pipeline()
+            .get(MinecraftEncoder.class);
+    if (minecraftEncoder != null) {
+      minecraftEncoder.setState(state);
+    }
+    final MinecraftDecoder minecraftDecoder = this.channel.pipeline()
+            .get(MinecraftDecoder.class);
+    if (minecraftDecoder != null) {
+      minecraftDecoder.setState(state);
+    }
 
     if (state == StateRegistry.CONFIG) {
       // Activate the play packet queue


### PR DESCRIPTION
When a legacy client pinged the server, it tried to assign the StateRegistry to the decoder and encoder of the connection, but being a legacy client it has its own legacy encoder and decoder, therefore, a NullPointerException occurred which was not shown in the console because it occurred in a netty thread.

![image](https://github.com/PaperMC/Velocity/assets/68704415/a2709d00-4bfc-4fa9-9817-e043e2af978d)

![image](https://github.com/PaperMC/Velocity/assets/68704415/25c8a514-9e22-43cb-8cae-e187690aa370)
![image](https://github.com/PaperMC/Velocity/assets/68704415/a03d3e25-88d5-4bbc-80ad-a320e676a715)


_Normally I wouldn't do this kind of fix to such old versions, but there was a guy who kept complaining about it_