### PR TITLE
Add KickPlayerRaw plugin messaging action

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BungeeCordMessageResponder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BungeeCordMessageResponder.java
@@ -260,6 +260,13 @@ public class BungeeCordMessageResponder {
     });
   }
 
+  private void processKickRaw(ByteBufDataInput in) {
+    proxy.getPlayer(in.readUTF()).ifPresent(player -> {
+      String kickReason = in.readUTF();
+      player.disconnect(GsonComponentSerializer.gson().deserialize(kickReason));
+    });
+  }
+
   private void processForwardToPlayer(ByteBufDataInput in) {
     Optional<Player> player = proxy.getPlayer(in.readUTF());
     if (player.isPresent()) {
@@ -371,6 +378,9 @@ public class BungeeCordMessageResponder {
         break;
       case "KickPlayer":
         this.processKick(in);
+        break;
+      case "KickPlayerRaw":
+        this.processKickRaw(in);
         break;
       default:
         // Do nothing, unknown command


### PR DESCRIPTION
feat: add KickPlayerRaw plugin messaging action

- Added `processKickRaw` method to handle raw JSON kick reasons using `GsonComponentSerializer`.
- This allows for more complex and formatted kick messages compared to the legacy section format used in `processKick`.
