### PR TITLE
feat: Add server registered/unregistered events

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.event.proxy.server;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.server.ServerInfo;
+
+/**
+ * This event is fired by the proxy after a backend server is registered to the server map.
+ * Currently, it may occur when a server is registered dynamically at runtime or when a server is
+ * replaced due to configuration reload.
+ *
+ *  @see com.velocitypowered.api.proxy.ProxyServer#registerServer(ServerInfo)
+ */
+public final class ServerRegisteredEvent {
+
+  private final RegisteredServer registeredServer;
+
+  public ServerRegisteredEvent(RegisteredServer registeredServer) {
+    this.registeredServer = Preconditions.checkNotNull(registeredServer, "registeredServer");
+  }
+
+  public RegisteredServer getRegisteredServer() {
+    return registeredServer;
+  }
+
+  @Override
+  public String toString() {
+    return "ServerRegisteredEvent{"
+         + "registeredServer=" + registeredServer
+         + '}';
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.NotNull;
  */
 @Beta
 public record ServerRegisteredEvent(@NotNull RegisteredServer registeredServer) {
-    public ServerRegisteredEvent {
-        Preconditions.checkNotNull(registeredServer, "registeredServer");
-    }
+  public ServerRegisteredEvent {
+    Preconditions.checkNotNull(registeredServer, "registeredServer");
+  }
 }

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
  * Currently, it may occur when a server is registered dynamically at runtime or when a server is
  * replaced due to configuration reload.
  *
- *  @see com.velocitypowered.api.proxy.ProxyServer#registerServer(ServerInfo)
+ * @see com.velocitypowered.api.proxy.ProxyServer#registerServer(ServerInfo)
  *
  * @param registeredServer A {@link RegisteredServer} that has been registered.
  * @since 3.3.0

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
  *
  *  @see com.velocitypowered.api.proxy.ProxyServer#registerServer(ServerInfo)
  *
- * @param registeredServer A registeredServer that just has been registered.
+ * @param registeredServer A {@link RegisteredServer} that has been registered.
  * @since 3.3.0
  */
 @Beta

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
@@ -7,6 +7,7 @@
 
 package com.velocitypowered.api.event.proxy.server;
 
+import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
@@ -18,6 +19,7 @@ import com.velocitypowered.api.proxy.server.ServerInfo;
  *
  *  @see com.velocitypowered.api.proxy.ProxyServer#registerServer(ServerInfo)
  */
+@Beta
 public final class ServerRegisteredEvent {
 
   private final RegisteredServer registeredServer;

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
@@ -8,9 +8,9 @@
 package com.velocitypowered.api.event.proxy.server;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Preconditions;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This event is fired by the proxy after a backend server is registered to the server map.
@@ -18,24 +18,10 @@ import com.velocitypowered.api.proxy.server.ServerInfo;
  * replaced due to configuration reload.
  *
  *  @see com.velocitypowered.api.proxy.ProxyServer#registerServer(ServerInfo)
+ *
+ * @param registeredServer A registeredServer that just has been registered.
+ * @since 3.3.0
  */
 @Beta
-public final class ServerRegisteredEvent {
-
-  private final RegisteredServer registeredServer;
-
-  public ServerRegisteredEvent(RegisteredServer registeredServer) {
-    this.registeredServer = Preconditions.checkNotNull(registeredServer, "registeredServer");
-  }
-
-  public RegisteredServer getRegisteredServer() {
-    return registeredServer;
-  }
-
-  @Override
-  public String toString() {
-    return "ServerRegisteredEvent{"
-         + "registeredServer=" + registeredServer
-         + '}';
-  }
+public record ServerRegisteredEvent(@NotNull RegisteredServer registeredServer) {
 }

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
@@ -8,6 +8,7 @@
 package com.velocitypowered.api.event.proxy.server;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Preconditions;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
 import org.jetbrains.annotations.NotNull;
@@ -24,4 +25,7 @@ import org.jetbrains.annotations.NotNull;
  */
 @Beta
 public record ServerRegisteredEvent(@NotNull RegisteredServer registeredServer) {
+    public ServerRegisteredEvent {
+        Preconditions.checkNotNull(registeredServer, "registeredServer");
+    }
 }

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
  * Currently, it may occur when a server is unregistered dynamically at runtime
  * or when a server is replaced due to configuration reload.
  *
- *  @see com.velocitypowered.api.proxy.ProxyServer#unregisterServer(ServerInfo)
+ * @see com.velocitypowered.api.proxy.ProxyServer#unregisterServer(ServerInfo)
  *
  * @param unregisteredServer A {@link RegisteredServer} that has been unregistered.
  * @since 3.3.0

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.NotNull;
  */
 @Beta
 public record ServerUnregisteredEvent(@NotNull RegisteredServer unregisteredServer) {
-    public ServerUnregisteredEvent {
-        Preconditions.checkNotNull(unregisteredServer, "unregisteredServer");
-    }
+  public ServerUnregisteredEvent {
+    Preconditions.checkNotNull(unregisteredServer, "unregisteredServer");
+  }
 }

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
@@ -7,6 +7,7 @@
 
 package com.velocitypowered.api.event.proxy.server;
 
+import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
@@ -18,6 +19,7 @@ import com.velocitypowered.api.proxy.server.ServerInfo;
  *
  *  @see com.velocitypowered.api.proxy.ProxyServer#unregisterServer(ServerInfo)
  */
+@Beta
 public class ServerUnregisteredEvent {
 
   private final RegisteredServer unregisteredServer;

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.event.proxy.server;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.server.ServerInfo;
+
+/**
+ * This event is fired by the proxy after a backend server is unregistered from the server map.
+ * Currently, it may occur when a server is unregistered dynamically at runtime
+ * or when a server is replaced due to configuration reload.
+ *
+ *  @see com.velocitypowered.api.proxy.ProxyServer#unregisterServer(ServerInfo)
+ */
+public class ServerUnregisteredEvent {
+
+  private final RegisteredServer unregisteredServer;
+
+  public ServerUnregisteredEvent(RegisteredServer unregisteredServer) {
+    this.unregisteredServer = Preconditions.checkNotNull(unregisteredServer, "unregisteredServer");
+  }
+
+  public RegisteredServer getUnregisteredServer() {
+    return unregisteredServer;
+  }
+
+  @Override
+  public String toString() {
+    return "ServerUnRegisteredEvent{"
+         + "unregisteredServer=" + unregisteredServer
+         + '}';
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
@@ -8,6 +8,7 @@
 package com.velocitypowered.api.event.proxy.server;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Preconditions;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
 import org.jetbrains.annotations.NotNull;
@@ -24,4 +25,7 @@ import org.jetbrains.annotations.NotNull;
  */
 @Beta
 public record ServerUnregisteredEvent(@NotNull RegisteredServer unregisteredServer) {
+    public ServerUnregisteredEvent {
+        Preconditions.checkNotNull(unregisteredServer, "unregisteredServer");
+    }
 }

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
@@ -8,9 +8,9 @@
 package com.velocitypowered.api.event.proxy.server;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Preconditions;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This event is fired by the proxy after a backend server is unregistered from the server map.
@@ -18,24 +18,10 @@ import com.velocitypowered.api.proxy.server.ServerInfo;
  * or when a server is replaced due to configuration reload.
  *
  *  @see com.velocitypowered.api.proxy.ProxyServer#unregisterServer(ServerInfo)
+ *
+ * @param unregisteredServer A registeredServer that just has been unregistered.
+ * @since 3.3.0
  */
 @Beta
-public class ServerUnregisteredEvent {
-
-  private final RegisteredServer unregisteredServer;
-
-  public ServerUnregisteredEvent(RegisteredServer unregisteredServer) {
-    this.unregisteredServer = Preconditions.checkNotNull(unregisteredServer, "unregisteredServer");
-  }
-
-  public RegisteredServer getUnregisteredServer() {
-    return unregisteredServer;
-  }
-
-  @Override
-  public String toString() {
-    return "ServerUnRegisteredEvent{"
-         + "unregisteredServer=" + unregisteredServer
-         + '}';
-  }
+public record ServerUnregisteredEvent(@NotNull RegisteredServer unregisteredServer) {
 }

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
  *
  *  @see com.velocitypowered.api.proxy.ProxyServer#unregisterServer(ServerInfo)
  *
- * @param unregisteredServer A registeredServer that just has been unregistered.
+ * @param unregisteredServer A {@link RegisteredServer} that has been unregistered.
  * @since 3.3.0
  */
 @Beta

--- a/proxy/src/main/java/com/velocitypowered/proxy/server/ServerMap.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/server/ServerMap.java
@@ -19,6 +19,8 @@ package com.velocitypowered.proxy.server;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.velocitypowered.api.event.proxy.server.ServerRegisteredEvent;
+import com.velocitypowered.api.event.proxy.server.ServerUnregisteredEvent;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
 import com.velocitypowered.proxy.VelocityServer;
@@ -84,6 +86,10 @@ public class ServerMap {
       throw new IllegalArgumentException(
           "Server with name " + serverInfo.getName() + " already registered");
     } else if (existing == null) {
+      if (server != null) {
+        server.getEventManager().fireAndForget(new ServerRegisteredEvent(rs));
+      }
+
       return rs;
     } else {
       return existing;
@@ -107,5 +113,9 @@ public class ServerMap {
         "Trying to remove server %s with differing information", serverInfo.getName());
     Preconditions.checkState(servers.remove(lowerName, rs),
         "Server with name %s replaced whilst unregistering", serverInfo.getName());
+
+    if (server != null) {
+      server.getEventManager().fireAndForget(new ServerUnregisteredEvent(rs));
+    }
   }
 }


### PR DESCRIPTION
These events are useful for handling dynamically registered servers by other plugins or reloads of velocity configuration.

This PR replaces #1050, due to owners inactivity.