### PR TITLE
Validate plugin dependency IDs in accordance to plugin ID requirements

### DIFF
--- a/api/src/ap/java/com/velocitypowered/api/plugin/ap/PluginAnnotationProcessor.java
+++ b/api/src/ap/java/com/velocitypowered/api/plugin/ap/PluginAnnotationProcessor.java
@@ -9,6 +9,7 @@ package com.velocitypowered.api.plugin.ap;
 
 import com.google.auto.service.AutoService;
 import com.google.gson.Gson;
+import com.velocitypowered.api.plugin.Dependency;
 import com.velocitypowered.api.plugin.Plugin;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -85,6 +86,16 @@ public class PluginAnnotationProcessor extends AbstractProcessor {
             + ". IDs must start alphabetically, have lowercase alphanumeric characters, and "
             + "can contain dashes or underscores.");
         return false;
+      }
+
+      for (Dependency dependency : plugin.dependencies()) {
+        if (!SerializedPluginDescription.ID_PATTERN.matcher(dependency.id()).matches()) {
+          environment.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                  "Invalid dependency ID '" + dependency.id() + "' for plugin " + qualifiedName
+                  + ". IDs must start alphabetically, have lowercase alphanumeric characters, and "
+                  + "can contain dashes or underscores.");
+          return false;
+        }
       }
 
       // All good, generate the velocity-plugin.json.

--- a/proxy/src/main/java/com/velocitypowered/proxy/plugin/loader/java/JavaPluginLoader.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/plugin/loader/java/JavaPluginLoader.java
@@ -72,6 +72,14 @@ public class JavaPluginLoader implements PluginLoader {
       throw new InvalidPluginException("Plugin ID '" + pd.getId() + "' is invalid.");
     }
 
+    for (SerializedPluginDescription.Dependency dependency : pd.getDependencies()) {
+      if (!SerializedPluginDescription.ID_PATTERN.matcher(dependency.getId()).matches()) {
+        throw new InvalidPluginException(
+            "Dependency ID '" + dependency.getId() + "' for plugin '" + pd.getId() + "' is invalid."
+        );
+      }
+    }
+
     return createCandidateDescription(pd, source);
   }
 


### PR DESCRIPTION
As-is, the `@Plugin` annotation processor doesn't validate IDs of specified dependencies, allowing the accidental declaration of a dependency that cannot be satisfied. 

Example:
![image](https://github.com/PaperMC/Velocity/assets/17730120/117c0ed6-92ea-4659-ae76-e434091ad769)
![image](https://github.com/PaperMC/Velocity/assets/17730120/674b8fdd-7169-4ece-9393-4d6871bbf7c7)
 
The changes appear to compile and work as intended: 
![image](https://github.com/PaperMC/Velocity/assets/17730120/58799f9b-6a4c-4250-a3ed-3d7771674ad8)
![image](https://github.com/PaperMC/Velocity/assets/17730120/1062a4a2-eb67-49fe-9565-21f279175212)
