### PR TITLE
A couple of fixes for handling of secure chat

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -54,6 +54,7 @@ import com.velocitypowered.proxy.protocol.packet.ServerboundCookieResponsePacket
 import com.velocitypowered.proxy.protocol.packet.TabCompleteRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.TabCompleteResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.TabCompleteResponsePacket.Offer;
+import com.velocitypowered.proxy.protocol.packet.chat.ChatAcknowledgementPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatHandler;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatTimeKeeper;
 import com.velocitypowered.proxy.protocol.packet.chat.CommandHandler;
@@ -420,6 +421,15 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
       });
     }
     configSwitchFuture.complete(null);
+    return true;
+  }
+
+  @Override
+  public boolean handle(ChatAcknowledgementPacket packet) {
+    if (player.getCurrentServer().isEmpty()) {
+      return true;
+    }
+    player.getChatQueue().handleAcknowledgement(packet.offset());
     return true;
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1112,6 +1112,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       ChatBuilderV2 message = getChatBuilderFactory().builder().asPlayer(this).message(input);
       this.chatQueue.queuePacket(chatState -> {
         message.setTimestamp(chatState.lastTimestamp);
+        message.setLastSeenMessages(chatState.createLastSeen());
         return message.toServer();
       });
     } else {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -83,6 +83,7 @@ import com.velocitypowered.proxy.protocol.packet.chat.ChatType;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import com.velocitypowered.proxy.protocol.packet.chat.PlayerChatCompletionPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.builder.ChatBuilderFactory;
+import com.velocitypowered.proxy.protocol.packet.chat.builder.ChatBuilderV2;
 import com.velocitypowered.proxy.protocol.packet.chat.legacy.LegacyChatPacket;
 import com.velocitypowered.proxy.protocol.packet.config.ClientboundServerLinksPacket;
 import com.velocitypowered.proxy.protocol.packet.config.StartUpdatePacket;
@@ -1108,11 +1109,11 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
         "input cannot be greater than " + LegacyChatPacket.MAX_SERVERBOUND_MESSAGE_LENGTH
             + " characters in length");
     if (getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_19)) {
-      this.chatQueue.hijack(getChatBuilderFactory().builder().asPlayer(this).message(input),
-          (instant, item) -> {
-            item.setTimestamp(instant);
-            return item.toServer();
-          });
+      ChatBuilderV2 message = getChatBuilderFactory().builder().asPlayer(this).message(input);
+      this.chatQueue.queuePacket(chatState -> {
+        message.setTimestamp(chatState.lastTimestamp);
+        return message.toServer();
+      });
     } else {
       ensureBackendConnection().write(getChatBuilderFactory().builder()
           .asPlayer(this).message(input).toServer());

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatAcknowledgementPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatAcknowledgementPacket.java
@@ -54,4 +54,8 @@ public class ChatAcknowledgementPacket implements MinecraftPacket {
                 "offset=" + offset +
                 '}';
     }
+
+    public int offset() {
+        return offset;
+    }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/LastSeenMessages.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/LastSeenMessages.java
@@ -24,13 +24,19 @@ import java.util.BitSet;
 
 public class LastSeenMessages {
 
-  private static final int DIV_FLOOR = -Math.floorDiv(-20, 8);
+  public static final int WINDOW_SIZE = 20;
+  private static final int DIV_FLOOR = -Math.floorDiv(-WINDOW_SIZE, 8);
   private int offset;
   private BitSet acknowledged;
 
   public LastSeenMessages() {
     this.offset = 0;
     this.acknowledged = new BitSet();
+  }
+
+  public LastSeenMessages(int offset, BitSet acknowledged) {
+    this.offset = offset;
+    this.acknowledged = acknowledged;
   }
 
   public LastSeenMessages(ByteBuf buf) {
@@ -52,6 +58,14 @@ public class LastSeenMessages {
 
   public int getOffset() {
     return this.offset;
+  }
+
+  public BitSet getAcknowledged() {
+    return acknowledged;
+  }
+
+  public LastSeenMessages offset(final int offset) {
+    return new LastSeenMessages(this.offset + offset, acknowledged);
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/LastSeenMessages.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/LastSeenMessages.java
@@ -52,10 +52,6 @@ public class LastSeenMessages {
     buf.writeBytes(Arrays.copyOf(acknowledged.toByteArray(), DIV_FLOOR));
   }
 
-  public boolean isEmpty() {
-    return acknowledged.isEmpty();
-  }
-
   public int getOffset() {
     return this.offset;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/builder/ChatBuilderV2.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/builder/ChatBuilderV2.java
@@ -21,6 +21,7 @@ import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatType;
+import com.velocitypowered.proxy.protocol.packet.chat.LastSeenMessages;
 import java.time.Instant;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
@@ -36,6 +37,7 @@ public abstract class ChatBuilderV2 {
   protected @Nullable Identity senderIdentity;
   protected Instant timestamp;
   protected ChatType type = ChatType.CHAT;
+  protected @Nullable LastSeenMessages lastSeenMessages;
 
   protected ChatBuilderV2(ProtocolVersion version) {
     this.version = version;
@@ -74,6 +76,11 @@ public abstract class ChatBuilderV2 {
 
   public ChatBuilderV2 asServer() {
     this.senderIdentity = null;
+    return this;
+  }
+
+  public ChatBuilderV2 setLastSeenMessages(LastSeenMessages lastSeenMessages) {
+    this.lastSeenMessages = lastSeenMessages;
     return this;
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedChatHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedChatHandler.java
@@ -91,11 +91,12 @@ public class KeyedChatHandler implements
       });
     }
     chatQueue.queuePacket(
-        chatFuture.exceptionally((ex) -> {
+        newLastSeen -> chatFuture.exceptionally((ex) -> {
           logger.error("Exception while handling player chat for {}", player, ex);
           return null;
         }),
-        packet.getExpiry()
+        packet.getExpiry(),
+        null
     );
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedCommandHandler.java
@@ -43,7 +43,7 @@ public class KeyedCommandHandler implements CommandHandler<KeyedPlayerCommandPac
 
   @Override
   public void handlePlayerCommandInternal(KeyedPlayerCommandPacket packet) {
-    queueCommandResult(this.server, this.player, event -> {
+    queueCommandResult(this.server, this.player, (event, newLastSeenMessages) -> {
       CommandExecuteEvent.CommandResult result = event.getResult();
       IdentifiedKey playerKey = player.getIdentifiedKey();
       if (result == CommandExecuteEvent.CommandResult.denied()) {
@@ -111,6 +111,6 @@ public class KeyedCommandHandler implements CommandHandler<KeyedPlayerCommandPac
         }
         return null;
       });
-    }, packet.getCommand(), packet.getTimestamp());
+    }, packet.getCommand(), packet.getTimestamp(), null);
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyCommandHandler.java
@@ -42,7 +42,7 @@ public class LegacyCommandHandler implements CommandHandler<LegacyChatPacket> {
   @Override
   public void handlePlayerCommandInternal(LegacyChatPacket packet) {
     String command = packet.getMessage().substring(1);
-    queueCommandResult(this.server, this.player, event -> {
+    queueCommandResult(this.server, this.player, (event, newLastSeenMessages) -> {
       CommandExecuteEvent.CommandResult result = event.getResult();
       if (result == CommandExecuteEvent.CommandResult.denied()) {
         return CompletableFuture.completedFuture(null);
@@ -62,6 +62,6 @@ public class LegacyCommandHandler implements CommandHandler<LegacyChatPacket> {
         }
         return null;
       });
-    }, command, Instant.now());
+    }, command, Instant.now(), null);
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatBuilder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatBuilder.java
@@ -41,6 +41,7 @@ public class SessionChatBuilder extends ChatBuilderV2 {
 
   @Override
   public MinecraftPacket toServer() {
+    LastSeenMessages lastSeenMessages = this.lastSeenMessages != null ? this.lastSeenMessages : new LastSeenMessages();
     if (message.startsWith("/")) {
       if (version.noLessThan(ProtocolVersion.MINECRAFT_1_20_5)) {
         UnsignedPlayerCommandPacket command = new UnsignedPlayerCommandPacket();
@@ -52,7 +53,7 @@ public class SessionChatBuilder extends ChatBuilderV2 {
         command.salt = 0L;
         command.timeStamp = timestamp;
         command.argumentSignatures = new SessionPlayerCommandPacket.ArgumentSignatures();
-        command.lastSeenMessages = new LastSeenMessages();
+        command.lastSeenMessages = lastSeenMessages;
         return command;
       }
     } else {
@@ -62,7 +63,7 @@ public class SessionChatBuilder extends ChatBuilderV2 {
       chat.signature = new byte[0];
       chat.timestamp = timestamp;
       chat.salt = 0L;
-      chat.lastSeenMessages = new LastSeenMessages();
+      chat.lastSeenMessages = lastSeenMessages;
       return chat;
     }
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatHandler.java
@@ -29,6 +29,8 @@ import com.velocitypowered.proxy.protocol.packet.chat.ChatQueue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.concurrent.CompletableFuture;
+
 public class SessionChatHandler implements ChatHandler<SessionPlayerChatPacket> {
 
   private static final Logger logger = LogManager.getLogger(SessionChatHandler.class);
@@ -51,8 +53,9 @@ public class SessionChatHandler implements ChatHandler<SessionPlayerChatPacket> 
     ChatQueue chatQueue = this.player.getChatQueue();
     EventManager eventManager = this.server.getEventManager();
     PlayerChatEvent toSend = new PlayerChatEvent(player, packet.getMessage());
+    CompletableFuture<PlayerChatEvent> eventFuture = eventManager.fire(toSend);
     chatQueue.queuePacket(
-        eventManager.fire(toSend)
+        newLastSeenMessages -> eventFuture
             .thenApply(pme -> {
               PlayerChatEvent.ChatResult chatResult = pme.getResult();
               if (!chatResult.isAllowed()) {
@@ -72,13 +75,14 @@ public class SessionChatHandler implements ChatHandler<SessionPlayerChatPacket> 
                     .setTimestamp(packet.timestamp)
                     .toServer();
               }
-              return packet;
+              return packet.withLastSeenMessages(newLastSeenMessages);
             })
             .exceptionally((ex) -> {
               logger.error("Exception while handling player chat for {}", player, ex);
               return null;
             }),
-        packet.getTimestamp()
+        packet.getTimestamp(),
+        packet.getLastSeenMessages()
     );
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatHandler.java
@@ -73,6 +73,7 @@ public class SessionChatHandler implements ChatHandler<SessionPlayerChatPacket> 
                 }
                 return this.player.getChatBuilderFactory().builder().message(packet.message)
                     .setTimestamp(packet.timestamp)
+                    .setLastSeenMessages(newLastSeenMessages)
                     .toServer();
               }
               return packet.withLastSeenMessages(newLastSeenMessages);

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
@@ -20,10 +20,12 @@ package com.velocitypowered.proxy.protocol.packet.chat.session;
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
+import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatAcknowledgementPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.CommandHandler;
 import java.util.concurrent.CompletableFuture;
 import net.kyori.adventure.text.Component;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class SessionCommandHandler implements CommandHandler<SessionPlayerCommandPacket> {
 
@@ -40,6 +42,42 @@ public class SessionCommandHandler implements CommandHandler<SessionPlayerComman
     return SessionPlayerCommandPacket.class;
   }
 
+  @Nullable
+  private MinecraftPacket consumeCommand(SessionPlayerCommandPacket packet) {
+    if (packet.lastSeenMessages != null) {
+      return new ChatAcknowledgementPacket(packet.lastSeenMessages.getOffset());
+    }
+    return null;
+  }
+
+  @Nullable
+  private MinecraftPacket forwardCommand(SessionPlayerCommandPacket packet, String newCommand) {
+    if (packet.isSigned() && newCommand.equals(packet.command)) {
+      return packet;
+    }
+    return modifyCommand(packet, newCommand);
+  }
+
+  @Nullable
+  private MinecraftPacket modifyCommand(SessionPlayerCommandPacket packet, String newCommand) {
+    if (packet.isSigned()) {
+      logger.fatal("A plugin tried to change a command with signed component(s). "
+          + "This is not supported. "
+          + "Disconnecting player " + player.getUsername() + ". Command packet: " + packet);
+      player.disconnect(Component.text(
+          "A proxy plugin caused an illegal protocol state. "
+              + "Contact your network administrator."));
+      return null;
+    }
+
+    return this.player.getChatBuilderFactory()
+        .builder()
+        .setTimestamp(packet.timeStamp)
+        .asPlayer(this.player)
+        .message("/" + newCommand)
+        .toServer();
+  }
+
   @Override
   public void handlePlayerCommandInternal(SessionPlayerCommandPacket packet) {
     queueCommandResult(this.server, this.player, event -> {
@@ -53,64 +91,19 @@ public class SessionCommandHandler implements CommandHandler<SessionPlayerComman
               "A proxy plugin caused an illegal protocol state. "
                   + "Contact your network administrator."));
         }
-        // We seemingly can't actually do this if signed args exist, if not, we can probs keep stuff happy
-        if (packet.lastSeenMessages != null) {
-          return CompletableFuture.completedFuture(new ChatAcknowledgementPacket(packet.lastSeenMessages.getOffset()));
-        }
-        return CompletableFuture.completedFuture(null);
+        return CompletableFuture.completedFuture(consumeCommand(packet));
       }
 
       String commandToRun = result.getCommand().orElse(packet.command);
       if (result.isForwardToServer()) {
-        if (packet.isSigned() && commandToRun.equals(packet.command)) {
-          return CompletableFuture.completedFuture(packet);
-        } else {
-          if (packet.isSigned()) {
-            logger.fatal("A plugin tried to change a command with signed component(s). "
-                + "This is not supported. "
-                + "Disconnecting player " + player.getUsername() + ". Command packet: " + packet);
-            player.disconnect(Component.text(
-                "A proxy plugin caused an illegal protocol state. "
-                    + "Contact your network administrator."));
-            return CompletableFuture.completedFuture(null);
-          }
-
-          return CompletableFuture.completedFuture(this.player.getChatBuilderFactory()
-              .builder()
-              .setTimestamp(packet.timeStamp)
-              .asPlayer(this.player)
-              .message("/" + commandToRun)
-              .toServer());
-        }
+        return CompletableFuture.completedFuture(forwardCommand(packet, commandToRun));
       }
 
       return runCommand(this.server, this.player, commandToRun, hasRun -> {
-        if (!hasRun) {
-          if (packet.isSigned() && commandToRun.equals(packet.command)) {
-            return packet;
-          } else {
-            if (packet.isSigned()) {
-              logger.fatal("A plugin tried to change a command with signed component(s). "
-                  + "This is not supported. "
-                  + "Disconnecting player " + player.getUsername() + ". Command packet: " + packet);
-              player.disconnect(Component.text(
-                  "A proxy plugin caused an illegal protocol state. "
-                      + "Contact your network administrator."));
-              return null;
-            }
-
-            return this.player.getChatBuilderFactory()
-                .builder()
-                .setTimestamp(packet.timeStamp)
-                .asPlayer(this.player)
-                .message("/" + commandToRun)
-                .toServer();
-          }
+        if (hasRun) {
+          return consumeCommand(packet);
         }
-        if (packet.lastSeenMessages != null) {
-          return new ChatAcknowledgementPacket(packet.lastSeenMessages.getOffset());
-        }
-        return null;
+        return forwardCommand(packet, commandToRun);
       });
     }, packet.command, packet.timeStamp);
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
@@ -86,6 +86,7 @@ public class SessionCommandHandler implements CommandHandler<SessionPlayerComman
     return this.player.getChatBuilderFactory()
         .builder()
         .setTimestamp(packet.timeStamp)
+        .setLastSeenMessages(packet.lastSeenMessages)
         .asPlayer(this.player)
         .message("/" + newCommand)
         .toServer();

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
@@ -60,7 +60,11 @@ public class SessionCommandHandler implements CommandHandler<SessionPlayerComman
     }
     // An unsigned command with a 'last seen' update will not happen as of 1.20.5+, but for earlier versions - we still
     // need to pass through the acknowledgement
-    return new ChatAcknowledgementPacket(packet.lastSeenMessages.getOffset());
+    final int offset = packet.lastSeenMessages.getOffset();
+    if (offset != 0) {
+      return new ChatAcknowledgementPacket(offset);
+    }
+    return null;
   }
 
   @Nullable

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
@@ -18,7 +18,6 @@
 package com.velocitypowered.proxy.protocol.packet.chat.session;
 
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
-import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatAcknowledgementPacket;
@@ -55,7 +54,7 @@ public class SessionCommandHandler implements CommandHandler<SessionPlayerComman
                   + "Contact your network administrator."));
         }
         // We seemingly can't actually do this if signed args exist, if not, we can probs keep stuff happy
-        if (player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_19_3) && packet.lastSeenMessages != null) {
+        if (packet.lastSeenMessages != null) {
           return CompletableFuture.completedFuture(new ChatAcknowledgementPacket(packet.lastSeenMessages.getOffset()));
         }
         return CompletableFuture.completedFuture(null);
@@ -108,7 +107,7 @@ public class SessionCommandHandler implements CommandHandler<SessionPlayerComman
                 .toServer();
           }
         }
-        if (player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_19_3) && packet.lastSeenMessages != null) {
+        if (packet.lastSeenMessages != null) {
           return new ChatAcknowledgementPacket(packet.lastSeenMessages.getOffset());
         }
         return null;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
@@ -52,7 +52,7 @@ public class SessionCommandHandler implements CommandHandler<SessionPlayerComman
 
   @Nullable
   private MinecraftPacket forwardCommand(SessionPlayerCommandPacket packet, String newCommand) {
-    if (packet.isSigned() && newCommand.equals(packet.command)) {
+    if (newCommand.equals(packet.command)) {
       return packet;
     }
     return modifyCommand(packet, newCommand);

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionPlayerChatPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionPlayerChatPacket.java
@@ -99,4 +99,15 @@ public class SessionPlayerChatPacket implements MinecraftPacket {
     buf.readBytes(signature);
     return signature;
   }
+
+  public SessionPlayerChatPacket withLastSeenMessages(LastSeenMessages lastSeenMessages) {
+    SessionPlayerChatPacket packet = new SessionPlayerChatPacket();
+    packet.message = message;
+    packet.timestamp = timestamp;
+    packet.salt = salt;
+    packet.signed = signed;
+    packet.signature = signature;
+    packet.lastSeenMessages = lastSeenMessages;
+    return packet;
+  }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionPlayerCommandPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionPlayerCommandPacket.java
@@ -25,6 +25,8 @@ import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.packet.chat.LastSeenMessages;
 import com.velocitypowered.proxy.util.except.QuietDecoderException;
 import io.netty.buffer.ByteBuf;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.time.Instant;
 import java.util.List;
 
@@ -81,6 +83,21 @@ public class SessionPlayerCommandPacket implements MinecraftPacket {
             ", argumentSignatures=" + argumentSignatures +
             ", lastSeenMessages=" + lastSeenMessages +
             '}';
+  }
+
+  public SessionPlayerCommandPacket withLastSeenMessages(@Nullable LastSeenMessages lastSeenMessages) {
+    if (lastSeenMessages == null) {
+      UnsignedPlayerCommandPacket packet = new UnsignedPlayerCommandPacket();
+      packet.command = command;
+      return packet;
+    }
+    SessionPlayerCommandPacket packet = new SessionPlayerCommandPacket();
+    packet.command = command;
+    packet.timeStamp = timeStamp;
+    packet.salt = salt;
+    packet.argumentSignatures = argumentSignatures;
+    packet.lastSeenMessages = lastSeenMessages;
+    return packet;
   }
 
   public static class ArgumentSignatures {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionPlayerCommandPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionPlayerCommandPacket.java
@@ -65,8 +65,7 @@ public class SessionPlayerCommandPacket implements MinecraftPacket {
   }
 
   public boolean isSigned() {
-    if (salt == 0) return false;
-    return !lastSeenMessages.isEmpty() || !argumentSignatures.isEmpty();
+    return !argumentSignatures.isEmpty();
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/UnsignedPlayerCommandPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/UnsignedPlayerCommandPacket.java
@@ -19,7 +19,9 @@ package com.velocitypowered.proxy.protocol.packet.chat.session;
 
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import com.velocitypowered.proxy.protocol.packet.chat.LastSeenMessages;
 import io.netty.buffer.ByteBuf;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class UnsignedPlayerCommandPacket extends SessionPlayerCommandPacket {
 
@@ -31,6 +33,11 @@ public class UnsignedPlayerCommandPacket extends SessionPlayerCommandPacket {
   @Override
   public void encode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion protocolVersion) {
     ProtocolUtils.writeString(buf, this.command);
+  }
+
+  @Override
+  public SessionPlayerCommandPacket withLastSeenMessages(@Nullable LastSeenMessages lastSeenMessages) {
+    return this;
   }
 
   public boolean isSigned() {


### PR DESCRIPTION
This PR addresses a couple of issues in the implementation of secure chat handling in Velocity:
* Any command with a 'last seen' update (every command pre-1.20.5) could not be cancelled by the proxy
    * This PR introduces a system to 'delay' these acknowledgements to ensure that we can always pass a state to the server that is consistent with messages signed by the client
* Modified or spoofed commands would not have a last seen update attached, which would be rejected by pre-1.20.5 servers

Most of the diff is refactoring `ChatQueue` to be able to capture the state that we need - recommend to review commit-by-commit.

This potentially resolves some cases of #1127 - but it's hard to say given possible interaction from other plugins and servers, and would need to get some specific testing on that. However, from personal experience running these patches on a 1.20.4 server over a few months - we haven't been able to reproduce any issues. 🙂 

Thanks!