### PR TITLE
Increase readComponent string size limit to 262,143 for 1.13-1.20.2

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ComponentHolder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ComponentHolder.java
@@ -54,6 +54,7 @@ import java.util.Map;
 
 public class ComponentHolder {
   private static final Logger logger = LogManager.getLogger(ComponentHolder.class);
+  public static final int DEFAULT_MAX_STRING_SIZE = 262143;
 
   private final ProtocolVersion version;
   private @MonotonicNonNull Component component;
@@ -282,6 +283,8 @@ public class ComponentHolder {
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_20_3)) {
       return new ComponentHolder(version,
           ProtocolUtils.readBinaryTag(buf, version, BinaryTagIO.reader()));
+    } else if (version.noLessThan(ProtocolVersion.MINECRAFT_1_13)) {
+      return new ComponentHolder(version, ProtocolUtils.readString(buf, DEFAULT_MAX_STRING_SIZE));
     } else {
       return new ComponentHolder(version, ProtocolUtils.readString(buf));
     }


### PR DESCRIPTION
The `readComponent` method can read up to 262,143 characters from versions 1.13 to 1.20.2.

fix #1356