### PR TITLE
Freeze ubuntu version, Update Gradle Wrapper, Friendly names in CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,15 +2,16 @@
 # For more information see: https://docs.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
 name: Java CI with Gradle
-
 on: [push, pull_request]
 
 jobs:
-  build-17:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
-    - uses: gradle/wrapper-validation-action@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+    - name: Validate Gradle Wrapper
+      uses: gradle/actions/wrapper-validation@v3
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
1. Freezes the ubuntu version to `22.04` in case the upcoming `24.04` version is not ready yet for reproduction,
2. Replaces the old `gradle/wrapper-validation-action` with `gradle/actions/wrapper-validation` instead as the old repository responsible for validating the Gradle Wrapper has been merged into the new Gradle/Actions repo,
3. Adds friendly names to the steps to properly clarify what step is currently running.

Additional info: As for Java itself, Unsure if it is planned to be bumped to version 21 in future once 1.20.5 is released or if 17 can be maintained for a bit longer than that - hence this is left unchanged.