### PR TITLE
Expose raw vhost string

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/InboundConnection.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/InboundConnection.java
@@ -26,10 +26,19 @@ public interface InboundConnection {
 
   /**
    * Returns the hostname that the user entered into the client, if applicable.
-   *
+   * <br/>
+   * This is partially processed, including removing a trailing dot, and discarding data after a null byte.
+
    * @return the hostname from the client
    */
   Optional<InetSocketAddress> getVirtualHost();
+
+  /**
+   * Returns the raw hostname that the client sent, if applicable.
+   *
+   * @return the raw hostname from the client
+   */
+  Optional<String> getRawVirtualHost();
 
   /**
    * Determine whether or not the player remains online.

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
@@ -96,7 +96,7 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
 
       // Initiate a regular connection and move over to it.
       ConnectedPlayer player = new ConnectedPlayer(server, profileEvent.getGameProfile(),
-          mcConnection, inbound.getVirtualHost().orElse(null), onlineMode,
+          mcConnection, inbound.getVirtualHost().orElse(null), inbound.getRawVirtualHost().orElse(null), onlineMode,
           inbound.getIdentifiedKey());
       this.connectedPlayer = player;
       if (!server.canRegisterConnection(player)) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -155,6 +155,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
    */
   private final MinecraftConnection connection;
   private final @Nullable InetSocketAddress virtualHost;
+  private final @Nullable String rawVirtualHost;
   private GameProfile profile;
   private PermissionFunction permissionFunction;
   private int tryIndex = 0;
@@ -191,12 +192,13 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   private final ChatBuilderFactory chatBuilderFactory;
 
   ConnectedPlayer(VelocityServer server, GameProfile profile, MinecraftConnection connection,
-                  @Nullable InetSocketAddress virtualHost, boolean onlineMode,
+                  @Nullable InetSocketAddress virtualHost, @Nullable String rawVirtualHost, boolean onlineMode,
                   @Nullable IdentifiedKey playerKey) {
     this.server = server;
     this.profile = profile;
     this.connection = connection;
     this.virtualHost = virtualHost;
+    this.rawVirtualHost = rawVirtualHost;
     this.permissionFunction = PermissionFunction.ALWAYS_UNDEFINED;
     this.connectionPhase = connection.getType().getInitialClientPhase();
     this.onlineMode = onlineMode;
@@ -354,6 +356,11 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   @Override
   public Optional<InetSocketAddress> getVirtualHost() {
     return Optional.ofNullable(virtualHost);
+  }
+
+  @Override
+  public Optional<String> getRawVirtualHost() {
+    return Optional.ofNullable(rawVirtualHost);
   }
 
   void setPermissionFunction(PermissionFunction permissionFunction) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -244,6 +244,11 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
     }
 
     @Override
+    public Optional<String> getRawVirtualHost() {
+      return getVirtualHost().map(InetSocketAddress::getHostName);
+    }
+
+    @Override
     public boolean isActive() {
       return !connection.isClosed();
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialInboundConnection.java
@@ -64,6 +64,11 @@ public final class InitialInboundConnection implements VelocityInboundConnection
   }
 
   @Override
+  public Optional<String> getRawVirtualHost() {
+    return Optional.of(handshake.getServerAddress());
+  }
+
+  @Override
   public boolean isActive() {
     return connection.getChannel().isActive();
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginInboundConnection.java
@@ -72,6 +72,11 @@ public class LoginInboundConnection implements LoginPhaseConnection, KeyIdentifi
   }
 
   @Override
+  public Optional<String> getRawVirtualHost() {
+    return delegate.getRawVirtualHost();
+  }
+
+  @Override
   public boolean isActive() {
     return delegate.isActive();
   }


### PR DESCRIPTION
Supersedes #1413 in a more general purpose way, including bypassing other hostname cleaning methods, and implementing it on all inbound connections.

this should be as raw as possible as to what the client sends.

I'm not 100% sure if there is a desire to expose this tho