### PR TITLE
Update GitHub actions to the latest versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,14 +9,13 @@ jobs:
   build-17:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: gradle/wrapper-validation-action@v1
+    - uses: actions/checkout@v4
+    - uses: gradle/wrapper-validation-action@v2
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: 'temurin'
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+        cache: 'gradle'
     - name: Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
As Node.js 16 actions are deprecated according to GitHub, I have updated all of the GitHub actions to their latest versions. I also went ahead and enabled caching to shave off about half a minute of build time, not sure if you want this, but let me know if not. 

I also removed an unnecessary build step. You do not need to manually make gradlew executable, it already is.