### PR TITLE
Update Kyori Bom to release version

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -61,8 +61,7 @@ tasks {
             "https://guava.dev/releases/${libs.guava.get().version}/api/docs/",
             "https://google.github.io/guice/api-docs/${libs.guice.get().version}/javadoc/",
             "https://docs.oracle.com/en/java/javase/17/docs/api/",
-            //"https://jd.advntr.dev/api/${libs.adventure.bom.get().version}/",
-            "https://jd.advntr.dev/api/4.14.0/",
+            "https://jd.advntr.dev/api/${libs.adventure.bom.get().version}/",
             "https://javadoc.io/doc/com.github.ben-manes.caffeine/caffeine"
         )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ shadow = "com.github.johnrengelman.shadow:8.1.0"
 spotless = "com.diffplug.spotless:6.12.0"
 
 [libraries]
-# See JD links in velocity-apo when moving to non-snapshot versions
+# See JD links in velocity-api when moving to non-snapshot versions
 adventure-bom = "net.kyori:adventure-bom:4.15.0"
 adventure-facet = "net.kyori:adventure-platform-facet:4.3.0"
 asm = "org.ow2.asm:asm:9.5"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ spotless = "com.diffplug.spotless:6.12.0"
 
 [libraries]
 # See JD links in velocity-apo when moving to non-snapshot versions
-adventure-bom = "net.kyori:adventure-bom:4.15.0-SNAPSHOT"
+adventure-bom = "net.kyori:adventure-bom:4.15.0"
 adventure-facet = "net.kyori:adventure-platform-facet:4.3.0"
 asm = "org.ow2.asm:asm:9.5"
 asynchttpclient = "org.asynchttpclient:async-http-client:2.12.3"


### PR DESCRIPTION
When I was trying to use Kyori Adventure 4.15.0-SNAPSHOT, it couldn't be found by any maven search. Version 4.15 is also stable, as of about 3 weeks ago, so it should work.