### PR TITLE
Improved PluginMessaging API by adding a method to easily encode the data to be sent

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -288,7 +288,7 @@ public interface Player extends
    * @inheritDoc
    */
   @Override
-  boolean sendPluginMessage(ChannelIdentifier identifier, byte[] data);
+  boolean sendPluginMessage(@NotNull ChannelIdentifier identifier, byte @NotNull [] data);
 
   @Override
   default @NotNull Key key() {

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -7,6 +7,7 @@
 
 package com.velocitypowered.api.proxy;
 
+import com.google.common.io.ByteArrayDataOutput;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.event.player.PlayerResourcePackStatusEvent;
 import com.velocitypowered.api.proxy.crypto.KeyIdentifiable;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.key.Key;
@@ -281,14 +283,52 @@ public interface Player extends
   /**
    * <strong>Note that this method does not send a plugin message to the server the player
    * is connected to.</strong> You should only use this method if you are trying to communicate
-   * with a mod that is installed on the player's client. To send a plugin message to the server
+   * with a mod that is installed on the player's client.
+   *
+   * <p>To send a plugin message to the server
    * from the player, you should use the equivalent method on the instance returned by
    * {@link #getCurrentServer()}.
+   *
+   * <pre>
+   *    final ChannelIdentifier identifier;
+   *    final Player player;
+   *    player.getCurrentServer()
+   *          .map(ServerConnection::getServer)
+   *          .ifPresent((RegisteredServer server) -> {
+   *            server.sendPluginMessage(identifier, data);
+   *          });
+   *  </pre>
    *
    * @inheritDoc
    */
   @Override
   boolean sendPluginMessage(@NotNull ChannelIdentifier identifier, byte @NotNull [] data);
+
+  /**
+   * {@inheritDoc}
+   *
+   * <strong>Note that this method does not send a plugin message to the server the player
+   * is connected to.</strong> You should only use this method if you are trying to communicate
+   * with a mod that is installed on the player's client.
+   *
+   * <p>To send a plugin message to the server
+   * from the player, you should use the equivalent method on the instance returned by
+   * {@link #getCurrentServer()}.
+   *
+   * <pre>
+   *   final ChannelIdentifier identifier;
+   *   final Player player;
+   *   player.getCurrentServer()
+   *         .map(ServerConnection::getServer)
+   *         .ifPresent((RegisteredServer server) -> {
+   *           server.sendPluginMessage(identifier, dataEncoder);
+   *         });
+   * </pre>
+   *
+   * @inheritDoc
+   */
+  @Override
+  boolean sendPluginMessage(@NotNull ChannelIdentifier identifier, @NotNull Consumer<ByteArrayDataOutput> dataEncoder);
 
   @Override
   default @NotNull Key key() {

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -7,13 +7,13 @@
 
 package com.velocitypowered.api.proxy;
 
-import com.google.common.io.ByteArrayDataOutput;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.event.player.PlayerResourcePackStatusEvent;
 import com.velocitypowered.api.proxy.crypto.KeyIdentifiable;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.messages.ChannelMessageSink;
 import com.velocitypowered.api.proxy.messages.ChannelMessageSource;
+import com.velocitypowered.api.proxy.messages.PluginMessageEncoder;
 import com.velocitypowered.api.proxy.player.PlayerSettings;
 import com.velocitypowered.api.proxy.player.ResourcePackInfo;
 import com.velocitypowered.api.proxy.player.TabList;
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.inventory.Book;
@@ -284,9 +283,11 @@ public interface Player extends
   @NotNull Collection<ResourcePackInfo> getPendingResourcePacks();
 
   /**
-   * <strong>Note that this method does not send a plugin message to the server the player
+   * {@inheritDoc}
+   *
+   * <p><strong>Note that this method does not send a plugin message to the server the player
    * is connected to.</strong> You should only use this method if you are trying to communicate
-   * with a mod that is installed on the player's client.
+   * with a mod that is installed on the player's client.</p>
    *
    * <p>To send a plugin message to the server
    * from the player, you should use the equivalent method on the instance returned by
@@ -302,36 +303,22 @@ public interface Player extends
    *          });
    *  </pre>
    *
-   * @inheritDoc
    */
   @Override
   boolean sendPluginMessage(@NotNull ChannelIdentifier identifier, byte @NotNull [] data);
 
   /**
    * {@inheritDoc}
-   *
-   * <strong>Note that this method does not send a plugin message to the server the player
+   * <p><strong>Note that this method does not send a plugin message to the server the player
    * is connected to.</strong> You should only use this method if you are trying to communicate
-   * with a mod that is installed on the player's client.
+   * with a mod that is installed on the player's client.</p>
    *
    * <p>To send a plugin message to the server
    * from the player, you should use the equivalent method on the instance returned by
    * {@link #getCurrentServer()}.
-   *
-   * <pre>
-   *   final ChannelIdentifier identifier;
-   *   final Player player;
-   *   player.getCurrentServer()
-   *         .map(ServerConnection::getServer)
-   *         .ifPresent((RegisteredServer server) -> {
-   *           server.sendPluginMessage(identifier, dataEncoder);
-   *         });
-   * </pre>
-   *
-   * @inheritDoc
    */
   @Override
-  boolean sendPluginMessage(@NotNull ChannelIdentifier identifier, @NotNull Consumer<ByteArrayDataOutput> dataEncoder);
+  boolean sendPluginMessage(@NotNull ChannelIdentifier identifier, @NotNull PluginMessageEncoder dataEncoder);
 
   @Override
   default @NotNull Key key() {

--- a/api/src/main/java/com/velocitypowered/api/proxy/messages/ChannelMessageSink.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/messages/ChannelMessageSink.java
@@ -7,8 +7,7 @@
 
 package com.velocitypowered.api.proxy.messages;
 
-import com.google.common.io.ByteArrayDataOutput;
-import java.util.function.Consumer;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -41,7 +40,8 @@ public interface ChannelMessageSink {
    * @param dataEncoder the encoder of the data to be sent
    * @return whether the message could be sent
    */
+  @ApiStatus.Experimental
   boolean sendPluginMessage(
           @NotNull ChannelIdentifier identifier,
-          @NotNull Consumer<ByteArrayDataOutput> dataEncoder);
+          @NotNull PluginMessageEncoder dataEncoder);
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/messages/ChannelMessageSink.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/messages/ChannelMessageSink.java
@@ -7,6 +7,10 @@
 
 package com.velocitypowered.api.proxy.messages;
 
+import com.google.common.io.ByteArrayDataOutput;
+import java.util.function.Consumer;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents something that can be sent plugin messages.
  */
@@ -19,5 +23,9 @@ public interface ChannelMessageSink {
    * @param data the data to send
    * @return whether or not the message could be sent
    */
-  boolean sendPluginMessage(ChannelIdentifier identifier, byte[] data);
+  boolean sendPluginMessage(@NotNull ChannelIdentifier identifier, byte @NotNull[] data);
+
+  boolean sendPluginMessage(
+          @NotNull ChannelIdentifier identifier,
+          @NotNull Consumer<ByteArrayDataOutput> dataEncoder);
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/messages/ChannelMessageSink.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/messages/ChannelMessageSink.java
@@ -25,6 +25,22 @@ public interface ChannelMessageSink {
    */
   boolean sendPluginMessage(@NotNull ChannelIdentifier identifier, byte @NotNull[] data);
 
+  /**
+   * Sends a plugin message to this target.
+   *
+   * <pre>
+   *   final ChannelMessageSink target;
+   *   final ChannelIdentifier identifier;
+   *   final boolean result = target.sendPluginMessage(identifier, (output) -> {
+   *     output.writeUTF("some input");
+   *     output.writeInt(1);
+   *   });
+   * </pre>
+   *
+   * @param identifier the channel identifier to send the message on
+   * @param dataEncoder the encoder of the data to be sent
+   * @return whether the message could be sent
+   */
   boolean sendPluginMessage(
           @NotNull ChannelIdentifier identifier,
           @NotNull Consumer<ByteArrayDataOutput> dataEncoder);

--- a/api/src/main/java/com/velocitypowered/api/proxy/messages/PluginMessageEncoder.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/messages/PluginMessageEncoder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.proxy.messages;
+
+import com.google.common.io.ByteArrayDataOutput;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A data encoder to be sent via a plugin message.
+ *
+ * @since 3.3.0
+ */
+@FunctionalInterface
+@ApiStatus.Experimental
+public interface PluginMessageEncoder {
+
+  /**
+   * Encodes data into a {@link ByteArrayDataOutput} to be transmitted by plugin messages.
+   *
+   * @param output the {@link ByteArrayDataOutput} provided
+   */
+  void encode(@NotNull ByteArrayDataOutput output);
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/adventure/ComponentLoggerProviderImpl.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/adventure/ComponentLoggerProviderImpl.java
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.velocitypowered.proxy.provider;
+package com.velocitypowered.proxy.adventure;
 
 import com.google.auto.service.AutoService;
 import com.velocitypowered.proxy.util.TranslatableMapper;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -22,10 +22,10 @@ import static com.velocitypowered.proxy.network.Connections.HANDLER;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;
-import com.google.common.io.ByteArrayDataOutput;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.ServerConnection;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
+import com.velocitypowered.api.proxy.messages.PluginMessageEncoder;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
 import com.velocitypowered.proxy.VelocityServer;
@@ -52,7 +52,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -270,13 +269,13 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
   @Override
   public boolean sendPluginMessage(
           final @NotNull ChannelIdentifier identifier,
-          final @NotNull Consumer<ByteArrayDataOutput> dataEncoder
+          final @NotNull PluginMessageEncoder dataEncoder
   ) {
     requireNonNull(identifier);
     requireNonNull(dataEncoder);
     final ByteBuf buf = Unpooled.buffer();
     final ByteBufDataOutput dataOutput = new ByteBufDataOutput(buf);
-    dataEncoder.accept(dataOutput);
+    dataEncoder.encode(dataOutput);
     if (buf.isReadable()) {
       return sendPluginMessage(identifier, buf);
     } else {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -19,8 +19,10 @@ package com.velocitypowered.proxy.connection.backend;
 
 import static com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConstants.HANDSHAKE_HOSTNAME_TOKEN;
 import static com.velocitypowered.proxy.network.Connections.HANDLER;
+import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;
+import com.google.common.io.ByteArrayDataOutput;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.ServerConnection;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
@@ -41,6 +43,7 @@ import com.velocitypowered.proxy.protocol.packet.HandshakePacket;
 import com.velocitypowered.proxy.protocol.packet.JoinGamePacket;
 import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
 import com.velocitypowered.proxy.protocol.packet.ServerLoginPacket;
+import com.velocitypowered.proxy.protocol.util.ByteBufDataOutput;
 import com.velocitypowered.proxy.server.VelocityRegisteredServer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -49,9 +52,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Handles a connection from the proxy to some backend server.
@@ -255,8 +260,29 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
   }
 
   @Override
-  public boolean sendPluginMessage(ChannelIdentifier identifier, byte[] data) {
+  public boolean sendPluginMessage(
+          final @NotNull ChannelIdentifier identifier,
+          final byte @NotNull [] data
+  ) {
     return sendPluginMessage(identifier, Unpooled.wrappedBuffer(data));
+  }
+
+  @Override
+  public boolean sendPluginMessage(
+          final @NotNull ChannelIdentifier identifier,
+          final @NotNull Consumer<ByteArrayDataOutput> dataEncoder
+  ) {
+    requireNonNull(identifier);
+    requireNonNull(dataEncoder);
+    final ByteBuf buf = Unpooled.buffer();
+    final ByteBufDataOutput dataOutput = new ByteBufDataOutput(buf);
+    dataEncoder.accept(dataOutput);
+    if (buf.isReadable()) {
+      return sendPluginMessage(identifier, buf);
+    } else {
+      buf.release();
+      return false;
+    }
   }
 
   /**
@@ -270,9 +296,9 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
     Preconditions.checkNotNull(identifier, "identifier");
     Preconditions.checkNotNull(data, "data");
 
-    MinecraftConnection mc = ensureConnected();
+    final MinecraftConnection mc = ensureConnected();
 
-    PluginMessagePacket message = new PluginMessagePacket(identifier.getId(), data);
+    final PluginMessagePacket message = new PluginMessagePacket(identifier.getId(), data);
     mc.write(message);
     return true;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -23,7 +23,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 import com.google.common.base.Preconditions;
-import com.google.common.io.ByteArrayDataOutput;
 import com.google.gson.JsonObject;
 import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.connection.DisconnectEvent.LoginStatus;
@@ -45,6 +44,7 @@ import com.velocitypowered.api.proxy.ServerConnection;
 import com.velocitypowered.api.proxy.crypto.IdentifiedKey;
 import com.velocitypowered.api.proxy.crypto.KeyIdentifiable;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
+import com.velocitypowered.api.proxy.messages.PluginMessageEncoder;
 import com.velocitypowered.api.proxy.player.PlayerSettings;
 import com.velocitypowered.api.proxy.player.ResourcePackInfo;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
@@ -99,7 +99,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Consumer;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.identity.Identity;
@@ -960,13 +959,13 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   @Override
   public boolean sendPluginMessage(
           final @NotNull ChannelIdentifier identifier,
-          @NotNull Consumer<ByteArrayDataOutput> dataEncoder
+          final @NotNull PluginMessageEncoder dataEncoder
   ) {
     requireNonNull(identifier);
     requireNonNull(dataEncoder);
     final ByteBuf buf = Unpooled.buffer();
     final ByteBufDataOutput dataOutput = new ByteBufDataOutput(buf);
-    dataEncoder.accept(dataOutput);
+    dataEncoder.encode(dataOutput);
     if (buf.isReadable()) {
       final PluginMessagePacket message = new PluginMessagePacket(identifier.getId(), buf);
       connection.write(message);

--- a/proxy/src/main/java/com/velocitypowered/proxy/server/VelocityRegisteredServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/server/VelocityRegisteredServer.java
@@ -27,9 +27,9 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.ByteArrayDataOutput;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
+import com.velocitypowered.api.proxy.messages.PluginMessageEncoder;
 import com.velocitypowered.api.proxy.server.PingOptions;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
@@ -58,7 +58,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -157,13 +156,13 @@ public class VelocityRegisteredServer implements RegisteredServer, ForwardingAud
   @Override
   public boolean sendPluginMessage(
           final @NotNull ChannelIdentifier identifier,
-          final @NotNull Consumer<ByteArrayDataOutput> dataEncoder
+          final @NotNull PluginMessageEncoder dataEncoder
   ) {
     requireNonNull(identifier);
     requireNonNull(dataEncoder);
     final ByteBuf buf = Unpooled.buffer();
     final ByteBufDataOutput dataInput = new ByteBufDataOutput(buf);
-    dataEncoder.accept(dataInput);
+    dataEncoder.encode(dataInput);
     if (buf.isReadable()) {
       return sendPluginMessage(identifier, buf);
     } else {


### PR DESCRIPTION
partially implements https://github.com/PaperMC/Velocity/issues/224

```java
final ChannelMessageSink target;
final ChannelIdentifier identifier;
final boolean result = target.sendPluginMessage(identifier, (output) -> {
    output.writeUTF("some input");
    output.writeInt(1);
});
 ```