### PR TITLE
Update Adventure to 4.16.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,11 +7,11 @@ netty = "4.1.106.Final"
 
 [plugins]
 indra-publishing = "net.kyori.indra.publishing:2.0.6"
-shadow = "com.github.johnrengelman.shadow:8.1.1"
+shadow = "io.github.goooler.shadow:8.1.5"
 spotless = "com.diffplug.spotless:6.12.0"
 
 [libraries]
-adventure-bom = "net.kyori:adventure-bom:4.15.0"
+adventure-bom = "net.kyori:adventure-bom:4.16.0"
 adventure-facet = "net.kyori:adventure-platform-facet:4.3.2"
 asm = "org.ow2.asm:asm:9.6"
 auto-service = "com.google.auto.service:auto-service:1.0.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Also migrated shadow from `com.github.johnrengelman.shadow` to `io.github.goooler.shadow`, which fixes the project compilation using Java 21 and Gradle 8.6 https://github.com/johnrengelman/shadow/pull/876