### PR TITLE
Refactor: Replace enum comparison with .equals method

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
@@ -82,7 +82,7 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
   public boolean handle(LoginPluginMessagePacket packet) {
     MinecraftConnection mc = serverConn.ensureConnected();
     VelocityConfiguration configuration = server.getConfiguration();
-    if (configuration.getPlayerInfoForwardingMode() == PlayerInfoForwarding.MODERN
+    if (configuration.getPlayerInfoForwardingMode().equals(PlayerInfoForwarding.MODERN)
         && packet.getChannel().equals(PlayerDataForwarding.CHANNEL)) {
 
       int requestedForwardingVersion = PlayerDataForwarding.MODERN_DEFAULT;


### PR DESCRIPTION
- Updated the comparison method for PlayerInfoForwarding mode to use .equals instead of '=='.
- Ensured consistent and reliable comparison for PlayerInfoForwarding and PlayerDataForwarding.