### PR TITLE
Pass through packets in config state

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -128,17 +128,20 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
   public boolean handle(PingIdentifyPacket packet) {
     if (player.getConnectionInFlight() != null) {
       player.getConnectionInFlight().ensureConnected().write(packet);
+      return true;
     }
-    return true;
+
+    return false;
   }
 
   @Override
   public boolean handle(KnownPacksPacket packet) {
     if (player.getConnectionInFlight() != null) {
       player.getConnectionInFlight().ensureConnected().write(packet);
+      return true;
     }
 
-    return true;
+    return false;
   }
 
   @Override


### PR DESCRIPTION
Since 1.20.5 there's an additional "handshake" when the client enters the configuration state. 
If there's no connection in flight, the `play:serverbound/minecraft:configuration_acknowledged` emitted by the client isn't passed through to the backend server. This means the backend server won't start sending the rest of the registry data to the client, thus the client ends up in an infinite "Reconfiguring... " screen.

In 99% of normal use cases there will be a connection in flight, but I sadly ran into a case where there wasn't a connection in flight. This PR solves this issue by just passing through the packet if there's no connection in flight.