### PR TITLE
Use the default Minecraft port instead of custom one

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -59,7 +59,7 @@ public class VelocityConfiguration implements ProxyConfig {
   private static final Logger logger = LogManager.getLogger(VelocityConfiguration.class);
 
   @Expose
-  private String bind = "0.0.0.0:25577";
+  private String bind = "0.0.0.0:25565";
   @Expose
   private String motd = "<aqua>A Velocity Server";
   @Expose
@@ -497,7 +497,7 @@ public class VelocityConfiguration implements ProxyConfig {
       final PingPassthroughMode pingPassthroughMode = config.getEnumOrElse("ping-passthrough",
               PingPassthroughMode.DISABLED);
 
-      final String bind = config.getOrElse("bind", "0.0.0.0:25577");
+      final String bind = config.getOrElse("bind", "0.0.0.0:25565");
       final int maxPlayers = config.getIntOrElse("show-max-players", 500);
       final boolean onlineMode = config.getOrElse("online-mode", true);
       final boolean forceKeyAuthentication = config.getOrElse("force-key-authentication", true);
@@ -816,7 +816,7 @@ public class VelocityConfiguration implements ProxyConfig {
     @Expose
     private boolean queryEnabled = false;
     @Expose
-    private int queryPort = 25577;
+    private int queryPort = 25565;
     @Expose
     private String queryMap = "Velocity";
     @Expose
@@ -835,7 +835,7 @@ public class VelocityConfiguration implements ProxyConfig {
     private Query(CommentedConfig config) {
       if (config != null) {
         this.queryEnabled = config.getOrElse("enabled", false);
-        this.queryPort = config.getIntOrElse("port", 25577);
+        this.queryPort = config.getIntOrElse("port", 25565);
         this.queryMap = config.getOrElse("map", "Velocity");
         this.showPlugins = config.getOrElse("show-plugins", false);
       }

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -1,8 +1,8 @@
 # Config version. Do not change this
 config-version = "2.6"
 
-# What port should the proxy be bound to? By default, we'll bind to all addresses on port 25577.
-bind = "0.0.0.0:25577"
+# What port should the proxy be bound to? By default, we'll bind to all addresses on port 25565.
+bind = "0.0.0.0:25565"
 
 # What should be the MOTD? This gets displayed when the player adds your server to
 # their server list. Only MiniMessage format is accepted.
@@ -146,7 +146,7 @@ log-player-connections = true
 enabled = false
 
 # If query is enabled, on what port should the query protocol listen on?
-port = 25577
+port = 25565
 
 # This is the map name that is reported to the query services.
 map = "Velocity"


### PR DESCRIPTION
Currently Velocity uses the custom port `25577` in its default config which does not make any sense for 99.9% of deployments and has caused confusion and unnecessary support requests time and time again without any obvious benefit as usually you want the proxy to be reachable instead of your normal servers which wouldn't even be usable anymore as soon as you enable proxy support on the Minecraft server. (I kinda assume this was originally just copied from Bungee's default being 25577)

While a non-standard port can be useful for testing in some situations when already having a Minecraft server running in others it might actually be decremental (e.g. because you need to add another server into your server list instead of just using one localhost with port 25565). For cases where this behaviour is desired a custom port can always be specified in the config anyways.

Existing setups should not get influenced by this change as they already have a config with the value and even in a case where a container image is used which relies on a specific port this change should not cause any issues as the config should either be persisted or be part of the container image if it is setup right. (e.g. like how the [Velocity Pterodactyl egg](https://github.com/parkervcp/eggs/blob/54209dbe130b1eb00d8cf3702e64f2146c138103/game_eggs/minecraft/proxy/java/velocity/velocity.toml#L5) does it)

_And if there was discussion/issues/PRs open for that before then I'm sorry but I couldn't find them..._