### PR TITLE
Fix `null` or empty handling in `LegacyResourcepackHandler`

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/LegacyResourcePackHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/LegacyResourcePackHandler.java
@@ -109,7 +109,7 @@ public sealed class LegacyResourcePackHandler extends ResourcePackHandler
             break;
           }
           onResourcePackResponse(new ResourcePackResponseBundle(queued.getId(),
-                  new String(queued.getHash()),
+                  queued.getHash() == null ? "" : new String(queued.getHash()),
                   PlayerResourcePackStatusEvent.Status.DECLINED));
           queued = null;
         }
@@ -172,6 +172,10 @@ public sealed class LegacyResourcePackHandler extends ResourcePackHandler
 
   @Override
   public boolean hasPackAppliedByHash(final byte[] hash) {
+    if (hash == null) {
+      return false;
+    }
+
     return this.appliedResourcePack != null
             && Arrays.equals(this.appliedResourcePack.getHash(), hash);
   }


### PR DESCRIPTION
I've been running this patch safely on production without any issues for over two weeks.

Fixes the following errors:
```
[19:58:23 ERROR]: Exception while handling resource pack send for com.velocitypowered.proxy.connection.MinecraftConnection@2aa69008
java.util.concurrent.CompletionException: java.lang.NullPointerException
        at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[?:?]
        at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320) ~[?:?]
        at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:722) ~[?:?]
        at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482) ~[?:?]
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[velocity.jar:3.3.0-SNAPSHOT (git-1ae611b5)]
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[velocity.jar:3.3.0-SNAPSHOT (git-1ae611b5)]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[velocity.jar:3.3.0-SNAPSHOT (git-1ae611b5)]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:405) ~[velocity.jar:3.3.0-SNAPSHOT (git-1ae611b5)]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[velocity.jar:3.3.0-SNAPSHOT (git-1ae611b5)]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[velocity.jar:3.3.0-SNAPSHOT (git-1ae611b5)]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[velocity.jar:3.3.0-SNAPSHOT (git-1ae611b5)]
        at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: java.lang.NullPointerException

and


[10:35:47 ERROR]: Exception while handling resource pack send for com.velocitypowered.proxy.connection.MinecraftConnection@3bd98dbe
java.util.concurrent.CompletionException: java.lang.NullPointerException: Cannot read the array length because "bytes" is null

(plus its extension)