### PR TITLE
Support loading plugins from classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     `java-library`
     id("velocity-checkstyle") apply false
     id("velocity-spotless") apply false
+    alias(libs.plugins.ideaExt)
 }
 
 subprojects {
@@ -9,6 +10,7 @@ subprojects {
 
     apply(plugin = "velocity-checkstyle")
     apply(plugin = "velocity-spotless")
+    apply(plugin = "org.jetbrains.gradle.plugin.idea-ext")
 
     java {
         toolchain {
@@ -25,6 +27,22 @@ subprojects {
             useJUnitPlatform()
             reports {
                 junitXml.required.set(true)
+            }
+        }
+    }
+
+    idea {
+        if (project != null) {
+            (project as ExtensionAware).extensions["settings"].run {
+                (this as ExtensionAware).extensions.getByType(org.jetbrains.gradle.ext.ActionDelegationConfig::class).run {
+                    delegateBuildRunToGradle = false
+                    testRunner = org.jetbrains.gradle.ext.ActionDelegationConfig.TestRunner.PLATFORM
+                }
+                extensions.getByType(org.jetbrains.gradle.ext.IdeaCompilerConfiguration::class).run {
+                    addNotNullAssertions = false
+                    useReleaseOption = JavaVersion.current().isJava10Compatible
+                    parallelCompilation = true
+                }
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,11 +4,13 @@ configurate4 = "4.1.2"
 flare = "2.0.1"
 log4j = "2.22.1"
 netty = "4.1.106.Final"
+ideaExt = "1.1.8"
 
 [plugins]
 indra-publishing = "net.kyori.indra.publishing:2.0.6"
 shadow = "io.github.goooler.shadow:8.1.5"
 spotless = "com.diffplug.spotless:6.25.0"
+ideaExt = { id = "org.jetbrains.gradle.plugin.idea-ext", version.ref = "ideaExt" }
 
 [libraries]
 adventure-bom = "net.kyori:adventure-bom:4.16.0"


### PR DESCRIPTION
Best reviewed without whitespaces.

Adds support for loading plugins from the classpath to allow faster plugin development iteration and easy debugging capabilities. This is something Sponge has supported for ages and is very useful from the developer perspectice. How to use this in practice is described well in [Sponge documentation](https://docs.spongepowered.org/stable/en/plugin/debugging.html).

The build changes are to allow appending the classpath from the IDEA.