### PR TITLE
Stabilize and expose suggestions API

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
@@ -7,8 +7,10 @@
 
 package com.velocitypowered.api.command;
 
+import com.mojang.brigadier.suggestion.Suggestions;
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -111,6 +113,25 @@ public interface CommandManager {
    *         Can be completed exceptionally if an exception is thrown during execution.
    */
   CompletableFuture<Boolean> executeImmediatelyAsync(CommandSource source, String cmdLine);
+
+  /**
+   * Returns suggestions to fill in the given command.
+   *
+   * @param source  the source to execute the command for
+   * @param cmdLine the partially completed command
+   * @return a {@link CompletableFuture} eventually completed with a {@link List}, possibly empty
+   */
+  CompletableFuture<List<String>> offerSuggestions(CommandSource source, String cmdLine);
+
+  /**
+   * Returns suggestions to fill in the given command.
+   *
+   * @param source  the source to execute the command for
+   * @param cmdLine the partially completed command
+   * @return a {@link CompletableFuture} eventually completed with {@link Suggestions}, possibly
+   *         empty
+   */
+  CompletableFuture<Suggestions> offerBrigadierSuggestions(CommandSource source, String cmdLine);
 
   /**
    * Returns an immutable collection of the case-insensitive aliases registered

--- a/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandManager.java
@@ -115,7 +115,8 @@ public interface CommandManager {
   CompletableFuture<Boolean> executeImmediatelyAsync(CommandSource source, String cmdLine);
 
   /**
-   * Returns suggestions to fill in the given command.
+   * Asynchronously collects suggestions to fill in the given command {@code cmdLine}.
+   * Returns only the raw completion suggestions without tooltips.
    *
    * @param source  the source to execute the command for
    * @param cmdLine the partially completed command
@@ -124,7 +125,8 @@ public interface CommandManager {
   CompletableFuture<List<String>> offerSuggestions(CommandSource source, String cmdLine);
 
   /**
-   * Returns suggestions to fill in the given command.
+   * Asynchronously collects suggestions to fill in the given command {@code cmdLine}.
+   * Returns the brigadier {@link Suggestions} with tooltips for each result.
    *
    * @param source  the source to execute the command for
    * @param cmdLine the partially completed command

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -279,27 +279,14 @@ public class VelocityCommandManager implements CommandManager {
         () -> executeImmediately0(source, cmdLine), eventManager.getAsyncExecutor());
   }
 
-  /**
-   * Returns suggestions to fill in the given command.
-   *
-   * @param source  the source to execute the command for
-   * @param cmdLine the partially completed command
-   * @return a {@link CompletableFuture} eventually completed with a {@link List}, possibly empty
-   */
+  @Override
   public CompletableFuture<List<String>> offerSuggestions(final CommandSource source,
       final String cmdLine) {
     return offerBrigadierSuggestions(source, cmdLine)
         .thenApply(suggestions -> Lists.transform(suggestions.getList(), Suggestion::getText));
   }
 
-  /**
-   * Returns suggestions to fill in the given command.
-   *
-   * @param source  the source to execute the command for
-   * @param cmdLine the partially completed command
-   * @return a {@link CompletableFuture} eventually completed with {@link Suggestions}, possibly
-   *         empty
-   */
+  @Override
   public CompletableFuture<Suggestions> offerBrigadierSuggestions(
       final CommandSource source, final String cmdLine) {
     Preconditions.checkNotNull(source, "source");


### PR DESCRIPTION
This PR stabilizes and exposes the internal suggestions API for third-party developers. My usecase for this API is that I'm building a dashboard for running commands on both bukkit and velocity servers with tab completion. 
Right now there is no API to get any command completions for Velocity commands using the API.
Bukkit already has a public API for tab completions: https://jd.papermc.io/paper/1.21.5/org/bukkit/command/CommandMap.html#tabComplete(org.bukkit.command.CommandSender,java.lang.String)
So I think it would be good if velocity also exposed the internal suggestions API.