### PR TITLE
Implement some missing resource pack API

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -231,22 +231,6 @@ public interface Player extends
   void sendResourcePackOffer(ResourcePackInfo packInfo);
 
   /**
-   * Requests that the player remove all applied resource packs. To
-   * monitor the status of any removed resource packs, subscribe to
-   * {@link PlayerResourcePackStatusEvent}.
-   */
-  void requestResourcePackRemoval();
-
-  /**
-   * Requests that the player remove a resource pack. To monitor
-   * the status of the removed resource pack, subscribe to
-   * {@link PlayerResourcePackStatusEvent}.
-   *
-   * @param packInfo the resource-pack in question
-   */
-  void requestResourcePackRemoval(ResourcePackInfo packInfo);
-
-  /**
    * Gets the {@link ResourcePackInfo} of the currently applied
    * resource-pack or null if none.
    *

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -231,8 +231,29 @@ public interface Player extends
   void sendResourcePackOffer(ResourcePackInfo packInfo);
 
   /**
+   * Requests that the player remove all applied resource packs. To
+   * monitor the status of any removed resource packs, subscribe to
+   * {@link PlayerResourcePackStatusEvent}.
+   */
+  void requestResourcePackRemoval();
+
+  /**
+   * Requests that the player remove a resource pack. To monitor
+   * the status of the removed resource pack, subscribe to
+   * {@link PlayerResourcePackStatusEvent}.
+   *
+   * @param packInfo the resource-pack in question
+   */
+  void requestResourcePackRemoval(ResourcePackInfo packInfo);
+
+  /**
    * Gets the {@link ResourcePackInfo} of the currently applied
    * resource-pack or null if none.
+   *
+   * <p> Note that since 1.20.3 it is no longer recommended to use
+   * this method as it will only return the last applied
+   * resource pack. To get all applied resource packs, use
+   * {@link #getAppliedResourcePacks()} instead. </p>
    *
    * @return the applied resource pack or null if none.
    */
@@ -244,6 +265,11 @@ public interface Player extends
    * Gets the {@link ResourcePackInfo} of the resource pack
    * the user is currently downloading or is currently
    * prompted to install or null if none.
+   *
+   * <p> Note that since 1.20.3 it is no longer recommended to use
+   * this method as it will only return the last pending
+   * resource pack. To get all pending resource packs, use
+   * {@link #getPendingResourcePacks()} instead. </p>
    *
    * @return the pending resource pack or null if none
    */

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -104,6 +104,9 @@ import net.kyori.adventure.permission.PermissionChecker;
 import net.kyori.adventure.platform.facet.FacetPointers;
 import net.kyori.adventure.platform.facet.FacetPointers.Type;
 import net.kyori.adventure.pointer.Pointers;
+import net.kyori.adventure.resource.ResourcePackInfoLike;
+import net.kyori.adventure.resource.ResourcePackRequest;
+import net.kyori.adventure.resource.ResourcePackRequestLike;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
@@ -980,18 +983,40 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   }
 
   @Override
-  public void requestResourcePackRemoval() {
+  public void clearResourcePacks() {
     if (this.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_20_3)) {
       connection.write(new RemoveResourcePackPacket());
     }
   }
 
   @Override
-  public void requestResourcePackRemoval(ResourcePackInfo packInfo) {
+  public void removeResourcePacks(@NotNull UUID id, @NotNull UUID @NotNull ... others) {
     if (this.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_20_3)) {
-      Preconditions.checkNotNull(packInfo, "packInfo");
-      Preconditions.checkNotNull(packInfo.getId(), "packInfo to remove must have an id");
-      connection.write(new RemoveResourcePackPacket(packInfo.getId()));
+      connection.write(new RemoveResourcePackPacket(id));
+      for (final UUID other : others) {
+        connection.write(new RemoveResourcePackPacket(other));
+      }
+    }
+  }
+
+  @Override
+  public void removeResourcePacks(@NotNull ResourcePackRequest request) {
+    for (final net.kyori.adventure.resource.ResourcePackInfo resourcePackInfo : request.packs()) {
+      removeResourcePacks(resourcePackInfo.id());
+    }
+  }
+
+  @Override
+  public void removeResourcePacks(@NotNull ResourcePackRequestLike request) {
+    removeResourcePacks(request.asResourcePackRequest());
+  }
+
+  @Override
+  @SuppressWarnings("checkstyle:linelength")
+  public void removeResourcePacks(@NotNull ResourcePackInfoLike request, @NotNull ResourcePackInfoLike @NotNull ... others) {
+    removeResourcePacks(request.asResourcePackInfo().id());
+    for (final ResourcePackInfoLike other : others) {
+      removeResourcePacks(other.asResourcePackInfo().id());
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ResourcePackRequestPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ResourcePackRequestPacket.java
@@ -146,7 +146,12 @@ public class ResourcePackRequestPacket implements MinecraftPacket {
 
   @Override
   public String toString() {
-    return "ResourcePackRequest{" + "url='" + url + '\'' + ", hash='" + hash + '\'' +
-        ", isRequired=" + isRequired + ", prompt='" + prompt + '\'' + '}';
+    return "ResourcePackRequestPacket{" +
+            "id=" + id +
+            ", url='" + url + '\'' +
+            ", hash='" + hash + '\'' +
+            ", isRequired=" + isRequired +
+            ", prompt=" + prompt +
+            '}';
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ResourcePackResponsePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ResourcePackResponsePacket.java
@@ -83,6 +83,10 @@ public class ResourcePackResponsePacket implements MinecraftPacket {
 
   @Override
   public String toString() {
-    return "ResourcePackResponse{" + "hash=" + hash + ", " + "status=" + status + '}';
+    return "ResourcePackResponsePacket{" +
+            "id=" + id +
+            ", hash='" + hash + '\'' +
+            ", status=" + status +
+            '}';
   }
 }


### PR DESCRIPTION
Just taking a quick jab at this, looking to re-ignite some discussion around filling some gaps in the current API / implementation for resource packs.

~This does not attempt to implement adventure's new resource pack API currently, as nothing else in Velocity currently uses it, and it seemed strange to me to use it only for the new methods added here - should probably be addressed in a separate PR (possibly resulting in a quick deprecation along with a lot of the other resource pack API).~
We're going on an adventure.

The tracking for pending/applied resource packs gets a little weird since older packs don't have an ID, but it at least implements the current stub API method making it usable.

Also for `getAppliedResourcePack` and `getPendingResourcePack` I added a note regarding the return value as this is always going to be incorrect when used on players on 1.20.3+ since they can have several packs. The API will just return the last pack applied or pending. I think it's worth considering strengthening the deprecation to for removal as well.