### PR TITLE
Decompose TabCompleteEvent into PlayerTabCompleteEvent and TabCompletionResponseEvent

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/player/PlayerTabCompleteEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/PlayerTabCompleteEvent.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2019-2023 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.event.player;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.event.ResultedEvent;
+import com.velocitypowered.api.event.annotation.AwaitingEvent;
+import com.velocitypowered.api.proxy.Player;
+
+/**
+ * For clients 1.12.2 and below, this event is triggered when the player
+ * requests a Tab complete from the remote server. Velocity will wait for this
+ * event to complete, and then decide what information to send to the remote
+ * server based on the result of the trigger.
+ */
+@AwaitingEvent
+public class PlayerTabCompleteEvent implements ResultedEvent<ResultedEvent.GenericResult> {
+
+    private final Player player;
+    private String partialMessage;
+    private GenericResult result;
+
+    /**
+     * Constructs a new TabCompleteEvent instance.
+     *
+     * @param player the player
+     * @param partialMessage the partial message
+     */
+    public PlayerTabCompleteEvent(Player player, String partialMessage) {
+        this.player = checkNotNull(player, "player");
+        this.partialMessage = checkNotNull(partialMessage, "partialMessage");
+    }
+
+    /**
+     * Returns the player requesting the tab completion.
+     *
+     * @return the requesting player
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Returns the message being partially completed.
+     *
+     * @return the partial message
+     */
+    public String getPartialMessage() {
+        return partialMessage;
+    }
+
+    /**
+     * Set the message being partially completed.
+     */
+    public void setPartialMessage(String partialMessage) {
+        this.partialMessage = Preconditions.checkNotNull(partialMessage, "partialMessage");
+    }
+
+    @Override
+    public String toString() {
+        return "PlayerTabCompleteEvent{"
+                + "player=" + player
+                + ", partialMessage='" + partialMessage + '\''
+                + ", result=" + result
+                + '}';
+    }
+
+    @Override
+    public GenericResult getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(GenericResult result) {
+        this.result = Preconditions.checkNotNull(result, "result");
+    }
+}

--- a/api/src/main/java/com/velocitypowered/api/event/player/PlayerTabCompleteEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/PlayerTabCompleteEvent.java
@@ -19,6 +19,8 @@ import com.velocitypowered.api.proxy.Player;
  * requests a Tab complete from the remote server. Velocity will wait for this
  * event to complete, and then decide what information to send to the remote
  * server based on the result of the trigger.
+ *
+ * @since 3.3.0
  */
 @AwaitingEvent
 public class PlayerTabCompleteEvent implements ResultedEvent<ResultedEvent.GenericResult> {
@@ -66,10 +68,10 @@ public class PlayerTabCompleteEvent implements ResultedEvent<ResultedEvent.Gener
     @Override
     public String toString() {
         return "PlayerTabCompleteEvent{"
-                + "player=" + player
-                + ", partialMessage='" + partialMessage + '\''
-                + ", result=" + result
-                + '}';
+            + "player=" + player
+            + ", partialMessage='" + partialMessage + '\''
+            + ", result=" + result
+            + '}';
     }
 
     @Override

--- a/api/src/main/java/com/velocitypowered/api/event/player/TabCompleteEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/TabCompleteEvent.java
@@ -71,9 +71,9 @@ public class TabCompleteEvent {
   @Override
   public String toString() {
     return "TabCompleteEvent{"
-            + "player=" + player
-            + ", partialMessage='" + partialMessage + '\''
-            + ", suggestions=" + suggestions
-            + '}';
+        + "player=" + player
+        + ", partialMessage='" + partialMessage + '\''
+        + ", suggestions=" + suggestions
+        + '}';
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/event/player/TabCompleteEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/TabCompleteEvent.java
@@ -20,8 +20,12 @@ import java.util.List;
  * Velocity will wait for this event to finish firing before sending the tab complete results to
  * the client. Be sure to be as fast as possible, since the client will freeze while it waits for
  * the tab complete results.
+ *
+ * @deprecated This event is deprecated and no longer called, we strongly advise you to
+ *     use PlayerTabCompleteEvent and TabCompletionResponseEvent,java instead.
  */
 @AwaitingEvent
+@Deprecated
 public class TabCompleteEvent {
   private final Player player;
   private final String partialMessage;
@@ -70,9 +74,9 @@ public class TabCompleteEvent {
   @Override
   public String toString() {
     return "TabCompleteEvent{"
-        + "player=" + player
-        + ", partialMessage='" + partialMessage + '\''
-        + ", suggestions=" + suggestions
-        + '}';
+            + "player=" + player
+            + ", partialMessage='" + partialMessage + '\''
+            + ", suggestions=" + suggestions
+            + '}';
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/event/player/TabCompleteEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/TabCompleteEvent.java
@@ -20,9 +20,6 @@ import java.util.List;
  * Velocity will wait for this event to finish firing before sending the tab complete results to
  * the client. Be sure to be as fast as possible, since the client will freeze while it waits for
  * the tab complete results.
- *
- * @deprecated This event is deprecated and no longer called, we strongly advise you to
- *     use PlayerTabCompleteEvent and TabCompletionResponseEvent,java instead.
  */
 @AwaitingEvent
 @Deprecated

--- a/api/src/main/java/com/velocitypowered/api/event/player/TabCompleteEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/TabCompleteEvent.java
@@ -22,7 +22,7 @@ import java.util.List;
  * the tab complete results.
  */
 @AwaitingEvent
-@Deprecated
+@Deprecated(since = "3.3.0")
 public class TabCompleteEvent {
   private final Player player;
   private final String partialMessage;

--- a/api/src/main/java/com/velocitypowered/api/event/player/TabCompletionResponseEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/TabCompletionResponseEvent.java
@@ -22,6 +22,8 @@ import java.util.List;
  * Velocity will wait for this event to finish firing before sending the tab complete results to
  * the client. Be sure to be as fast as possible, since the client will freeze while it waits for
  * the tab complete results.
+ *
+ * @since 3.3.0
  */
 @AwaitingEvent
 public class TabCompletionResponseEvent implements ResultedEvent<ResultedEvent.GenericResult> {
@@ -89,11 +91,11 @@ public class TabCompletionResponseEvent implements ResultedEvent<ResultedEvent.G
     @Override
     public String toString() {
         return "TabCompletionResponseEvent{"
-                + "player=" + player
-                + ", partialMessage='" + partialMessage + '\''
-                + ", suggestions=" + suggestions
-                + ", result=" + result
-                + '}';
+            + "player=" + player
+            + ", partialMessage='" + partialMessage + '\''
+            + ", suggestions=" + suggestions
+            + ", result=" + result
+            + '}';
     }
 
     @Override

--- a/api/src/main/java/com/velocitypowered/api/event/player/TabCompletionResponseEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/TabCompletionResponseEvent.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2019-2023 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.event.player;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.event.ResultedEvent;
+import com.velocitypowered.api.event.annotation.AwaitingEvent;
+import com.velocitypowered.api.proxy.Player;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This event is fired after a tab complete response is sent by the remote server, for clients on
+ * 1.12.2 and below. You have the opportunity to modify the response sent to the remote player.
+ * Velocity will wait for this event to finish firing before sending the tab complete results to
+ * the client. Be sure to be as fast as possible, since the client will freeze while it waits for
+ * the tab complete results.
+ */
+@AwaitingEvent
+public class TabCompletionResponseEvent implements ResultedEvent<ResultedEvent.GenericResult> {
+    private final Player player;
+    private final String partialMessage;
+    private List<String> suggestions;
+    private GenericResult result;
+
+    /**
+     * Constructs a new TabCompleteEvent instance.
+     *
+     * @param player the player
+     * @param partialMessage the partial message
+     * @param suggestions the initial list of suggestions
+     */
+    public TabCompletionResponseEvent(Player player, String partialMessage, List<String> suggestions) {
+        this.player = checkNotNull(player, "player");
+        this.partialMessage = checkNotNull(partialMessage, "partialMessage");
+        this.suggestions = new ArrayList<>(checkNotNull(suggestions, "suggestions"));
+    }
+
+    /**
+     * Returns the player requesting the tab completion.
+     *
+     * @return the requesting player
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Returns the message being partially completed.
+     *
+     * @return the partial message
+     */
+    public String getPartialMessage() {
+        return partialMessage;
+    }
+
+    /**
+     * Returns all the suggestions provided to the user, as a mutable list.
+     *
+     * @return the suggestions
+     */
+    public List<String> getSuggestions() {
+        return suggestions;
+    }
+
+    /**
+     * Set the suggestions provided to the user.
+     */
+    public void setSuggestions(List<String> suggestions) {
+        this.suggestions = Preconditions.checkNotNull(suggestions, "suggestions");
+    }
+
+    @Override
+    public String toString() {
+        return "TabCompletionResponseEvent{"
+                + "player=" + player
+                + ", partialMessage='" + partialMessage + '\''
+                + ", suggestions=" + suggestions
+                + ", result=" + result
+                + '}';
+    }
+
+    @Override
+    public GenericResult getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(GenericResult result) {
+        this.result = Preconditions.checkNotNull(result, "result");
+    }
+}

--- a/api/src/main/java/com/velocitypowered/api/event/player/TabCompletionResponseEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/TabCompletionResponseEvent.java
@@ -29,6 +29,7 @@ public class TabCompletionResponseEvent implements ResultedEvent<ResultedEvent.G
     private final String partialMessage;
     private List<String> suggestions;
     private GenericResult result;
+    private boolean isSuggestionsModified = false;
 
     /**
      * Constructs a new TabCompleteEvent instance.
@@ -75,6 +76,14 @@ public class TabCompletionResponseEvent implements ResultedEvent<ResultedEvent.G
      */
     public void setSuggestions(List<String> suggestions) {
         this.suggestions = Preconditions.checkNotNull(suggestions, "suggestions");
+        isSuggestionsModified = true;
+    }
+
+    /**
+     * Get if the suggestions list is modified.
+     */
+    public boolean isSuggestionsModified() {
+        return isSuggestionsModified;
     }
 
     @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -17,75 +17,167 @@
 
 package com.velocitypowered.proxy.connection.client;
 
+import static com.velocitypowered.proxy.protocol.util.PluginMessageUtil.constructChannelsPacket;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.brigadier.suggestion.Suggestion;
+import com.velocitypowered.api.command.VelocityBrigadierMessage;
+import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.event.player.CookieReceiveEvent;
+import com.velocitypowered.api.event.player.PlayerChannelRegisterEvent;
 import com.velocitypowered.api.event.player.PlayerClientBrandEvent;
-import com.velocitypowered.api.event.player.configuration.PlayerConfigurationEvent;
-import com.velocitypowered.api.event.player.configuration.PlayerFinishConfigurationEvent;
-import com.velocitypowered.api.event.player.configuration.PlayerFinishedConfigurationEvent;
+import com.velocitypowered.api.event.player.PlayerTabCompleteEvent;
+import com.velocitypowered.api.event.player.TabCompletionResponseEvent;
+import com.velocitypowered.api.event.player.configuration.PlayerEnteredConfigurationEvent;
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
+import com.velocitypowered.api.proxy.messages.LegacyChannelIdentifier;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import com.velocitypowered.proxy.VelocityServer;
+import com.velocitypowered.proxy.connection.ConnectionTypes;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.connection.backend.BackendConnectionPhases;
+import com.velocitypowered.proxy.connection.backend.BungeeCordMessageResponder;
 import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
+import com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConstants;
 import com.velocitypowered.proxy.connection.player.resourcepack.ResourcePackResponseBundle;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
-import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.StateRegistry;
-import com.velocitypowered.proxy.protocol.netty.MinecraftEncoder;
+import com.velocitypowered.proxy.protocol.packet.BossBarPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientSettingsPacket;
+import com.velocitypowered.proxy.protocol.packet.JoinGamePacket;
 import com.velocitypowered.proxy.protocol.packet.KeepAlivePacket;
-import com.velocitypowered.proxy.protocol.packet.PingIdentifyPacket;
 import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
 import com.velocitypowered.proxy.protocol.packet.ResourcePackResponsePacket;
+import com.velocitypowered.proxy.protocol.packet.RespawnPacket;
 import com.velocitypowered.proxy.protocol.packet.ServerboundCookieResponsePacket;
+import com.velocitypowered.proxy.protocol.packet.TabCompleteRequestPacket;
+import com.velocitypowered.proxy.protocol.packet.TabCompleteResponsePacket;
+import com.velocitypowered.proxy.protocol.packet.TabCompleteResponsePacket.Offer;
+import com.velocitypowered.proxy.protocol.packet.chat.ChatAcknowledgementPacket;
+import com.velocitypowered.proxy.protocol.packet.chat.ChatHandler;
+import com.velocitypowered.proxy.protocol.packet.chat.ChatTimeKeeper;
+import com.velocitypowered.proxy.protocol.packet.chat.CommandHandler;
+import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
+import com.velocitypowered.proxy.protocol.packet.chat.keyed.KeyedChatHandler;
+import com.velocitypowered.proxy.protocol.packet.chat.keyed.KeyedCommandHandler;
+import com.velocitypowered.proxy.protocol.packet.chat.keyed.KeyedPlayerChatPacket;
+import com.velocitypowered.proxy.protocol.packet.chat.keyed.KeyedPlayerCommandPacket;
+import com.velocitypowered.proxy.protocol.packet.chat.legacy.LegacyChatHandler;
+import com.velocitypowered.proxy.protocol.packet.chat.legacy.LegacyChatPacket;
+import com.velocitypowered.proxy.protocol.packet.chat.legacy.LegacyCommandHandler;
+import com.velocitypowered.proxy.protocol.packet.chat.session.SessionChatHandler;
+import com.velocitypowered.proxy.protocol.packet.chat.session.SessionCommandHandler;
+import com.velocitypowered.proxy.protocol.packet.chat.session.SessionPlayerChatPacket;
+import com.velocitypowered.proxy.protocol.packet.chat.session.SessionPlayerCommandPacket;
 import com.velocitypowered.proxy.protocol.packet.config.FinishedUpdatePacket;
-import com.velocitypowered.proxy.protocol.packet.config.KnownPacksPacket;
+import com.velocitypowered.proxy.protocol.packet.title.GenericTitlePacket;
 import com.velocitypowered.proxy.protocol.util.PluginMessageUtil;
+import com.velocitypowered.proxy.util.CharacterUtil;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Queue;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Handles the client config stage.
+ * Handles communication with the connected Minecraft client. This is effectively the primary nerve
+ * center that joins backend servers with players.
  */
-public class ClientConfigSessionHandler implements MinecraftSessionHandler {
+public class ClientPlaySessionHandler implements MinecraftSessionHandler {
 
-  private static final Logger logger = LogManager.getLogger(ClientConfigSessionHandler.class);
-  private final VelocityServer server;
+  private static final Logger logger = LogManager.getLogger(ClientPlaySessionHandler.class);
+
   private final ConnectedPlayer player;
-  private String brandChannel = null;
+  private boolean spawned = false;
+  private final List<UUID> serverBossBars = new ArrayList<>();
+  private final Queue<PluginMessagePacket> loginPluginMessages = new ConcurrentLinkedQueue<>();
+  private final VelocityServer server;
+  private @Nullable TabCompleteRequestPacket outstandingTabComplete;
+  private final ChatHandler<? extends MinecraftPacket> chatHandler;
+  private final CommandHandler<? extends MinecraftPacket> commandHandler;
+  private final ChatTimeKeeper timeKeeper = new ChatTimeKeeper();
 
-  private CompletableFuture<?> configurationFuture;
   private CompletableFuture<Void> configSwitchFuture;
 
   /**
-   * Constructs a client config session handler.
+   * Constructs a client play session handler.
    *
    * @param server the Velocity server instance
    * @param player the player
    */
-  public ClientConfigSessionHandler(VelocityServer server, ConnectedPlayer player) {
-    this.server = server;
+  public ClientPlaySessionHandler(VelocityServer server, ConnectedPlayer player) {
     this.player = player;
+    this.server = server;
+
+    if (this.player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_19_3)) {
+      this.chatHandler = new SessionChatHandler(this.player, this.server);
+      this.commandHandler = new SessionCommandHandler(this.player, this.server);
+    } else if (this.player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_19)) {
+      this.chatHandler = new KeyedChatHandler(this.server, this.player);
+      this.commandHandler = new KeyedCommandHandler(this.player, this.server);
+    } else {
+      this.chatHandler = new LegacyChatHandler(this.server, this.player);
+      this.commandHandler = new LegacyCommandHandler(this.player, this.server);
+    }
+  }
+
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+  private boolean updateTimeKeeper(@Nullable Instant instant) {
+    if (instant == null) {
+      return true;
+    }
+    if (!this.timeKeeper.update(instant)) {
+      player.disconnect(Component.translatable("multiplayer.disconnect.out_of_order_chat"));
+      return false;
+    }
+    return true;
+  }
+
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+  private boolean validateChat(String message) {
+    if (CharacterUtil.containsIllegalCharacters(message)) {
+      player.disconnect(
+              Component.translatable("velocity.error.illegal-chat-characters", NamedTextColor.RED));
+      return false;
+    }
+    return true;
   }
 
   @Override
   public void activated() {
     configSwitchFuture = new CompletableFuture<>();
+    Collection<String> channels =
+            server.getChannelRegistrar().getChannelsForProtocol(player.getProtocolVersion());
+    if (!channels.isEmpty()) {
+      PluginMessagePacket register = constructChannelsPacket(player.getProtocolVersion(), channels);
+      player.getConnection().write(register);
+    }
   }
 
   @Override
   public void deactivated() {
-    configurationFuture = null;
+    for (PluginMessagePacket message : loginPluginMessages) {
+      ReferenceCountUtil.release(message);
+    }
   }
 
   @Override
-  public boolean handle(final KeepAlivePacket packet) {
+  public boolean handle(KeepAlivePacket packet) {
     player.forwardKeepAlive(packet);
     return true;
   }
@@ -93,82 +185,262 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
   @Override
   public boolean handle(ClientSettingsPacket packet) {
     player.setClientSettings(packet);
+    VelocityServerConnection serverConnection = player.getConnectedServer();
+    if (serverConnection == null) {
+      // No server connection yet, probably transitioning.
+      return true;
+    }
+    player.getConnectedServer().ensureConnected().write(packet);
+    return true; // will forward onto the server
+  }
+
+  @Override
+  public boolean handle(SessionPlayerCommandPacket packet) {
+    if (player.getCurrentServer().isEmpty()) {
+      return true;
+    }
+
+    if (!updateTimeKeeper(packet.getTimeStamp())) {
+      return true;
+    }
+
+    if (!validateChat(packet.getCommand())) {
+      return true;
+    }
+
+    return this.commandHandler.handlePlayerCommand(packet);
+  }
+
+  @Override
+  public boolean handle(SessionPlayerChatPacket packet) {
+    if (player.getCurrentServer().isEmpty()) {
+      return true;
+    }
+
+    if (!updateTimeKeeper(packet.getTimestamp())) {
+      return true;
+    }
+
+    if (!validateChat(packet.getMessage())) {
+      return true;
+    }
+
+    return this.chatHandler.handlePlayerChat(packet);
+  }
+
+  @Override
+  public boolean handle(KeyedPlayerCommandPacket packet) {
+    if (player.getCurrentServer().isEmpty()) {
+      return true;
+    }
+
+    if (!updateTimeKeeper(packet.getTimestamp())) {
+      return true;
+    }
+
+    if (!validateChat(packet.getCommand())) {
+      return true;
+    }
+
+    return this.commandHandler.handlePlayerCommand(packet);
+  }
+
+  @Override
+  public boolean handle(KeyedPlayerChatPacket packet) {
+    if (player.getCurrentServer().isEmpty()) {
+      return true;
+    }
+
+    if (!updateTimeKeeper(packet.getExpiry())) {
+      return true;
+    }
+
+    if (!validateChat(packet.getMessage())) {
+      return true;
+    }
+
+    return this.chatHandler.handlePlayerChat(packet);
+  }
+
+  @Override
+  public boolean handle(LegacyChatPacket packet) {
+    if (player.getCurrentServer().isEmpty()) {
+      return true;
+    }
+
+    String msg = packet.getMessage();
+    if (!validateChat(msg)) {
+      return true;
+    }
+
+    if (msg.startsWith("/")) {
+      this.commandHandler.handlePlayerCommand(packet);
+    } else {
+      this.chatHandler.handlePlayerChat(packet);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean handle(TabCompleteRequestPacket packet) {
+    boolean isCommand = !packet.isAssumeCommand() && packet.getCommand().startsWith("/");
+
+    if (isCommand) {
+      return this.handleCommandTabComplete(packet);
+    } else {
+      return this.handleRegularTabComplete(packet);
+    }
+  }
+
+  @Override
+  public boolean handle(PluginMessagePacket packet) {
+    // Handling edge case when packet with FML client handshake (state COMPLETE)
+    // arrives after JoinGame packet from destination server
+    VelocityServerConnection serverConn =
+            (player.getConnectedServer() == null
+                    && packet.getChannel().equals(
+                    LegacyForgeConstants.FORGE_LEGACY_HANDSHAKE_CHANNEL))
+                    ? player.getConnectionInFlight() : player.getConnectedServer();
+
+    MinecraftConnection backendConn = serverConn != null ? serverConn.getConnection() : null;
+    if (serverConn != null && backendConn != null) {
+      if (backendConn.getState() != StateRegistry.PLAY) {
+        logger.warn("A plugin message was received while the backend server was not "
+                + "ready. Channel: {}. Packet discarded.", packet.getChannel());
+      } else if (PluginMessageUtil.isRegister(packet)) {
+        List<String> channels = PluginMessageUtil.getChannels(packet);
+        List<ChannelIdentifier> channelIdentifiers = new ArrayList<>();
+        for (String channel : channels) {
+          try {
+            channelIdentifiers.add(MinecraftChannelIdentifier.from(channel));
+          } catch (IllegalArgumentException e) {
+            channelIdentifiers.add(new LegacyChannelIdentifier(channel));
+          }
+        }
+        server.getEventManager()
+                .fireAndForget(
+                        new PlayerChannelRegisterEvent(player, ImmutableList.copyOf(channelIdentifiers)));
+        backendConn.write(packet.retain());
+      } else if (PluginMessageUtil.isUnregister(packet)) {
+        backendConn.write(packet.retain());
+      } else if (PluginMessageUtil.isMcBrand(packet)) {
+        String brand = PluginMessageUtil.readBrandMessage(packet.content());
+        server.getEventManager().fireAndForget(new PlayerClientBrandEvent(player, brand));
+        player.setClientBrand(brand);
+        backendConn.write(packet.retain());
+      } else if (BungeeCordMessageResponder.isBungeeCordMessage(packet)) {
+        return true;
+      } else {
+        if (serverConn.getPhase() == BackendConnectionPhases.IN_TRANSITION) {
+          // We must bypass the currently-connected server when forwarding Forge packets.
+          VelocityServerConnection inFlight = player.getConnectionInFlight();
+          if (inFlight != null) {
+            player.getPhase().handle(player, packet, inFlight);
+          }
+          return true;
+        }
+
+        if (!player.getPhase().handle(player, packet, serverConn)) {
+          ChannelIdentifier id = server.getChannelRegistrar().getFromId(packet.getChannel());
+          if (id == null) {
+            // We don't have any plugins listening on this channel, process the packet now.
+            if (!player.getPhase().consideredComplete() || !serverConn.getPhase()
+                    .consideredComplete()) {
+              // The client is trying to send messages too early. This is primarily caused by mods,
+              // but further aggravated by Velocity. To work around these issues, we will queue any
+              // non-FML handshake messages to be sent once the FML handshake has completed or the
+              // JoinGame packet has been received by the proxy, whichever comes first.
+              //
+              // We also need to make sure to retain these packets, so they can be flushed
+              // appropriately.
+              loginPluginMessages.add(packet.retain());
+            } else {
+              // The connection is ready, send the packet now.
+              backendConn.write(packet.retain());
+            }
+          } else {
+            byte[] copy = ByteBufUtil.getBytes(packet.content());
+            PluginMessageEvent event = new PluginMessageEvent(player, serverConn, id, copy);
+            server.getEventManager().fire(event).thenAcceptAsync(pme -> {
+              if (pme.getResult().isAllowed()) {
+                PluginMessagePacket message = new PluginMessagePacket(packet.getChannel(),
+                        Unpooled.wrappedBuffer(copy));
+                if (!player.getPhase().consideredComplete() || !serverConn.getPhase()
+                        .consideredComplete()) {
+                  // We're still processing the connection (see above), enqueue the packet for now.
+                  loginPluginMessages.add(message.retain());
+                } else {
+                  backendConn.write(message);
+                }
+              }
+            }, backendConn.eventLoop()).exceptionally((ex) -> {
+              logger.error("Exception while handling plugin message packet for {}", player, ex);
+              return null;
+            });
+          }
+        }
+      }
+    }
+
     return true;
   }
 
   @Override
   public boolean handle(ResourcePackResponsePacket packet) {
     return player.resourcePackHandler().onResourcePackResponse(
-        new ResourcePackResponseBundle(packet.getId(),
-            packet.getHash(),
-            packet.getStatus())
-    );
+            new ResourcePackResponseBundle(packet.getId(),
+                    packet.getHash(),
+                    packet.getStatus()));
   }
 
   @Override
   public boolean handle(FinishedUpdatePacket packet) {
-    player.getConnection().setActiveSessionHandler(StateRegistry.PLAY, new ClientPlaySessionHandler(server, player));
-
+    // Complete client switch
+    player.getConnection().setActiveSessionHandler(StateRegistry.CONFIG);
+    VelocityServerConnection serverConnection = player.getConnectedServer();
+    server.getEventManager().fireAndForget(new PlayerEnteredConfigurationEvent(player, serverConnection));
+    if (serverConnection != null) {
+      MinecraftConnection smc = serverConnection.ensureConnected();
+      CompletableFuture.runAsync(() -> {
+        smc.write(packet);
+        smc.setActiveSessionHandler(StateRegistry.CONFIG);
+        smc.setAutoReading(true);
+      }, smc.eventLoop()).exceptionally((ex) -> {
+        logger.error("Error forwarding config state acknowledgement to server:", ex);
+        return null;
+      });
+    }
     configSwitchFuture.complete(null);
     return true;
   }
 
   @Override
-  public boolean handle(final PluginMessagePacket packet) {
-    final VelocityServerConnection serverConn = player.getConnectionInFlight();
-    if (PluginMessageUtil.isMcBrand(packet)) {
-      final String brand = PluginMessageUtil.readBrandMessage(packet.content());
-      server.getEventManager().fireAndForget(new PlayerClientBrandEvent(player, brand));
-      player.setClientBrand(brand);
-      brandChannel = packet.getChannel();
-      // Client sends `minecraft:brand` packet immediately after Login,
-      // but at this time the backend server may not be ready
-    } else if (serverConn != null) {
-      serverConn.ensureConnected().write(packet.retain());
-    }
-    return true;
-  }
-
-  @Override
-  public boolean handle(PingIdentifyPacket packet) {
-    if (player.getConnectionInFlight() != null) {
-      player.getConnectionInFlight().ensureConnected().write(packet);
+  public boolean handle(ChatAcknowledgementPacket packet) {
+    if (player.getCurrentServer().isEmpty()) {
       return true;
     }
-
-    return false;
-  }
-
-  @Override
-  public boolean handle(KnownPacksPacket packet) {
-    callConfigurationEvent().thenRun(() -> {
-      player.getConnectionInFlightOrConnectedServer().ensureConnected().write(packet);
-    }).exceptionally(ex -> {
-      logger.error("Error forwarding known packs response to backend:", ex);
-      return null;
-    });
-
+    player.getChatQueue().handleAcknowledgement(packet.offset());
     return true;
   }
 
   @Override
   public boolean handle(ServerboundCookieResponsePacket packet) {
     server.getEventManager()
-        .fire(new CookieReceiveEvent(player, packet.getKey(), packet.getPayload()))
-        .thenAcceptAsync(event -> {
-          if (event.getResult().isAllowed()) {
-            final VelocityServerConnection serverConnection = player.getConnectionInFlight();
-            if (serverConnection != null) {
-              final Key resultedKey = event.getResult().getKey() == null
-                  ? event.getOriginalKey() : event.getResult().getKey();
-              final byte[] resultedData = event.getResult().getData() == null
-                  ? event.getOriginalData() : event.getResult().getData();
+            .fire(new CookieReceiveEvent(player, packet.getKey(), packet.getPayload()))
+            .thenAcceptAsync(event -> {
+              if (event.getResult().isAllowed()) {
+                final VelocityServerConnection serverConnection = player.getConnectedServer();
+                if (serverConnection != null) {
+                  final Key resultedKey = event.getResult().getKey() == null
+                          ? event.getOriginalKey() : event.getResult().getKey();
+                  final byte[] resultedData = event.getResult().getData() == null
+                          ? event.getOriginalData() : event.getResult().getData();
 
-              serverConnection.ensureConnected()
-                  .write(new ServerboundCookieResponsePacket(resultedKey, resultedData));
-            }
-          }
-        }, player.getConnection().eventLoop());
+                  serverConnection.ensureConnected()
+                          .write(new ServerboundCookieResponsePacket(resultedKey, resultedData));
+                }
+              }
+            }, player.getConnection().eventLoop());
 
     return true;
   }
@@ -192,13 +464,13 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public void handleUnknown(ByteBuf buf) {
-    final VelocityServerConnection serverConnection = player.getConnectedServer();
+    VelocityServerConnection serverConnection = player.getConnectedServer();
     if (serverConnection == null) {
       // No server connection yet, probably transitioning.
       return;
     }
 
-    final MinecraftConnection smc = serverConnection.getConnection();
+    MinecraftConnection smc = serverConnection.getConnection();
     if (smc != null && !smc.isClosed() && serverConnection.getPhase().consideredComplete()) {
       smc.write(buf.retain());
     }
@@ -211,56 +483,340 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public void exception(Throwable throwable) {
-    player.disconnect(Component.translatable("velocity.error.player-connection-error", NamedTextColor.RED));
+    player.disconnect(
+            Component.translatable("velocity.error.player-connection-error", NamedTextColor.RED));
   }
 
-  /**
-   * Calls the {@link PlayerConfigurationEvent}.
-   * For 1.20.5+ backends this is done when the client responds to
-   * the known packs request. The response is delayed until the event
-   * has been called.
-   * For 1.20.2-1.20.4 servers this is done when the client acknowledges
-   * the end of the configuration.
-   * This is handled differently because for 1.20.5+ servers can't keep
-   * their connection alive between states and older servers don't have
-   * the known packs transaction.
-   */
-  private CompletableFuture<?> callConfigurationEvent() {
-    if (configurationFuture != null) {
-      return configurationFuture;
+  @Override
+  public void writabilityChanged() {
+    boolean writable = player.getConnection().getChannel().isWritable();
+
+    if (!writable) {
+      // We might have packets queued from the server, so flush them now to free up memory. Make
+      // sure to do it on a future invocation of the event loop, otherwise while the issue will
+      // fix itself, we'll still disable auto-reading and instead of backpressure resolution, we
+      // get client timeouts.
+      player.getConnection().eventLoop().execute(() -> player.getConnection().flush());
     }
-    return configurationFuture = server.getEventManager().fire(new PlayerConfigurationEvent(player, player.getConnectionInFlightOrConnectedServer()));
+
+    VelocityServerConnection serverConn = player.getConnectedServer();
+    if (serverConn != null) {
+      MinecraftConnection smc = serverConn.getConnection();
+      if (smc != null) {
+        smc.setAutoReading(writable);
+      }
+    }
   }
 
   /**
-   * Handles the backend finishing the config stage.
+   * Handles switching stages for swapping between servers.
    *
-   * @param serverConn the server connection
-   * @return a future that completes when the config stage is finished
+   * @return a future that completes when the switch is complete
    */
-  public CompletableFuture<Void> handleBackendFinishUpdate(VelocityServerConnection serverConn) {
-    final MinecraftConnection smc = serverConn.ensureConnected();
+  public CompletableFuture<Void> doSwitch() {
+    final VelocityServerConnection existingConnection = player.getConnectedServer();
 
-    final String brand = serverConn.getPlayer().getClientBrand();
-    if (brand != null && brandChannel != null) {
-      final ByteBuf buf = Unpooled.buffer();
-      ProtocolUtils.writeString(buf, brand);
-      final PluginMessagePacket brandPacket = new PluginMessagePacket(brandChannel, buf);
-      smc.write(brandPacket);
+    if (existingConnection != null) {
+      // Shut down the existing server connection.
+      player.setConnectedServer(null);
+      existingConnection.disconnect();
+
+      // Send keep alive to try to avoid timeouts
+      player.sendKeepAlive();
+
+      // Config state clears everything in the client. No need to clear later.
+      spawned = false;
+      serverBossBars.clear();
+      player.clearPlayerListHeaderAndFooterSilent();
+      player.getTabList().clearAllSilent();
     }
 
-    callConfigurationEvent().thenCompose(v -> {
-      return server.getEventManager().fire(new PlayerFinishConfigurationEvent(player, serverConn))
-          .completeOnTimeout(null, 5, TimeUnit.SECONDS);
-    }).thenRunAsync(() -> {
-      player.getConnection().write(FinishedUpdatePacket.INSTANCE);
-      player.getConnection().getChannel().pipeline().get(MinecraftEncoder.class).setState(StateRegistry.PLAY);
-      server.getEventManager().fireAndForget(new PlayerFinishedConfigurationEvent(player, serverConn));
-    }, player.getConnection().eventLoop()).exceptionally(ex -> {
-      logger.error("Error finishing configuration state:", ex);
-      return null;
-    });
+    player.switchToConfigState();
 
     return configSwitchFuture;
+  }
+
+  /**
+   * Handles the {@code JoinGame} packet. This function is responsible for handling the client-side
+   * switching servers in Velocity.
+   *
+   * @param joinGame    the join game packet
+   * @param destination the new server we are connecting to
+   */
+  public void handleBackendJoinGame(JoinGamePacket joinGame, VelocityServerConnection destination) {
+    final MinecraftConnection serverMc = destination.ensureConnected();
+
+    if (!spawned) {
+      // The player wasn't spawned in yet, so we don't need to do anything special. Just send
+      // JoinGame.
+      spawned = true;
+      player.getConnection().delayedWrite(joinGame);
+      // Required for Legacy Forge
+      player.getPhase().onFirstJoin(player);
+    } else {
+      // Clear tab list to avoid duplicate entries
+      player.getTabList().clearAll();
+
+      // The player is switching from a server already, so we need to tell the client to change
+      // entity IDs and send new dimension information.
+      if (player.getConnection().getType() == ConnectionTypes.LEGACY_FORGE) {
+        this.doSafeClientServerSwitch(joinGame);
+      } else {
+        this.doFastClientServerSwitch(joinGame);
+      }
+    }
+
+    destination.setActiveDimensionRegistry(joinGame.getRegistry()); // 1.16
+
+    // Remove previous boss bars. These don't get cleared when sending JoinGame, thus the need to
+    // track them.
+    for (UUID serverBossBar : serverBossBars) {
+      BossBarPacket deletePacket = new BossBarPacket();
+      deletePacket.setUuid(serverBossBar);
+      deletePacket.setAction(BossBarPacket.REMOVE);
+      player.getConnection().delayedWrite(deletePacket);
+    }
+    serverBossBars.clear();
+
+    // Tell the server about the proxy's plugin message channels.
+    ProtocolVersion serverVersion = serverMc.getProtocolVersion();
+    final Collection<String> channels = server.getChannelRegistrar()
+            .getChannelsForProtocol(serverMc.getProtocolVersion());
+    if (!channels.isEmpty()) {
+      serverMc.delayedWrite(constructChannelsPacket(serverVersion, channels));
+    }
+
+    // If we had plugin messages queued during login/FML handshake, send them now.
+    PluginMessagePacket pm;
+    while ((pm = loginPluginMessages.poll()) != null) {
+      serverMc.delayedWrite(pm);
+    }
+
+    // Clear any title from the previous server.
+    if (player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_8)) {
+      player.getConnection().delayedWrite(
+              GenericTitlePacket.constructTitlePacket(GenericTitlePacket.ActionType.RESET,
+                      player.getProtocolVersion()));
+    }
+
+    // Flush everything
+    player.getConnection().flush();
+    serverMc.flush();
+    destination.completeJoin();
+  }
+
+  private void doFastClientServerSwitch(JoinGamePacket joinGame) {
+    // In order to handle switching to another server, you will need to send two packets:
+    //
+    // - The join game packet from the backend server, with a different dimension
+    // - A respawn with the correct dimension
+    //
+    // Most notably, by having the client accept the join game packet, we can work around the need
+    // to perform entity ID rewrites, eliminating potential issues from rewriting packets and
+    // improving compatibility with mods.
+    final RespawnPacket respawn = RespawnPacket.fromJoinGame(joinGame);
+
+    if (player.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_16)) {
+      // Before Minecraft 1.16, we could not switch to the same dimension without sending an
+      // additional respawn. On older versions of Minecraft this forces the client to perform
+      // garbage collection which adds additional latency.
+      joinGame.setDimension(joinGame.getDimension() == 0 ? -1 : 0);
+    }
+    player.getConnection().delayedWrite(joinGame);
+    player.getConnection().delayedWrite(respawn);
+  }
+
+  private void doSafeClientServerSwitch(JoinGamePacket joinGame) {
+    // Some clients do not behave well with the "fast" respawn sequence. In this case we will use
+    // a "safe" respawn sequence that involves sending three packets to the client. They have the
+    // same effect but tend to work better with buggier clients (Forge 1.8 in particular).
+
+    // Send the JoinGame packet itself, unmodified.
+    player.getConnection().delayedWrite(joinGame);
+
+    // Send a respawn packet in a different dimension.
+    final RespawnPacket fakeSwitchPacket = RespawnPacket.fromJoinGame(joinGame);
+    fakeSwitchPacket.setDimension(joinGame.getDimension() == 0 ? -1 : 0);
+    player.getConnection().delayedWrite(fakeSwitchPacket);
+
+    // Now send a respawn packet in the correct dimension.
+    final RespawnPacket correctSwitchPacket = RespawnPacket.fromJoinGame(joinGame);
+    player.getConnection().delayedWrite(correctSwitchPacket);
+  }
+
+  public List<UUID> getServerBossBars() {
+    return serverBossBars;
+  }
+
+  private boolean handleCommandTabComplete(TabCompleteRequestPacket packet) {
+    // In 1.13+, we need to do additional work for the richer suggestions available.
+    String command = packet.getCommand().substring(1);
+    int commandEndPosition = command.indexOf(' ');
+    if (commandEndPosition == -1) {
+      commandEndPosition = command.length();
+    }
+
+    String commandLabel = command.substring(0, commandEndPosition);
+    if (!server.getCommandManager().hasCommand(commandLabel, player)) {
+      if (player.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_13)) {
+        // Outstanding tab completes are recorded for use with 1.12 clients and below to provide
+        // additional tab completion support.
+        outstandingTabComplete = packet;
+      }
+      return false;
+    }
+
+    server.getCommandManager().offerBrigadierSuggestions(player, command)
+            .thenAcceptAsync(suggestions -> {
+              if (suggestions.isEmpty()) {
+                return;
+              }
+
+              List<Offer> offers = new ArrayList<>();
+              for (Suggestion suggestion : suggestions.getList()) {
+                String offer = suggestion.getText();
+                ComponentHolder tooltip = null;
+                if (suggestion.getTooltip() != null
+                        && suggestion.getTooltip() instanceof VelocityBrigadierMessage) {
+                  tooltip = new ComponentHolder(player.getProtocolVersion(),
+                          ((VelocityBrigadierMessage) suggestion.getTooltip()).asComponent());
+                }
+                offers.add(new Offer(offer, tooltip));
+              }
+              int startPos = packet.getCommand().lastIndexOf(' ') + 1;
+              if (startPos > 0) {
+                TabCompleteResponsePacket resp = new TabCompleteResponsePacket();
+                resp.setTransactionId(packet.getTransactionId());
+                resp.setStart(startPos);
+                resp.setLength(packet.getCommand().length() - startPos);
+                resp.getOffers().addAll(offers);
+                player.getConnection().write(resp);
+              }
+            }, player.getConnection().eventLoop()).exceptionally((ex) -> {
+              logger.error("Exception while handling command tab completion for player {} executing {}",
+                      player, command, ex);
+              return null;
+            });
+    return true; // Sorry, handler; we're just gonna have to lie to you here.
+  }
+
+  private boolean handleRegularTabComplete(TabCompleteRequestPacket packet) {
+    if (player.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_13)) {
+      // Outstanding tab completes are recorded for use with 1.12 clients and below to provide
+      // additional tab completion support.
+      outstandingTabComplete = packet;
+    }
+    return false;
+  }
+
+  /**
+   * Handles additional tab complete.
+   *
+   * @param response the tab complete response from the backend
+   */
+  public void handleTabCompleteResponse(TabCompleteResponsePacket response) {
+    server.getEventManager().fire(new PlayerTabCompleteEvent(player,
+            outstandingTabComplete.getCommand())).thenAcceptAsync(e -> {
+      if (!e.getResult().isAllowed()) {
+        return;
+      }
+      outstandingTabComplete.setCommand(e.getPartialMessage());
+      if (outstandingTabComplete != null && !outstandingTabComplete.isAssumeCommand()) {
+        if (outstandingTabComplete.getCommand().startsWith("/")) {
+          this.finishCommandTabComplete(outstandingTabComplete, response);
+        } else {
+          this.finishRegularTabComplete(outstandingTabComplete, response);
+        }
+        outstandingTabComplete = null;
+      } else {
+        // Nothing to do
+        player.getConnection().write(response);
+      }
+    }, player.getConnection().eventLoop()).exceptionally((ex) -> {
+      logger.error(
+              "Exception while requesting tab completion,"
+                      + " with request {} and response {}",
+              outstandingTabComplete, response, ex);
+      return null;
+    });
+  }
+
+  private void finishCommandTabComplete(TabCompleteRequestPacket request,
+                                        TabCompleteResponsePacket response) {
+    String command = request.getCommand().substring(1);
+    server.getCommandManager().offerBrigadierSuggestions(player, command)
+            .thenAcceptAsync(offers -> {
+              boolean legacy =
+                      player.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_13);
+              try {
+                for (Suggestion suggestion : offers.getList()) {
+                  String offer = suggestion.getText();
+                  offer = legacy && !offer.startsWith("/") ? "/" + offer : offer;
+                  if (legacy && offer.startsWith(command)) {
+                    offer = offer.substring(command.length());
+                  }
+                  ComponentHolder tooltip = null;
+                  if (suggestion.getTooltip() != null
+                          && suggestion.getTooltip() instanceof VelocityBrigadierMessage) {
+                    tooltip = new ComponentHolder(player.getProtocolVersion(),
+                            ((VelocityBrigadierMessage) suggestion.getTooltip()).asComponent());
+                  }
+                  response.getOffers().add(new Offer(offer, tooltip));
+                }
+                response.getOffers().sort(null);
+                player.getConnection().write(response);
+              } catch (Exception e) {
+                logger.error("Unable to provide tab list completions for {} for command '{}'",
+                        player.getUsername(), command,
+                        e);
+              }
+            }, player.getConnection().eventLoop()).exceptionally((ex) -> {
+              logger.error(
+                      "Exception while finishing command tab completion,"
+                              + " with request {} and response {}",
+                      request, response, ex);
+              return null;
+            });
+  }
+
+  private void finishRegularTabComplete(TabCompleteRequestPacket request,
+                                        TabCompleteResponsePacket response) {
+    List<String> offers = new ArrayList<>();
+    for (Offer offer : response.getOffers()) {
+      offers.add(offer.getText());
+    }
+    server.getEventManager().fire(new TabCompletionResponseEvent(player, request.getCommand(), offers))
+            .thenAcceptAsync(e -> {
+              if (!e.getResult().isAllowed()) {
+                return;
+              }
+              response.getOffers().clear();
+              for (String s : e.getSuggestions()) {
+                response.getOffers().add(new Offer(s));
+              }
+              player.getConnection().write(response);
+            }, player.getConnection().eventLoop()).exceptionally((ex) -> {
+              logger.error(
+                      "Exception while finishing regular tab completion,"
+                              + " with request {} and response{}",
+                      request, response, ex);
+              return null;
+            });
+  }
+
+  /**
+   * Immediately send any queued messages to the server.
+   */
+  public void flushQueuedMessages() {
+    VelocityServerConnection serverConnection = player.getConnectedServer();
+    if (serverConnection != null) {
+      MinecraftConnection connection = serverConnection.getConnection();
+      if (connection != null) {
+        PluginMessagePacket pm;
+        while ((pm = loginPluginMessages.poll()) != null) {
+          connection.write(pm);
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Decompose TabCompleteEvent into PlayerTabCompleteEvent and TabCompletionResponseEvent. The original TabCompleteEvent has been deprecated.

Now we can trigger PlayerTabCompleteEvent when the player issues a Tab complete action and modify the "partialMessage" sent by the player to the remote server. When the remote server returns the content of Tab complete, a TabCompletionResponseEvent is triggered and the contents of the returned "suggestions" list can be modified.

If TabCompleteEvent and TabCompletionResponseEvent are listening at the same time and both the suggestions of them have been modified, the modified suggestions provided by TabCompletionResponseEvent will be used.