### PR TITLE
feat: Add basic API for server links

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -21,6 +21,7 @@ import com.velocitypowered.api.proxy.player.TabList;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.util.GameProfile;
 import com.velocitypowered.api.util.ModInfo;
+import com.velocitypowered.api.util.ServerLink;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.List;
@@ -461,4 +462,14 @@ public interface Player extends
    * @sinceMinecraft 1.20.5
    */
   void requestCookie(Key key);
+
+  /**
+   * Send the player a list of custom links to display in their client's pause menu.
+   *
+   * @param links an ordered list of {@link ServerLink}s to send to the player
+   * @throws IllegalArgumentException if the player is from a version lower than 1.21
+   * @since 3.3.0
+   * @sinceMinecraft 1.21
+   */
+  void setServerLinks(List<ServerLink> links);
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -465,6 +465,7 @@ public interface Player extends
 
   /**
    * Send the player a list of custom links to display in their client's pause menu.
+   * <p>Note that later packets sent by the backend server may override links sent by the proxy.
    *
    * @param links an ordered list of {@link ServerLink}s to send to the player
    * @throws IllegalArgumentException if the player is from a version lower than 1.21

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -471,5 +471,5 @@ public interface Player extends
    * @since 3.3.0
    * @sinceMinecraft 1.21
    */
-  void setServerLinks(List<ServerLink> links);
+  void setServerLinks(@NotNull List<ServerLink> links);
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -465,6 +465,7 @@ public interface Player extends
 
   /**
    * Send the player a list of custom links to display in their client's pause menu.
+   *
    * <p>Note that later packets sent by the backend server may override links sent by the proxy.
    *
    * @param links an ordered list of {@link ServerLink}s to send to the player

--- a/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
+++ b/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2021-2024 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.util;
+
+import java.util.Optional;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents a custom URL servers can show in player pause menus.
+ * Links can be of a built-in type or use a custom component text label.
+ */
+public final class ServerLink {
+
+  private @Nullable Type type;
+  private @Nullable Component label;
+  private final String link;
+
+  /**
+   * Construct a server link with a custom component label.
+   *
+   * @param label the label to display
+   * @param link  the URL to open when clicked
+   */
+  public ServerLink(Component label, String link) {
+    this.label = label;
+    this.link = link;
+  }
+
+  /**
+   * Construct a server link with a built-in type.
+   *
+   * @param type the {@link Type type} of link
+   * @param link the URL to open when clicked
+   */
+  public ServerLink(Type type, String link) {
+    this.type = type;
+    this.link = link;
+  }
+
+  /**
+   * Get the type of the server link.
+   *
+   * @return the type of the server link
+   */
+  public Optional<Type> getBuiltInType() {
+    return Optional.ofNullable(type);
+  }
+
+  /**
+   * Get the link URL.
+   *
+   * @return the link URL
+   */
+  public String getLink() {
+    return link;
+  }
+
+  /**
+   * Get the custom component label of the server link.
+   *
+   * @return the custom component label of the server link
+   */
+  public Optional<Component> getCustomLabel() {
+    return Optional.ofNullable(label);
+  }
+
+  /**
+   * Built-in types of server links.
+   *
+   * @apiNote {@link Type#BUG_REPORT} links are shown on the connection error screen
+   */
+  public enum Type {
+    BUG_REPORT,
+    COMMUNITY_GUIDELINES,
+    SUPPORT,
+    STATUS,
+    FEEDBACK,
+    COMMUNITY,
+    WEBSITE,
+    FORUMS,
+    NEWS,
+    ANNOUNCEMENTS
+  }
+
+}

--- a/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
+++ b/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
@@ -29,7 +29,7 @@ public final class ServerLink {
    * @param label a custom component label to display
    * @param link  the URL to open when clicked
    */
-  public ServerLink(Component label, String link) throws IllegalArgumentException {
+  public ServerLink(Component label, String link) {
     this.label = Preconditions.checkNotNull(label, "label");
     this.link = URI.create(link).toString();
   }
@@ -40,7 +40,7 @@ public final class ServerLink {
    * @param type the {@link Type built-in type} of link
    * @param link the URL to open when clicked
    */
-  public ServerLink(Type type, String link) throws IllegalArgumentException {
+  public ServerLink(Type type, String link) {
     this.type = Preconditions.checkNotNull(type, "type");
     this.link = URI.create(link).toString();
   }

--- a/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
+++ b/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
@@ -21,7 +21,17 @@ public final class ServerLink {
 
   private @Nullable Type type;
   private @Nullable Component label;
-  private final String link;
+  private final URI url;
+
+  private ServerLink(Component label, String url) {
+    this.label = Preconditions.checkNotNull(label, "label");
+    this.url = URI.create(url);
+  }
+
+  private ServerLink(Type type, String url) {
+    this.type = Preconditions.checkNotNull(type, "type");
+    this.url = URI.create(url);
+  }
 
   /**
    * Construct a server link with a custom component label.
@@ -29,9 +39,8 @@ public final class ServerLink {
    * @param label a custom component label to display
    * @param link  the URL to open when clicked
    */
-  public ServerLink(Component label, String link) {
-    this.label = Preconditions.checkNotNull(label, "label");
-    this.link = URI.create(link).toString();
+  public static ServerLink serverLink(Component label, String link) {
+    return new ServerLink(label, link);
   }
 
   /**
@@ -40,9 +49,8 @@ public final class ServerLink {
    * @param type the {@link Type built-in type} of link
    * @param link the URL to open when clicked
    */
-  public ServerLink(Type type, String link) {
-    this.type = Preconditions.checkNotNull(type, "type");
-    this.link = URI.create(link).toString();
+  public static ServerLink serverLink(Type type, String link) {
+      return new ServerLink(type, link);
   }
 
   /**
@@ -64,12 +72,12 @@ public final class ServerLink {
   }
 
   /**
-   * Get the link URL.
+   * Get the link {@link URI}.
    *
-   * @return the link URL
+   * @return the link {@link URI}
    */
-  public String getLink() {
-    return link;
+  public URI getUrl() {
+    return url;
   }
 
   /**

--- a/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
+++ b/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
@@ -50,7 +50,7 @@ public final class ServerLink {
    * @param link the URL to open when clicked
    */
   public static ServerLink serverLink(Type type, String link) {
-      return new ServerLink(type, link);
+    return new ServerLink(type, link);
   }
 
   /**

--- a/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
+++ b/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
@@ -7,6 +7,8 @@
 
 package com.velocitypowered.api.util;
 
+import com.google.common.base.Preconditions;
+import java.net.URI;
 import java.util.Optional;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.Nullable;
@@ -27,9 +29,9 @@ public final class ServerLink {
    * @param label the label to display
    * @param link  the URL to open when clicked
    */
-  public ServerLink(Component label, String link) {
-    this.label = label;
-    this.link = link;
+  public ServerLink(Component label, String link) throws IllegalArgumentException {
+    this.label = Preconditions.checkNotNull(label, "label");
+    this.link = URI.create(link).toString();
   }
 
   /**
@@ -38,9 +40,9 @@ public final class ServerLink {
    * @param type the {@link Type type} of link
    * @param link the URL to open when clicked
    */
-  public ServerLink(Type type, String link) {
-    this.type = type;
-    this.link = link;
+  public ServerLink(Type type, String link) throws IllegalArgumentException {
+    this.type = Preconditions.checkNotNull(type, "type");
+    this.link = URI.create(link).toString();
   }
 
   /**

--- a/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
+++ b/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
@@ -26,7 +26,7 @@ public final class ServerLink {
   /**
    * Construct a server link with a custom component label.
    *
-   * @param label the label to display
+   * @param label a custom component label to display
    * @param link  the URL to open when clicked
    */
   public ServerLink(Component label, String link) throws IllegalArgumentException {
@@ -37,7 +37,7 @@ public final class ServerLink {
   /**
    * Construct a server link with a built-in type.
    *
-   * @param type the {@link Type type} of link
+   * @param type the {@link Type built-in type} of link
    * @param link the URL to open when clicked
    */
   public ServerLink(Type type, String link) throws IllegalArgumentException {
@@ -55,21 +55,21 @@ public final class ServerLink {
   }
 
   /**
-   * Get the link URL.
-   *
-   * @return the link URL
-   */
-  public String getLink() {
-    return link;
-  }
-
-  /**
    * Get the custom component label of the server link.
    *
    * @return the custom component label of the server link
    */
   public Optional<Component> getCustomLabel() {
     return Optional.ofNullable(label);
+  }
+
+  /**
+   * Get the link URL.
+   *
+   * @return the link URL
+   */
+  public String getLink() {
+    return link;
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1060,7 +1060,6 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
         }, connection.eventLoop());
   }
 
-
   @Override
   public void setServerLinks(List<ServerLink> links) {
     Preconditions.checkNotNull(links);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonObject;
 import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.connection.DisconnectEvent.LoginStatus;
@@ -1072,7 +1073,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       throw new IllegalStateException("Can only send server links in CONFIGURATION or PLAY protocol");
     }
 
-    connection.write(new ClientboundServerLinksPacket(links.stream()
+    connection.write(new ClientboundServerLinksPacket(ImmutableList.copyOf(links).stream()
         .map(l -> new ClientboundServerLinksPacket.ServerLink(
             l.getBuiltInType().map(Enum::ordinal).orElse(-1),
             l.getCustomLabel().map(c -> new ComponentHolder(getProtocolVersion(), c)).orElse(null),

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1061,8 +1061,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   }
 
   @Override
-  public void setServerLinks(List<ServerLink> links) {
-    Preconditions.checkNotNull(links);
+  public void setServerLinks(final @NotNull List<ServerLink> links) {
+    Preconditions.checkNotNull(links, "links");
     Preconditions.checkArgument(
         this.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21),
         "Player version must be at least 1.21 to be able to set server links");

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -23,7 +23,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonObject;
 import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.connection.DisconnectEvent.LoginStatus;
@@ -1072,7 +1071,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       throw new IllegalStateException("Can only send server links in CONFIGURATION or PLAY protocol");
     }
 
-    connection.write(new ClientboundServerLinksPacket(ImmutableList.copyOf(links).stream()
+    connection.write(new ClientboundServerLinksPacket(List.copyOf(links).stream()
         .map(l -> new ClientboundServerLinksPacket.ServerLink(l, getProtocolVersion())).toList()));
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -54,6 +54,7 @@ import com.velocitypowered.api.proxy.player.ResourcePackInfo;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.util.GameProfile;
 import com.velocitypowered.api.util.ModInfo;
+import com.velocitypowered.api.util.ServerLink;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.adventure.VelocityBossBarImplementation;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
@@ -81,6 +82,7 @@ import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import com.velocitypowered.proxy.protocol.packet.chat.PlayerChatCompletionPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.builder.ChatBuilderFactory;
 import com.velocitypowered.proxy.protocol.packet.chat.legacy.LegacyChatPacket;
+import com.velocitypowered.proxy.protocol.packet.config.ClientboundServerLinksPacket;
 import com.velocitypowered.proxy.protocol.packet.config.StartUpdatePacket;
 import com.velocitypowered.proxy.protocol.packet.title.GenericTitlePacket;
 import com.velocitypowered.proxy.protocol.util.ByteBufDataOutput;
@@ -1055,6 +1057,26 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
             connection.write(new ClientboundCookieRequestPacket(resultedKey));
           }
         }, connection.eventLoop());
+  }
+
+
+  @Override
+  public void setServerLinks(List<ServerLink> links) {
+    Preconditions.checkNotNull(links);
+    Preconditions.checkArgument(
+        this.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21),
+        "Player version must be at least 1.21 to be able to set server links");
+
+    if (connection.getState() != StateRegistry.PLAY
+        && connection.getState() != StateRegistry.CONFIG) {
+      throw new IllegalStateException("Can only send server links in CONFIGURATION or PLAY protocol");
+    }
+
+    connection.write(new ClientboundServerLinksPacket(links.stream()
+        .map(l -> new ClientboundServerLinksPacket.ServerLink(
+            l.getBuiltInType().map(Enum::ordinal).orElse(-1),
+            l.getCustomLabel().map(c -> new ComponentHolder(getProtocolVersion(), c)).orElse(null),
+            l.getLink())).toList()));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1073,10 +1073,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     }
 
     connection.write(new ClientboundServerLinksPacket(ImmutableList.copyOf(links).stream()
-        .map(l -> new ClientboundServerLinksPacket.ServerLink(
-            l.getBuiltInType().map(Enum::ordinal).orElse(-1),
-            l.getCustomLabel().map(c -> new ComponentHolder(getProtocolVersion(), c)).orElse(null),
-            l.getLink())).toList()));
+        .map(l -> new ClientboundServerLinksPacket.ServerLink(l, getProtocolVersion())).toList()));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/ClientboundServerLinksPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/ClientboundServerLinksPacket.java
@@ -18,6 +18,7 @@
 package com.velocitypowered.proxy.protocol.packet.config;
 
 import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.api.util.ServerLink;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
@@ -66,6 +67,13 @@ public class ClientboundServerLinksPacket implements MinecraftPacket {
     }
 
     public record ServerLink(int id, ComponentHolder displayName, String url) {
+
+        public ServerLink(com.velocitypowered.api.util.ServerLink link, ProtocolVersion protocolVersion) {
+            this(link.getBuiltInType().map(Enum::ordinal).orElse(-1),
+                link.getCustomLabel().map(c -> new ComponentHolder(protocolVersion, c)).orElse(null),
+                link.getUrl().toString());
+        }
+
         private static ServerLink read(ByteBuf buf, ProtocolVersion version) {
             if (buf.readBoolean()) {
                 return new ServerLink(ProtocolUtils.readVarInt(buf), null, ProtocolUtils.readString(buf));


### PR DESCRIPTION
Adds a (very simple) API for setting a list of server links to display to the client with either built-in or component labels. Strings for URLs as is the case in the resource pack API.

I was thinking about doing something more complex with a builder or something, but I'm not sure it's really needed in this case?