### PR TITLE
Fix duplicate sending of resource packs responses to backend server

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -95,9 +95,6 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(ResourcePackResponsePacket packet) {
-    if (player.getConnectionInFlight() != null) {
-      player.getConnectionInFlight().ensureConnected().write(packet);
-    }
     return player.resourcePackHandler().onResourcePackResponse(
         new ResourcePackResponseBundle(packet.getId(),
             packet.getHash(),

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ModernResourcePackHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ModernResourcePackHandler.java
@@ -146,10 +146,20 @@ public final class ModernResourcePackHandler extends ResourcePackHandler {
       }
       // The resource pack has been applied correctly.
       case SUCCESSFUL -> {
+        pendingResourcePacks.remove(uuid);
         if (queued != null) {
           appliedResourcePacks.put(uuid, queued);
+        } else {
+          // When transitioning to another server that has a resource pack to apply,
+          // if one or more resource packs have already been applied from Velocity,
+          // the player sends more than 1 SUCCESSFUL response to the backend server,
+          // which results in the server receiving more resource pack responses
+          // than the server has sent requests to the player
+          final ResourcePackInfo appliedPack = appliedResourcePacks.get(uuid);
+          if (appliedPack != null) {
+            return handleResponseResult(appliedPack, bundle);
+          }
         }
-        pendingResourcePacks.remove(uuid);
       }
       // An error occurred while trying to download the resource pack to the client,
       // so the resource pack cannot be applied.


### PR DESCRIPTION
Also fixes the sending of SUCCESSFUL responses to the backend server that will apply a resource pack in case Velocity has already applied one or more resource packs to the player

fixes #1247 