### PR TITLE
Remove duplicate space from log pattern

### DIFF
--- a/proxy/src/main/resources/log4j2.xml
+++ b/proxy/src/main/resources/log4j2.xml
@@ -33,7 +33,7 @@
       filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz"
       immediateFlush="false">
       <PatternLayout
-        pattern="[%d{HH:mm:ss}] [%t/%level] [%logger]:  %stripAnsi{%msg}%n"/>
+        pattern="[%d{HH:mm:ss}] [%t/%level] [%logger]: %stripAnsi{%msg}%n"/>
       <Policies>
         <TimeBasedTriggeringPolicy/>
         <OnStartupTriggeringPolicy/>


### PR DESCRIPTION
This PR removes a duplicate space from the log pattern that was introduced in [a recent commit](https://github.com/PaperMC/Velocity/commit/28acf9eac1440947e6635d420c706326470c316a#diff-ac531cff5de2f36726f6c75ddcc1ccd6f0270e1d602661fee4d8c7d05b87a25bR36)

It looks like this was done on accident. If this second space is intended, please let me know.