### PR TITLE
Add API for custom chat completions like on Paper

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -309,4 +309,33 @@ public interface Player extends
    * @return the player's client brand
    */
   @Nullable String getClientBrand();
+
+
+  /**
+   * Add custom chat completion suggestions shown to the player while typing a message.
+   *
+   * @param completions the completions to send
+   */
+  void addCustomChatCompletions(@NotNull Collection<String> completions);
+
+  /**
+   * Remove custom chat completion suggestions shown to the player while typing a message.
+   *
+   * <p>Online player names can't be removed with this method, it will only affect
+   * custom completions added by {@link #addCustomChatCompletions(Collection)}
+   * or {@link #setCustomChatCompletions(Collection)}.
+   *
+   * @param completions the completions to remove
+   */
+  void removeCustomChatCompletions(@NotNull Collection<String> completions);
+
+  /**
+   * Set the list of chat completion suggestions shown to the player while typing a message.
+   *
+   * <p>If completions were set previously, this method will remove them all
+   * and replace them with the provided completions.
+   *
+   * @param completions the completions to set
+   */
+  void setCustomChatCompletions(@NotNull Collection<String> completions);
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -967,22 +967,27 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
 
   @Override
   public void addCustomChatCompletions(@NotNull Collection<String> completions) {
+    Preconditions.checkNotNull(completions, "completions");
     this.sendCustomChatCompletionPacket(completions, PlayerChatCompletionPacket.Action.ADD);
   }
 
   @Override
   public void removeCustomChatCompletions(@NotNull Collection<String> completions) {
+    Preconditions.checkNotNull(completions, "completions");
     this.sendCustomChatCompletionPacket(completions, PlayerChatCompletionPacket.Action.REMOVE);
   }
 
   @Override
   public void setCustomChatCompletions(@NotNull Collection<String> completions) {
+    Preconditions.checkNotNull(completions, "completions");
     this.sendCustomChatCompletionPacket(completions, PlayerChatCompletionPacket.Action.SET);
   }
 
   private void sendCustomChatCompletionPacket(@NotNull Collection<String> completions,
                                               PlayerChatCompletionPacket.Action action) {
-    connection.write(new PlayerChatCompletionPacket(completions.toArray(new String[0]), action));
+    if (connection.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_19_1)) {
+      connection.write(new PlayerChatCompletionPacket(completions.toArray(new String[0]), action));
+    }
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -70,6 +70,7 @@ import com.velocitypowered.proxy.protocol.packet.ResourcePackRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatQueue;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatType;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
+import com.velocitypowered.proxy.protocol.packet.chat.PlayerChatCompletionPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.builder.ChatBuilderFactory;
 import com.velocitypowered.proxy.protocol.packet.chat.legacy.LegacyChatPacket;
 import com.velocitypowered.proxy.protocol.packet.config.StartUpdatePacket;
@@ -962,6 +963,26 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
 
   void setClientBrand(String clientBrand) {
     this.clientBrand = clientBrand;
+  }
+
+  @Override
+  public void addCustomChatCompletions(@NotNull Collection<String> completions) {
+    this.sendCustomChatCompletionPacket(completions, PlayerChatCompletionPacket.Action.ADD);
+  }
+
+  @Override
+  public void removeCustomChatCompletions(@NotNull Collection<String> completions) {
+    this.sendCustomChatCompletionPacket(completions, PlayerChatCompletionPacket.Action.REMOVE);
+  }
+
+  @Override
+  public void setCustomChatCompletions(@NotNull Collection<String> completions) {
+    this.sendCustomChatCompletionPacket(completions, PlayerChatCompletionPacket.Action.SET);
+  }
+
+  private void sendCustomChatCompletionPacket(@NotNull Collection<String> completions,
+                                              PlayerChatCompletionPacket.Action action) {
+    connection.write(new PlayerChatCompletionPacket(completions.toArray(new String[0]), action));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/PlayerChatCompletionPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/PlayerChatCompletionPacket.java
@@ -28,6 +28,13 @@ public class PlayerChatCompletionPacket implements MinecraftPacket {
   private String[] completions;
   private Action action;
 
+  public PlayerChatCompletionPacket() {
+  }
+
+  public PlayerChatCompletionPacket(String[] completions, Action action) {
+    this.completions = completions;
+    this.action = action;
+  }
 
   public String[] getCompletions() {
     return completions;
@@ -64,9 +71,9 @@ public class PlayerChatCompletionPacket implements MinecraftPacket {
     return handler.handle(this);
   }
 
-  enum Action {
+  public enum Action {
     ADD,
     REMOVE,
-    ALTER
+    SET
   }
 }


### PR DESCRIPTION
I added 3 API methods to the Player class like they are present on Paper. It compiled successfully and appears to work: 
![image](https://github.com/PaperMC/Velocity/assets/17730120/da5109a1-ca92-4d24-9c40-31a8bb8fe8c2)

The reason for changing the single enumeration is that it's name, `ALTER`, does not seem to match it's function or the name used by Mojang/Yarn/Searge mappings, which call it `SET`.
The change shouldn't be breaking, as the enum class isn't part of the public API and not directly called in the internal API

Please let me know if something is wrong/not to your likings.