### PR TITLE
Fix exception while serializing JsonArray

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ComponentHolder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ComponentHolder.java
@@ -173,21 +173,21 @@ public class ComponentHolder {
         case 1://BinaryTagTypes.BYTE:
           byte[] bytes = new byte[jsonArray.size()];
           for (int i = 0; i < bytes.length; i++) {
-            bytes[i] = (Byte) jsonArray.get(i).getAsNumber();
+            bytes[i] = jsonArray.get(i).getAsNumber().byteValue();
           }
 
           return ByteArrayBinaryTag.byteArrayBinaryTag(bytes);
         case 3://BinaryTagTypes.INT:
           int[] ints = new int[jsonArray.size()];
           for (int i = 0; i < ints.length; i++) {
-            ints[i] = (Integer) jsonArray.get(i).getAsNumber();
+            ints[i] = jsonArray.get(i).getAsNumber().intValue();
           }
 
           return IntArrayBinaryTag.intArrayBinaryTag(ints);
         case 4://BinaryTagTypes.LONG:
           long[] longs = new long[jsonArray.size()];
           for (int i = 0; i < longs.length; i++) {
-            longs[i] = (Long) jsonArray.get(i).getAsNumber();
+            longs[i] = jsonArray.get(i).getAsNumber().longValue();
           }
 
           return LongArrayBinaryTag.longArrayBinaryTag(longs);


### PR DESCRIPTION
Recently I encountered a issue with `SystemChatPacket`:

```
io.netty.handler.codec.EncoderException: java.lang.ClassCastException: class com.google.gson.internal.LazilyParsedNumber cannot be cast to class java.lang.Integer (com.google.gson.internal.LazilyParsedNumber is in unnamed module of loader 'app'; java.lang.Integer is in module java.base of loader 'bootstrap')
        at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:125) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:893) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:875) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:984) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:868) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:113) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:893) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:875) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:984) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:868) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.DefaultChannelPipeline.write(DefaultChannelPipeline.java:1015) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannel.write(AbstractChannel.java:301) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at org.geysermc.geyser.network.netty.ChannelWrapper.write(ChannelWrapper.java:209) ~[?:?]
        at com.velocitypowered.proxy.connection.MinecraftConnection.delayedWrite(MinecraftConnection.java:248) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at com.velocitypowered.proxy.connection.backend.BackendPlaySessionHandler.handleGeneric(BackendPlaySessionHandler.java:449) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at com.velocitypowered.proxy.connection.MinecraftConnection.channelRead(MinecraftConnection.java:154) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at com.velocitypowered.proxy.protocol.netty.AutoReadHolderHandler.channelRead(AutoReadHolderHandler.java:57) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at com.velocitypowered.proxy.protocol.netty.MinecraftDecoder.tryDecode(MinecraftDecoder.java:91) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at com.velocitypowered.proxy.protocol.netty.MinecraftDecoder.channelRead(MinecraftDecoder.java:60) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:509) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:407) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: java.lang.ClassCastException: class com.google.gson.internal.LazilyParsedNumber cannot be cast to class java.lang.Integer (com.google.gson.internal.LazilyParsedNumber is in unnamed module of loader 'app'; java.lang.Integer is in module java.base of loader 'bootstrap')
        at com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder.serialize(ComponentHolder.java:183) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder.serialize(ComponentHolder.java:147) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder.getBinaryTag(ComponentHolder.java:109) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder.write(ComponentHolder.java:295) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at com.velocitypowered.proxy.protocol.packet.chat.SystemChatPacket.encode(SystemChatPacket.java:56) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at com.velocitypowered.proxy.protocol.netty.MinecraftEncoder.encode(MinecraftEncoder.java:54) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at com.velocitypowered.proxy.protocol.netty.MinecraftEncoder.encode(MinecraftEncoder.java:32) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:107) ~[server.jar:3.3.0-SNAPSHOT (git-3c23ee75-b430)]
        ... 55 more
```

After diving into the code, I found that `ComponentHolder`'s JsonArray serialization cannot handle type correctly:

```java
switch (listType.id()) {
case 1://BinaryTagTypes.BYTE:
    byte[] bytes = new byte[jsonArray.size()];
    for (int i = 0; i < bytes.length; i++) {
        bytes[i] = (Byte) jsonArray.get(i).getAsNumber();
    }

    return ByteArrayBinaryTag.byteArrayBinaryTag(bytes);
case 3://BinaryTagTypes.INT:
    int[] ints = new int[jsonArray.size()];
    for (int i = 0; i < ints.length; i++) {
        ints[i] = (Integer) jsonArray.get(i).getAsNumber();
    }

    return IntArrayBinaryTag.intArrayBinaryTag(ints);
case 4://BinaryTagTypes.LONG:
    long[] longs = new long[jsonArray.size()];
    for (int i = 0; i < longs.length; i++) {
        longs[i] = (Long) jsonArray.get(i).getAsNumber();
    }

    return LongArrayBinaryTag.longArrayBinaryTag(longs);
case 10://BinaryTagTypes.COMPOUND:
    tagItems.replaceAll(tag -> {
        if (tag.type() == BinaryTagTypes.COMPOUND) {
            return tag;
        } else {
            return CompoundBinaryTag.builder().put("", tag).build();
        }
    });
    break;
}
```

The return value of `JsonElement#getAsNumber` could be a instance of `LazilyParsedNumber`, so it cannot be cast to `Integer`.
I replaced the explicit cast to corresponding method such as `Number#intValue` to solve this problem.