### PR TITLE
fix: apply message in `PlayerChatEvent` when handling `SessionPlayerChatPacket`

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionChatHandler.java
@@ -71,7 +71,8 @@ public class SessionChatHandler implements ChatHandler<SessionPlayerChatPacket> 
                   invalidChange(logger, player);
                   return null;
                 }
-                return this.player.getChatBuilderFactory().builder().message(packet.message)
+                return this.player.getChatBuilderFactory().builder()
+                    .message(chatResult.getMessage().orElse(packet.getMessage()))
                     .setTimestamp(packet.timestamp)
                     .setLastSeenMessages(newLastSeenMessages)
                     .toServer();


### PR DESCRIPTION
Fix 1.19.3+ unsigned chat not being changed by `PlayerChatEvent`.