### PR TITLE
Remove duplicate space from NativeZlibInflate

### DIFF
--- a/native/src/main/java/com/velocitypowered/natives/compression/NativeZlibInflate.java
+++ b/native/src/main/java/com/velocitypowered/natives/compression/NativeZlibInflate.java
@@ -28,6 +28,6 @@ class NativeZlibInflate {
 
   static native long free(long ctx);
 
-  static  native boolean process(long ctx, long sourceAddress, int sourceLength,
+  static native boolean process(long ctx, long sourceAddress, int sourceLength,
       long destinationAddress, int destinationLength) throws DataFormatException;
 }


### PR DESCRIPTION
As suggested, this PR eliminates the additional space in NativeZlibInflate, that appears to desynchronize with the format of NativeZlibDeflate.