### PR TITLE
Correctly handle "select known packs" packet

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftSessionHandler.java
@@ -63,6 +63,7 @@ import com.velocitypowered.proxy.protocol.packet.chat.session.SessionPlayerChatP
 import com.velocitypowered.proxy.protocol.packet.chat.session.SessionPlayerCommandPacket;
 import com.velocitypowered.proxy.protocol.packet.config.ActiveFeaturesPacket;
 import com.velocitypowered.proxy.protocol.packet.config.FinishedUpdatePacket;
+import com.velocitypowered.proxy.protocol.packet.config.KnownPacksPacket;
 import com.velocitypowered.proxy.protocol.packet.config.RegistrySyncPacket;
 import com.velocitypowered.proxy.protocol.packet.config.StartUpdatePacket;
 import com.velocitypowered.proxy.protocol.packet.config.TagsUpdatePacket;
@@ -332,6 +333,10 @@ public interface MinecraftSessionHandler {
   }
 
   default boolean handle(TransferPacket transfer) {
+    return false;
+  }
+
+  default boolean handle(KnownPacksPacket packet) {
     return false;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -33,6 +33,7 @@ import com.velocitypowered.proxy.protocol.packet.PingIdentifyPacket;
 import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
 import com.velocitypowered.proxy.protocol.packet.ResourcePackResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.config.FinishedUpdatePacket;
+import com.velocitypowered.proxy.protocol.packet.config.KnownPacksPacket;
 import com.velocitypowered.proxy.protocol.util.PluginMessageUtil;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -128,6 +129,15 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
     if (player.getConnectionInFlight() != null) {
       player.getConnectionInFlight().ensureConnected().write(packet);
     }
+    return true;
+  }
+
+  @Override
+  public boolean handle(KnownPacksPacket packet) {
+    if (player.getConnectionInFlight() != null) {
+      player.getConnectionInFlight().ensureConnected().write(packet);
+    }
+
     return true;
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
@@ -92,6 +92,7 @@ import com.velocitypowered.proxy.protocol.packet.chat.session.SessionPlayerComma
 import com.velocitypowered.proxy.protocol.packet.chat.session.UnsignedPlayerCommandPacket;
 import com.velocitypowered.proxy.protocol.packet.config.ActiveFeaturesPacket;
 import com.velocitypowered.proxy.protocol.packet.config.FinishedUpdatePacket;
+import com.velocitypowered.proxy.protocol.packet.config.KnownPacksPacket;
 import com.velocitypowered.proxy.protocol.packet.config.RegistrySyncPacket;
 import com.velocitypowered.proxy.protocol.packet.config.StartUpdatePacket;
 import com.velocitypowered.proxy.protocol.packet.config.TagsUpdatePacket;
@@ -165,6 +166,10 @@ public enum StateRegistry {
           ResourcePackResponsePacket::new,
           map(0x05, MINECRAFT_1_20_2, false),
           map(0x06, MINECRAFT_1_20_5, false));
+      serverbound.register(
+          KnownPacksPacket.class,
+          KnownPacksPacket::new,
+          map(0x07, MINECRAFT_1_20_5, false));
 
       clientbound.register(
           PluginMessagePacket.class, PluginMessagePacket::new,
@@ -207,6 +212,8 @@ public enum StateRegistry {
           map(0x08, MINECRAFT_1_20_2, false),
           map(0x09, MINECRAFT_1_20_3, false),
           map(0x0D, MINECRAFT_1_20_5, false));
+      clientbound.register(KnownPacksPacket.class, KnownPacksPacket::new,
+          map(0x0E, MINECRAFT_1_20_5, false));
     }
   },
   PLAY {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/KnownPacksPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/KnownPacksPacket.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.protocol.packet.config;
+
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import io.netty.buffer.ByteBuf;
+
+public class KnownPacksPacket implements MinecraftPacket {
+
+    private KnownPack[] packs;
+
+    @Override
+    public void decode(ByteBuf buf, ProtocolUtils.Direction direction,
+                       ProtocolVersion protocolVersion) {
+        final int packCount = ProtocolUtils.readVarInt(buf);
+        final KnownPack[] packs = new KnownPack[packCount];
+
+        for (int i = 0; i < packCount; i++) {
+            packs[i] = KnownPack.read(buf);
+        }
+
+        this.packs = packs;
+    }
+
+    @Override
+    public void encode(ByteBuf buf, ProtocolUtils.Direction direction,
+                       ProtocolVersion protocolVersion) {
+        ProtocolUtils.writeVarInt(buf, packs.length);
+
+        for (KnownPack pack : packs) {
+            pack.write(buf);
+        }
+    }
+
+    @Override
+    public boolean handle(MinecraftSessionHandler handler) {
+        return handler.handle(this);
+    }
+
+    public record KnownPack(String namespace, String id, String version) {
+        private static KnownPack read(ByteBuf buf) {
+            return new KnownPack(ProtocolUtils.readString(buf), ProtocolUtils.readString(buf), ProtocolUtils.readString(buf));
+        }
+
+        private void write(ByteBuf buf) {
+            ProtocolUtils.writeString(buf, namespace);
+            ProtocolUtils.writeString(buf, id);
+            ProtocolUtils.writeString(buf, version);
+        }
+    }
+}


### PR DESCRIPTION
This is required for connecting to 1.20.5 servers to succeed. Implementation was tested using https://github.com/OKTW-Network/FabricProxy-Lite/pull/84. 