### PR TITLE
feat: Add primitive support for sound api

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -383,8 +383,14 @@ public interface Player extends
   /**
    * {@inheritDoc}
    *
-   * <b>This method is not currently implemented in Velocity
-   * and will not perform any actions.</b>
+   * <p>Note: This method is currently only implemented for players from version 1.19.3 and above.
+   * <br>A {@link ServerConnection} is required for this to function, so a {@link #getCurrentServer()}.isPresent() check should be made beforehand.
+   *
+   * @param sound the sound to play
+   * @throws IllegalArgumentException if the player is from a version lower than 1.19.3
+   * @throws IllegalStateException if no server is connected
+   * @since 3.3.0
+   * @sinceMinecraft 1.19.3
    */
   @Override
   default void playSound(@NotNull Sound sound) {
@@ -413,8 +419,12 @@ public interface Player extends
   /**
    * {@inheritDoc}
    *
-   * <b>This method is not currently implemented in Velocity
-   * and will not perform any actions.</b>
+   * <p>Note: This method is currently only implemented for players from version 1.19.3 and above.
+   *
+   * @param stop the sound and/or a sound source, to stop
+   * @throws IllegalArgumentException if the player is from a version lower than 1.19.3
+   * @since 3.3.0
+   * @sinceMinecraft 1.19.3
    */
   @Override
   default void stopSound(@NotNull SoundStop stop) {

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -48,7 +48,7 @@ public interface Player extends
     /* Fundamental Velocity interfaces */
     CommandSource, InboundConnection, ChannelMessageSource, ChannelMessageSink,
     /* Adventure-specific interfaces */
-    Identified, HoverEventSource<HoverEvent.ShowEntity>, Keyed, KeyIdentifiable {
+    Identified, HoverEventSource<HoverEvent.ShowEntity>, Keyed, KeyIdentifiable, Sound.Emitter {
 
   /**
    * Returns the player's current username.
@@ -403,11 +403,13 @@ public interface Player extends
   /**
    * {@inheritDoc}
    *
+   * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC/issues/MC-146721">MC-146721</a>, stereo sounds are always played globally.
+   *
    * <p>Note: This method is currently only implemented for players from version 1.19.3 and above
-   * and requires a present {@link #getCurrentServer}. Additionally, it only supports {@link Sound.Emitter#self()} for now.
+   * and requires a present {@link #getCurrentServer} for the emitting player as well as this player.
    *
    * @param sound the sound to play
-   * @param emitter the emitter of the sound
+   * @param emitter the emitter of the sound; may be another player of this player's server
    * @since 3.4.0
    * @sinceMinecraft 1.19.3
    */

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -383,27 +383,25 @@ public interface Player extends
   /**
    * {@inheritDoc}
    *
-   * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC/issues/MC-146721">MC-146721</a>, stereo sounds are always played globally in 1.14+.
    *
-   * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC/issues/MC-138832">MC-138832</a>, the volume and pitch are ignored when using this method in 1.14 to 1.16.5.
-   *
-   * <p>Note: This method is currently only implemented for players on 1.19.3+
-   * and requires a present {@link #getCurrentServer} for the emitting player as well as this player.
-   *
-   * @param sound the sound to play
-   * @since 3.4.0
-   * @sinceMinecraft 1.19.3
+   * @apiNote <b>This method is not currently implemented in Velocity
+   *     and will not perform any actions.</b>
+   * @see #playSound(Sound, Sound.Emitter)
+   * @see <a href="https://docs.papermc.io/velocity/dev/pitfalls/#audience-operations-are-not-fully-supported">
+   *   Unsupported Adventure Operations</a>
    */
   @Override
   default void playSound(@NotNull Sound sound) {
-    this.playSound(sound, Sound.Emitter.self());
   }
 
   /**
    * {@inheritDoc}
    *
-   * <b>This method is not currently implemented in Velocity
-   * and will not perform any actions.</b>
+   * @apiNote <b>This method is not currently implemented in Velocity
+   *     and will not perform any actions.</b>
+   * @see #playSound(Sound, Sound.Emitter)
+   * @see <a href="https://docs.papermc.io/velocity/dev/pitfalls/#audience-operations-are-not-fully-supported">
+   *   Unsupported Adventure Operations</a>
    */
   @Override
   default void playSound(@NotNull Sound sound, double x, double y, double z) {
@@ -416,13 +414,12 @@ public interface Player extends
    *
    * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC/issues/MC-138832">MC-138832</a>, the volume and pitch are ignored when using this method in 1.14 to 1.16.5.
    *
-   * <p>Note: This method is currently only implemented for players on 1.19.3+
-   * and requires a present {@link #getCurrentServer} for the emitting player as well as this player.
-   *
    * @param sound the sound to play
    * @param emitter the emitter of the sound; may be another player of this player's server
    * @since 3.4.0
    * @sinceMinecraft 1.19.3
+   * @apiNote This method is currently only implemented for players on 1.19.3+
+   *     and requires a present {@link #getCurrentServer} for the emitting player as well as this player.
    */
   @Override
   default void playSound(@NotNull Sound sound, @NotNull Sound.Emitter emitter) {
@@ -431,11 +428,10 @@ public interface Player extends
   /**
    * {@inheritDoc}
    *
-   * <p>Note: This method is currently only implemented for players on 1.19.3+.
-   *
    * @param stop the sound and/or a sound source, to stop
    * @since 3.4.0
    * @sinceMinecraft 1.19.3
+   * @apiNote This method is currently only implemented for players on 1.19.3+.
    */
   @Override
   default void stopSound(@NotNull SoundStop stop) {
@@ -446,6 +442,9 @@ public interface Player extends
    *
    * <b>This method is not currently implemented in Velocity
    * and will not perform any actions.</b>
+   *
+   * @see <a href="https://docs.papermc.io/velocity/dev/pitfalls/#audience-operations-are-not-fully-supported">
+   *   Unsupported Adventure Operations</a>
    */
   @Override
   default void openBook(@NotNull Book book) {

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -407,7 +407,7 @@ public interface Player extends
    *
    * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC/issues/MC-138832">MC-138832</a>, the volume and pitch are ignored when using this method in 1.14 to 1.16.5.
    *
-   * <p>Note: This method is currently only implemented for players from version 1.19.3 and above
+   * <p>Note: This method is currently only implemented for players on 1.19.3+
    * and requires a present {@link #getCurrentServer} for the emitting player as well as this player.
    *
    * @param sound the sound to play
@@ -422,7 +422,7 @@ public interface Player extends
   /**
    * {@inheritDoc}
    *
-   * <p>Note: This method is currently only implemented for players from version 1.19.3 and above.
+   * <p>Note: This method is currently only implemented for players on 1.19.3+.
    *
    * @param stop the sound and/or a sound source, to stop
    * @since 3.4.0

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -29,6 +29,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.UnaryOperator;
+import net.kyori.adventure.dialog.DialogLike;
 import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.key.Key;
@@ -448,6 +449,32 @@ public interface Player extends
    */
   @Override
   default void openBook(@NotNull Book book) {
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <b>This method is not currently implemented in Velocity
+   * and will not perform any actions.</b>
+   *
+   * @see <a href="https://docs.papermc.io/velocity/dev/pitfalls/#audience-operations-are-not-fully-supported">
+   *   Unsupported Adventure Operations</a>
+   */
+  @Override
+  default void showDialog(@NotNull DialogLike dialog) {
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <b>This method is not currently implemented in Velocity
+   * and will not perform any actions.</b>
+   *
+   * @see <a href="https://docs.papermc.io/velocity/dev/pitfalls/#audience-operations-are-not-fully-supported">
+   *   Unsupported Adventure Operations</a>
+   */
+  @Override
+  default void closeDialog() {
   }
 
   /**

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -403,7 +403,9 @@ public interface Player extends
   /**
    * {@inheritDoc}
    *
-   * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC/issues/MC-146721">MC-146721</a>, stereo sounds are always played globally.
+   * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC/issues/MC-146721">MC-146721</a>, stereo sounds are always played globally in 1.14+.
+   *
+   * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC/issues/MC-138832">MC-138832</a>, the volume and pitch are ignored when using this method in 1.14 to 1.16.5.
    *
    * <p>Note: This method is currently only implemented for players from version 1.19.3 and above
    * and requires a present {@link #getCurrentServer} for the emitting player as well as this player.

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -383,11 +383,20 @@ public interface Player extends
   /**
    * {@inheritDoc}
    *
-   * <b>This method is not currently implemented in Velocity
-   * and will not perform any actions.</b>
+   * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC/issues/MC-146721">MC-146721</a>, stereo sounds are always played globally in 1.14+.
+   *
+   * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC/issues/MC-138832">MC-138832</a>, the volume and pitch are ignored when using this method in 1.14 to 1.16.5.
+   *
+   * <p>Note: This method is currently only implemented for players on 1.19.3+
+   * and requires a present {@link #getCurrentServer} for the emitting player as well as this player.
+   *
+   * @param sound the sound to play
+   * @since 3.4.0
+   * @sinceMinecraft 1.19.3
    */
   @Override
   default void playSound(@NotNull Sound sound) {
+    this.playSound(sound, Sound.Emitter.self());
   }
 
   /**

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -383,14 +383,8 @@ public interface Player extends
   /**
    * {@inheritDoc}
    *
-   * <p>Note: This method is currently only implemented for players from version 1.19.3 and above.
-   * <br>A {@link ServerConnection} is required for this to function, so a {@link #getCurrentServer()}.isPresent() check should be made beforehand.
-   *
-   * @param sound the sound to play
-   * @throws IllegalArgumentException if the player is from a version lower than 1.19.3
-   * @throws IllegalStateException if no server is connected
-   * @since 3.3.0
-   * @sinceMinecraft 1.19.3
+   * <b>This method is not currently implemented in Velocity
+   * and will not perform any actions.</b>
    */
   @Override
   default void playSound(@NotNull Sound sound) {
@@ -409,11 +403,16 @@ public interface Player extends
   /**
    * {@inheritDoc}
    *
-   * <b>This method is not currently implemented in Velocity
-   * and will not perform any actions.</b>
+   * <p>Note: This method is currently only implemented for players from version 1.19.3 and above
+   * and requires a present {@link #getCurrentServer}. Additionally, it only supports {@link Sound.Emitter#self()} for now.
+   *
+   * @param sound the sound to play
+   * @param emitter the emitter of the sound
+   * @since 3.4.0
+   * @sinceMinecraft 1.19.3
    */
   @Override
-  default void playSound(@NotNull Sound sound, Sound.Emitter emitter) {
+  default void playSound(@NotNull Sound sound, @NotNull Sound.Emitter emitter) {
   }
 
   /**
@@ -422,8 +421,7 @@ public interface Player extends
    * <p>Note: This method is currently only implemented for players from version 1.19.3 and above.
    *
    * @param stop the sound and/or a sound source, to stop
-   * @throws IllegalArgumentException if the player is from a version lower than 1.19.3
-   * @since 3.3.0
+   * @since 3.4.0
    * @sinceMinecraft 1.19.3
    */
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftSessionHandler.java
@@ -23,6 +23,8 @@ import com.velocitypowered.proxy.protocol.packet.BossBarPacket;
 import com.velocitypowered.proxy.protocol.packet.BundleDelimiterPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientSettingsPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientboundCookieRequestPacket;
+import com.velocitypowered.proxy.protocol.packet.ClientboundSoundEntityPacket;
+import com.velocitypowered.proxy.protocol.packet.ClientboundStopSoundPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientboundStoreCookiePacket;
 import com.velocitypowered.proxy.protocol.packet.DialogClearPacket;
 import com.velocitypowered.proxy.protocol.packet.DialogShowPacket;
@@ -390,4 +392,11 @@ public interface MinecraftSessionHandler {
     return false;
   }
 
+  default boolean handle(ClientboundSoundEntityPacket packet) {
+    return false;
+  }
+
+  default boolean handle(ClientboundStopSoundPacket packet) {
+    return false;
+  }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -53,6 +53,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.NotNull;
 
@@ -70,6 +71,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
   private boolean gracefulDisconnect = false;
   private BackendConnectionPhase connectionPhase = BackendConnectionPhases.UNKNOWN;
   private final Map<Long, Long> pendingPings = new HashMap<>();
+  private @MonotonicNonNull Integer entityId;
 
   /**
    * Initializes a new server connection.
@@ -322,6 +324,14 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
 
   public Map<Long, Long> getPendingPings() {
     return pendingPings;
+  }
+
+  public Integer getEntityId() {
+    return entityId;
+  }
+
+  public void setEntityId(Integer entityId) {
+    this.entityId = entityId;
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -575,6 +575,8 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
       }
     }
 
+    destination.setEntityId(joinGame.getEntityId()); // used for sound api
+
     // Remove previous boss bars. These don't get cleared when sending JoinGame, thus the need to
     // track them.
     for (UUID serverBossBar : serverBossBars) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1047,26 +1047,25 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   }
 
   @Override
-  public void playSound(@NotNull Sound sound) {
+  public void playSound(@NotNull Sound sound, @NotNull Sound.Emitter emitter) {
     Preconditions.checkNotNull(sound, "sound");
-    Preconditions.checkArgument(
-        getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_19_3),
-        "Player version must be 1.19.3 to be able to interact with sounds");
-    if (connection.getState() != StateRegistry.PLAY) {
-      throw new IllegalStateException("Can only interact with sounds in PLAY protocol");
+    Preconditions.checkNotNull(emitter, "emitter");
+    Preconditions.checkArgument(emitter.equals(Sound.Emitter.self()), "non-self emitter not supported");
+    if (getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_19_3)
+        || connection.getState() != StateRegistry.PLAY
+        || getConnectedServer() == null) {
+      return;
     }
 
-    connection.write(new ClientboundSoundEntityPacket(sound, null, ensureAndGetCurrentServer().getEntityId()));
+    connection.write(new ClientboundSoundEntityPacket(sound, null, getConnectedServer().getEntityId()));
   }
 
   @Override
   public void stopSound(@NotNull SoundStop stop) {
     Preconditions.checkNotNull(stop, "stop");
-    Preconditions.checkArgument(
-        getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_19_3),
-        "Player version must be 1.19.3 to be able to interact with sounds");
-    if (connection.getState() != StateRegistry.PLAY) {
-      throw new IllegalStateException("Can only interact with sounds in PLAY protocol");
+    if (getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_19_3)
+        || connection.getState() != StateRegistry.PLAY) {
+      return;
     }
 
     connection.write(new ClientboundStopSoundPacket(stop));

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -73,6 +73,8 @@ import com.velocitypowered.proxy.protocol.netty.MinecraftEncoder;
 import com.velocitypowered.proxy.protocol.packet.BundleDelimiterPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientSettingsPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientboundCookieRequestPacket;
+import com.velocitypowered.proxy.protocol.packet.ClientboundSoundEntityPacket;
+import com.velocitypowered.proxy.protocol.packet.ClientboundStopSoundPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientboundStoreCookiePacket;
 import com.velocitypowered.proxy.protocol.packet.DisconnectPacket;
 import com.velocitypowered.proxy.protocol.packet.HeaderAndFooterPacket;
@@ -127,6 +129,8 @@ import net.kyori.adventure.pointer.PointersSupplier;
 import net.kyori.adventure.resource.ResourcePackInfoLike;
 import net.kyori.adventure.resource.ResourcePackRequest;
 import net.kyori.adventure.resource.ResourcePackRequestLike;
+import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.sound.SoundStop;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
@@ -1040,6 +1044,32 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
 
   void setClientBrand(final @Nullable String clientBrand) {
     this.clientBrand = clientBrand;
+  }
+
+  @Override
+  public void playSound(@NotNull Sound sound) {
+    Preconditions.checkNotNull(sound, "sound");
+    Preconditions.checkArgument(
+        getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_19_3),
+        "Player version must be 1.19.3 to be able to interact with sounds");
+    if (connection.getState() != StateRegistry.PLAY) {
+      throw new IllegalStateException("Can only interact with sounds in PLAY protocol");
+    }
+
+    connection.write(new ClientboundSoundEntityPacket(sound, null, ensureAndGetCurrentServer().getEntityId()));
+  }
+
+  @Override
+  public void stopSound(@NotNull SoundStop stop) {
+    Preconditions.checkNotNull(stop, "stop");
+    Preconditions.checkArgument(
+        getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_19_3),
+        "Player version must be 1.19.3 to be able to interact with sounds");
+    if (connection.getState() != StateRegistry.PLAY) {
+      throw new IllegalStateException("Can only interact with sounds in PLAY protocol");
+    }
+
+    connection.write(new ClientboundStopSoundPacket(stop));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1050,7 +1050,6 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   public void playSound(@NotNull Sound sound, @NotNull Sound.Emitter emitter) {
     Preconditions.checkNotNull(sound, "sound");
     Preconditions.checkNotNull(emitter, "emitter");
-    Preconditions.checkArgument(emitter.equals(Sound.Emitter.self()), "non-self emitter not supported");
     if (getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_19_3)
         || connection.getState() != StateRegistry.PLAY
         || getConnectedServer() == null) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1053,7 +1053,9 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     VelocityServerConnection soundTargetServerConn = getConnectedServer();
     if (getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_19_3)
         || connection.getState() != StateRegistry.PLAY
-        || soundTargetServerConn == null) {
+        || soundTargetServerConn == null
+        || (sound.source() == Sound.Source.UI
+            && getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_21_5))) {
       return;
     }
 
@@ -1079,7 +1081,9 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   public void stopSound(@NotNull SoundStop stop) {
     Preconditions.checkNotNull(stop, "stop");
     if (getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_19_3)
-        || connection.getState() != StateRegistry.PLAY) {
+        || connection.getState() != StateRegistry.PLAY
+        || (stop.source() == Sound.Source.UI
+            && getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_21_5))) {
       return;
     }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1050,13 +1050,29 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   public void playSound(@NotNull Sound sound, @NotNull Sound.Emitter emitter) {
     Preconditions.checkNotNull(sound, "sound");
     Preconditions.checkNotNull(emitter, "emitter");
+    VelocityServerConnection soundTargetServerConn = getConnectedServer();
     if (getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_19_3)
         || connection.getState() != StateRegistry.PLAY
-        || getConnectedServer() == null) {
+        || soundTargetServerConn == null) {
       return;
     }
 
-    connection.write(new ClientboundSoundEntityPacket(sound, null, getConnectedServer().getEntityId()));
+    VelocityServerConnection soundEmitterServerConn;
+    if (emitter == Sound.Emitter.self()) {
+      soundEmitterServerConn = soundTargetServerConn;
+    } else if (emitter instanceof ConnectedPlayer player) {
+      if ((soundEmitterServerConn = player.getConnectedServer()) == null) {
+        return;
+      }
+
+      if (!soundEmitterServerConn.getServer().equals(soundTargetServerConn.getServer())) {
+        return;
+      }
+    } else {
+      return;
+    }
+
+    connection.write(new ClientboundSoundEntityPacket(sound, null, soundEmitterServerConn.getEntityId()));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
@@ -44,6 +44,7 @@ import net.kyori.adventure.nbt.BinaryTagIO;
 import net.kyori.adventure.nbt.BinaryTagType;
 import net.kyori.adventure.nbt.BinaryTagTypes;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.json.JSONOptions;
 import net.kyori.adventure.text.serializer.json.legacyimpl.NBTLegacyHoverEventSerializer;
@@ -779,6 +780,40 @@ public enum ProtocolUtils {
     IdentifiedKey.Revision revision = version.noGreaterOrLessThan(ProtocolVersion.MINECRAFT_1_19)
         ? IdentifiedKey.Revision.GENERIC_V1 : IdentifiedKey.Revision.LINKED_V2;
     return new IdentifiedKeyImpl(revision, key, expiry, signature);
+  }
+
+  /**
+   * Reads a {@link Sound.Source} from the buffer.
+   *
+   * @param buf the buffer
+   * @param version the protocol version
+   * @return the sound source
+   */
+  public static Sound.Source readSoundSource(ByteBuf buf, ProtocolVersion version) {
+    int ordinal = readVarInt(buf);
+
+    if (version.noGreaterThan(ProtocolVersion.MINECRAFT_1_21_5)
+        && ordinal == Sound.Source.UI.ordinal()) {
+      throw new UnsupportedOperationException("UI sound-source is only supported in 1.21.5+");
+    }
+
+    return Sound.Source.values()[ordinal];
+  }
+
+  /**
+   * Writes a {@link Sound.Source} to the buffer.
+   *
+   * @param buf the buffer
+   * @param version the protocol version
+   * @param source the sound source to write
+   */
+  public static void writeSoundSource(ByteBuf buf, ProtocolVersion version, Sound.Source source) {
+    if (version.noGreaterThan(ProtocolVersion.MINECRAFT_1_21_5)
+        && source == Sound.Source.UI) {
+      throw new UnsupportedOperationException("UI sound-source is only supported in 1.21.5+");
+    }
+
+    writeVarInt(buf, source.ordinal());
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
@@ -318,6 +318,16 @@ public enum ProtocolUtils {
   }
 
   /**
+   * Writes the key to the buffer, dropping the "minecraft:" namespace when present.
+   *
+   * @param buf the buffer to write to
+   * @param key the key to write
+   */
+  public static void writeMinimalKey(ByteBuf buf, Key key) {
+    writeString(buf, key.asMinimalString());
+  }
+
+  /**
    * Reads a standard Mojang Text namespaced:key array from the buffer.
    *
    * @param buf the buffer to read from

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
@@ -792,7 +792,7 @@ public enum ProtocolUtils {
   public static Sound.Source readSoundSource(ByteBuf buf, ProtocolVersion version) {
     int ordinal = readVarInt(buf);
 
-    if (version.noGreaterThan(ProtocolVersion.MINECRAFT_1_21_5)
+    if (version.lessThan(ProtocolVersion.MINECRAFT_1_21_5)
         && ordinal == Sound.Source.UI.ordinal()) {
       throw new UnsupportedOperationException("UI sound-source is only supported in 1.21.5+");
     }
@@ -808,7 +808,7 @@ public enum ProtocolUtils {
    * @param source the sound source to write
    */
   public static void writeSoundSource(ByteBuf buf, ProtocolVersion version, Sound.Source source) {
-    if (version.noGreaterThan(ProtocolVersion.MINECRAFT_1_21_5)
+    if (version.lessThan(ProtocolVersion.MINECRAFT_1_21_5)
         && source == Sound.Source.UI) {
       throw new UnsupportedOperationException("UI sound-source is only supported in 1.21.5+");
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
@@ -458,7 +458,8 @@ public enum StateRegistry {
           map(0x65, MINECRAFT_1_20_3, true),
           map(0x67, MINECRAFT_1_20_5, true),
           map(0x6E, MINECRAFT_1_21_2, true),
-          map(0x6D, MINECRAFT_1_21_5, true));
+          map(0x6D, MINECRAFT_1_21_5, true),
+          map(0x72, MINECRAFT_1_21_9, true));
       clientbound.register(
           ClientboundStopSoundPacket.class, ClientboundStopSoundPacket::new,
           map(0x5F, MINECRAFT_1_19_3, true),
@@ -467,7 +468,8 @@ public enum StateRegistry {
           map(0x68, MINECRAFT_1_20_3, true),
           map(0x6A, MINECRAFT_1_20_5, true),
           map(0x71, MINECRAFT_1_21_2, true),
-          map(0x70, MINECRAFT_1_21_5, true));
+          map(0x70, MINECRAFT_1_21_5, true),
+          map(0x75, MINECRAFT_1_21_9, true));
       clientbound.register(
           PluginMessagePacket.class,
           PluginMessagePacket::new,

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
@@ -59,6 +59,8 @@ import com.velocitypowered.proxy.protocol.packet.BossBarPacket;
 import com.velocitypowered.proxy.protocol.packet.BundleDelimiterPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientSettingsPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientboundCookieRequestPacket;
+import com.velocitypowered.proxy.protocol.packet.ClientboundSoundEntityPacket;
+import com.velocitypowered.proxy.protocol.packet.ClientboundStopSoundPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientboundStoreCookiePacket;
 import com.velocitypowered.proxy.protocol.packet.DialogClearPacket;
 import com.velocitypowered.proxy.protocol.packet.DialogShowPacket;
@@ -448,6 +450,22 @@ public enum StateRegistry {
           ClientboundCookieRequestPacket.class, ClientboundCookieRequestPacket::new,
           map(0x16, MINECRAFT_1_20_5, false),
           map(0x15, MINECRAFT_1_21_5, false));
+      clientbound.register(
+          ClientboundSoundEntityPacket.class, ClientboundSoundEntityPacket::new,
+          map(0x5D, MINECRAFT_1_19_3, true),
+          map(0x61, MINECRAFT_1_19_4, true),
+          map(0x63, MINECRAFT_1_20_2, true),
+          map(0x65, MINECRAFT_1_20_3, true),
+          map(0x67, MINECRAFT_1_20_5, true),
+          map(0x6E, MINECRAFT_1_21_2, true));
+      clientbound.register(
+          ClientboundStopSoundPacket.class, ClientboundStopSoundPacket::new,
+          map(0x5F, MINECRAFT_1_19_3, true),
+          map(0x63, MINECRAFT_1_19_4, true),
+          map(0x66, MINECRAFT_1_20_2, true),
+          map(0x68, MINECRAFT_1_20_3, true),
+          map(0x6A, MINECRAFT_1_20_5, true),
+          map(0x71, MINECRAFT_1_21_2, true));
       clientbound.register(
           PluginMessagePacket.class,
           PluginMessagePacket::new,

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
@@ -457,7 +457,8 @@ public enum StateRegistry {
           map(0x63, MINECRAFT_1_20_2, true),
           map(0x65, MINECRAFT_1_20_3, true),
           map(0x67, MINECRAFT_1_20_5, true),
-          map(0x6E, MINECRAFT_1_21_2, true));
+          map(0x6E, MINECRAFT_1_21_2, true),
+          map(0x6D, MINECRAFT_1_21_5, true));
       clientbound.register(
           ClientboundStopSoundPacket.class, ClientboundStopSoundPacket::new,
           map(0x5F, MINECRAFT_1_19_3, true),
@@ -465,7 +466,8 @@ public enum StateRegistry {
           map(0x66, MINECRAFT_1_20_2, true),
           map(0x68, MINECRAFT_1_20_3, true),
           map(0x6A, MINECRAFT_1_20_5, true),
-          map(0x71, MINECRAFT_1_21_2, true));
+          map(0x71, MINECRAFT_1_21_2, true),
+          map(0x70, MINECRAFT_1_21_5, true));
       clientbound.register(
           PluginMessagePacket.class,
           PluginMessagePacket::new,

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.protocol.packet;
+
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import io.netty.buffer.ByteBuf;
+import net.kyori.adventure.sound.Sound;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Random;
+
+public class ClientboundSoundEntityPacket implements MinecraftPacket {
+
+  private static final Random SEEDS_RANDOM = new Random();
+
+  private Sound sound;
+  private @Nullable Float fixedRange;
+  private int entityId;
+
+  public ClientboundSoundEntityPacket() {}
+
+  public ClientboundSoundEntityPacket(Sound sound, @Nullable Float fixedRange, int entityId) {
+    this.sound = sound;
+    this.fixedRange = fixedRange;
+    this.entityId = entityId;
+  }
+
+  @Override
+  public void decode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion protocolVersion) {
+    throw new UnsupportedOperationException("Decode is not implemented");
+  }
+
+  @Override
+  public void encode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion protocolVersion) {
+    ProtocolUtils.writeVarInt(buf, 0); // version-dependent hardcoded sound id
+
+    ProtocolUtils.writeString(buf, sound.name().asMinimalString()); // not using writeKey, as the client already defaults to the vanilla namespace
+
+    buf.writeBoolean(fixedRange != null);
+    if (fixedRange != null)
+      buf.writeFloat(fixedRange);
+
+    ProtocolUtils.writeVarInt(buf, sound.source().ordinal());
+
+    ProtocolUtils.writeVarInt(buf, entityId);
+
+    buf.writeFloat(sound.volume());
+
+    buf.writeFloat(sound.pitch());
+
+    buf.writeLong(sound.seed().orElse(SEEDS_RANDOM.nextLong()));
+  }
+
+  @Override
+  public boolean handle(MinecraftSessionHandler handler) {
+    return handler.handle(this);
+  }
+
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
@@ -58,7 +58,7 @@ public class ClientboundSoundEntityPacket implements MinecraftPacket {
     if (fixedRange != null)
       buf.writeFloat(fixedRange);
 
-    ProtocolUtils.writeVarInt(buf, sound.source().ordinal());
+    ProtocolUtils.writeSoundSource(buf, protocolVersion, sound.source());
 
     ProtocolUtils.writeVarInt(buf, emitterEntityId);
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Velocity Contributors
+ * Copyright (C) 2025 Velocity Contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -50,9 +50,9 @@ public class ClientboundSoundEntityPacket implements MinecraftPacket {
 
   @Override
   public void encode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion protocolVersion) {
-    ProtocolUtils.writeVarInt(buf, 0); // version-dependent hardcoded sound id
+    ProtocolUtils.writeVarInt(buf, 0); // version-dependent, hardcoded sound ID
 
-    ProtocolUtils.writeString(buf, sound.name().asMinimalString()); // not using writeKey, as the client already defaults to the vanilla namespace
+    ProtocolUtils.writeString(buf, sound.name().asMinimalString()); // Not using writeKey, as the client already defaults to the vanilla namespace
 
     buf.writeBoolean(fixedRange != null);
     if (fixedRange != null)

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
@@ -33,14 +33,14 @@ public class ClientboundSoundEntityPacket implements MinecraftPacket {
 
   private Sound sound;
   private @Nullable Float fixedRange;
-  private int entityId;
+  private int emitterEntityId;
 
   public ClientboundSoundEntityPacket() {}
 
-  public ClientboundSoundEntityPacket(Sound sound, @Nullable Float fixedRange, int entityId) {
+  public ClientboundSoundEntityPacket(Sound sound, @Nullable Float fixedRange, int emitterEntityId) {
     this.sound = sound;
     this.fixedRange = fixedRange;
-    this.entityId = entityId;
+    this.emitterEntityId = emitterEntityId;
   }
 
   @Override
@@ -60,7 +60,7 @@ public class ClientboundSoundEntityPacket implements MinecraftPacket {
 
     ProtocolUtils.writeVarInt(buf, sound.source().ordinal());
 
-    ProtocolUtils.writeVarInt(buf, entityId);
+    ProtocolUtils.writeVarInt(buf, emitterEntityId);
 
     buf.writeFloat(sound.volume());
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
@@ -74,4 +74,28 @@ public class ClientboundSoundEntityPacket implements MinecraftPacket {
     return handler.handle(this);
   }
 
+  public Sound getSound() {
+    return sound;
+  }
+
+  public void setSound(Sound sound) {
+    this.sound = sound;
+  }
+
+  public @Nullable Float getFixedRange() {
+    return fixedRange;
+  }
+
+  public void setFixedRange(@Nullable Float fixedRange) {
+    this.fixedRange = fixedRange;
+  }
+
+  public int getEmitterEntityId() {
+    return emitterEntityId;
+  }
+
+  public void setEmitterEntityId(int emitterEntityId) {
+    this.emitterEntityId = emitterEntityId;
+  }
+
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundSoundEntityPacket.java
@@ -52,7 +52,7 @@ public class ClientboundSoundEntityPacket implements MinecraftPacket {
   public void encode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion protocolVersion) {
     ProtocolUtils.writeVarInt(buf, 0); // version-dependent, hardcoded sound ID
 
-    ProtocolUtils.writeString(buf, sound.name().asMinimalString()); // Not using writeKey, as the client already defaults to the vanilla namespace
+    ProtocolUtils.writeMinimalKey(buf, sound.name());
 
     buf.writeBoolean(fixedRange != null);
     if (fixedRange != null)

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundStopSoundPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundStopSoundPacket.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2024 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.protocol.packet;
+
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import io.netty.buffer.ByteBuf;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.sound.SoundStop;
+
+import javax.annotation.Nullable;
+
+public class ClientboundStopSoundPacket implements MinecraftPacket {
+
+  private @Nullable Sound.Source source;
+  private @Nullable Key soundName;
+
+  public ClientboundStopSoundPacket() {}
+
+  public ClientboundStopSoundPacket(SoundStop soundStop) {
+    this(soundStop.source(), soundStop.sound());
+  }
+
+  public ClientboundStopSoundPacket(@Nullable Sound.Source source, @Nullable Key soundName) {
+    this.source = source;
+    this.soundName = soundName;
+  }
+
+  @Override
+  public void decode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion protocolVersion) {
+    int flagsBitmask = buf.readByte();
+
+    if ((flagsBitmask & 1) != 0) {
+      source = Sound.Source.values()[ProtocolUtils.readVarInt(buf)];
+    } else {
+      source = null;
+    }
+
+    if ((flagsBitmask & 2) != 0) {
+      soundName = ProtocolUtils.readKey(buf);
+    } else {
+      soundName = null;
+    }
+  }
+
+  @Override
+  public void encode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion protocolVersion) {
+    int flagsBitmask = 0;
+    if (source != null && soundName == null) {
+      flagsBitmask |= 1;
+    } else if (soundName != null && source == null) {
+      flagsBitmask |= 2;
+    } else if (source != null /*&& sound != null*/) {
+      flagsBitmask |= 3;
+    }
+
+    buf.writeByte(flagsBitmask);
+
+    if (source != null) {
+      ProtocolUtils.writeVarInt(buf, source.ordinal());
+    }
+
+    if (soundName != null) {
+      ProtocolUtils.writeString(buf, soundName.asMinimalString()); // not using writeKey, as the client already defaults to the vanilla namespace
+    }
+  }
+
+  @Override
+  public boolean handle(MinecraftSessionHandler handler) {
+    return handler.handle(this);
+  }
+
+  @Nullable
+  public Sound.Source getSource() {
+    return source;
+  }
+
+  @Nullable
+  public Key getSoundName() {
+    return soundName;
+  }
+
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundStopSoundPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundStopSoundPacket.java
@@ -93,9 +93,17 @@ public class ClientboundStopSoundPacket implements MinecraftPacket {
     return source;
   }
 
+  public void setSource(@Nullable Sound.Source source) {
+    this.source = source;
+  }
+
   @Nullable
   public Key getSoundName() {
     return soundName;
+  }
+
+  public void setSoundName(@Nullable Key soundName) {
+    this.soundName = soundName;
   }
 
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundStopSoundPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundStopSoundPacket.java
@@ -79,7 +79,7 @@ public class ClientboundStopSoundPacket implements MinecraftPacket {
     }
 
     if (soundName != null) {
-      ProtocolUtils.writeString(buf, soundName.asMinimalString()); // Not using writeKey, as the client already defaults to the vanilla namespace
+      ProtocolUtils.writeMinimalKey(buf, soundName);
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundStopSoundPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundStopSoundPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Velocity Contributors
+ * Copyright (C) 2025 Velocity Contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -79,7 +79,7 @@ public class ClientboundStopSoundPacket implements MinecraftPacket {
     }
 
     if (soundName != null) {
-      ProtocolUtils.writeString(buf, soundName.asMinimalString()); // not using writeKey, as the client already defaults to the vanilla namespace
+      ProtocolUtils.writeString(buf, soundName.asMinimalString()); // Not using writeKey, as the client already defaults to the vanilla namespace
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundStopSoundPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientboundStopSoundPacket.java
@@ -49,7 +49,7 @@ public class ClientboundStopSoundPacket implements MinecraftPacket {
     int flagsBitmask = buf.readByte();
 
     if ((flagsBitmask & 1) != 0) {
-      source = Sound.Source.values()[ProtocolUtils.readVarInt(buf)];
+      source = ProtocolUtils.readSoundSource(buf, protocolVersion);
     } else {
       source = null;
     }
@@ -75,7 +75,7 @@ public class ClientboundStopSoundPacket implements MinecraftPacket {
     buf.writeByte(flagsBitmask);
 
     if (source != null) {
-      ProtocolUtils.writeVarInt(buf, source.ordinal());
+      ProtocolUtils.writeSoundSource(buf, protocolVersion, source);
     }
 
     if (soundName != null) {


### PR DESCRIPTION
With this PR, the Adventure-provided sound API is **partially** implemented.

It adds the ability to play sounds for a player (from the player itself or other players on the same server) and to stop sounds,
while making the methods fail silently if the sound can't be played/stopped.

What this PR implements:
- A method to play back (custom) sounds for a specific player (from the player itself or other players) for 1.19.3+
(- This also enables the respective methods on the registered server, by forwarding it to the players)
- A method to stop (custom) sounds for players with version 1.19.3+

What this PR **doesn't** implement:
- A method to play back (custom) sounds for a specific player at a position or another entity for players of all versions
- A method to play back (custom) sounds (globally) at a specific location for players of all versions
- A easily way to access a list of vanilla sounds
*- A method to play back (custom) sounds for a specific player for players with version 1.19.2 and below*
*- A method to stop (custom) sounds for players with version 1.19.2 and below*

Clarification:
This PR only implements a sound API for version 1.19.3+ because only in this version is the server able to play a (vanilla) sound for a player without requiring a version-dependent id for the sound.