### PR TITLE
Fix config phase packets getting lost

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -120,6 +120,8 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
       // but at this time the backend server may not be ready
     } else if (serverConn != null) {
       serverConn.ensureConnected().write(packet.retain());
+    } else {
+      player.getConnection().write(packet.retain());
     }
     return true;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -128,18 +128,23 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(PingIdentifyPacket packet) {
-    if (player.getConnectionInFlight() != null) {
-      player.getConnectionInFlight().ensureConnected().write(packet);
+    final VelocityServerConnection serverConn = player.getConnectionInFlight();
+    if (serverConn != null) {
+      serverConn.ensureConnected().write(packet);
+    } else {
+      player.getConnection().write(packet);
     }
     return true;
   }
 
   @Override
   public boolean handle(KnownPacksPacket packet) {
-    if (player.getConnectionInFlight() != null) {
-      player.getConnectionInFlight().ensureConnected().write(packet);
+    final VelocityServerConnection serverConn = player.getConnectionInFlight();
+    if (serverConn != null) {
+      serverConn.ensureConnected().write(packet);
+    } else {
+      player.getConnection().write(packet);
     }
-
     return true;
   }
 


### PR DESCRIPTION
When the config-phase is initiated externally, packets are getting lost, as there is no `connectionInFlight`.

This is most noticeable with `PluginMessagePacket` as some client-only mods initiate their state in the config phase. The servers request is receipt, but the client has no way to acknowledge the pm.

One common scenario where it would occur is when you chain multiple Velocity servers. But it should be the expected behavior nonetheless.