### PR TITLE
feat: Add event to modify and/or block backend updates to the tablist

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/player/ServerUpdateTabListEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/ServerUpdateTabListEvent.java
@@ -18,7 +18,7 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- * This event is fired, when a {@link com.velocitypowered.api.proxy.player.TabList Tablist} is updated.
+ * This event is fired, when a {@link com.velocitypowered.api.proxy.player.TabList Tablist} is updated by a {@link com.velocitypowered.api.proxy.ServerConnection server}.
  * It can be used to override or cancel updates for {@link TabListEntry}s.
  * Velocity will wait for this event to finish firing before forwarding it to the server.
  *

--- a/api/src/main/java/com/velocitypowered/api/event/player/ServerUpdateTabListEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/ServerUpdateTabListEvent.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2019-2024 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.event.player;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.event.ResultedEvent;
+import com.velocitypowered.api.event.annotation.AwaitingEvent;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.player.TabListEntry;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * This event is fired, when a {@link com.velocitypowered.api.proxy.player.TabList Tablist} is updated.
+ * It can be used to override or cancel updates for {@link TabListEntry}s.
+ * Velocity will wait for this event to finish firing before forwarding it to the server.
+ *
+ * <p>Note: If the {@code actions} contain {@link Action#REMOVE_PLAYER Action.REMOVE_PLAYER}, that may be the only action.
+ *
+ * <p><b>Version-specific behavior:</b>
+ *   <li>For versions below 1.19.3, {@code actions} may only contain one action, and if that action
+ *   is {@link Action#ADD_PLAYER Action.ADD_PLAYER}, the values normally set by other actions
+ *       (e.g., {@link Action#UPDATE_GAME_MODE Action.UPDATE_GAME_MODE}) may still be set.
+ *   <li>For versions below 1.8, {@code actions} may only contain {@link Action#ADD_PLAYER Action.ADD_PLAYER}
+ *       or {@link Action#REMOVE_PLAYER Action.REMOVE_PLAYER}. {@link Action#ADD_PLAYER Action.ADD_PLAYER} may also act as a replacement
+ *       for actions like {@link Action#UPDATE_LATENCY Action.UPDATE_LATENCY}}.
+ */
+@AwaitingEvent
+public class ServerUpdateTabListEvent implements ResultedEvent<ServerUpdateTabListEvent.TabListUpdateResult> {
+
+  private final Player player;
+  private final Set<Action> actions;
+  private final List<TabListEntry> entries;
+  private TabListUpdateResult result;
+
+  /**
+   * Constructs a {@link ServerUpdateTabListEvent} instance.
+   *
+   * @param player the player for whom the tab list is being updated
+   * @param actions the {@link Action Action}s from the server for this tab list update
+   * @param entries the {@link TabListEntry}s in their updated form
+   */
+  public ServerUpdateTabListEvent(Player player, Set<Action> actions, List<TabListEntry> entries) {
+    this.player = Preconditions.checkNotNull(player, "player");
+    this.actions = Preconditions.checkNotNull(actions, "actions");
+    this.entries = Preconditions.checkNotNull(entries, "entries");
+    this.result = TabListUpdateResult.allowed();
+  }
+
+  public Player getPlayer() {
+    return player;
+  }
+
+  public Set<Action> getActions() {
+    return actions;
+  }
+
+  /**
+   * The updated {@link TabListEntry}s that will be applied to the {@link com.velocitypowered.api.proxy.player.TabList Tablist}
+   * of the {@code player} (or in the case of {@link Action#REMOVE_PLAYER Action.REMOVE_PLAYER} removed).
+   *
+   * @return the updated entries, normally immutable
+   */
+  public List<TabListEntry> getEntries() {
+    return entries;
+  }
+
+  @Override
+  public TabListUpdateResult getResult() {
+    return result;
+  }
+
+  @Override
+  public void setResult(TabListUpdateResult result) {
+    this.result = Preconditions.checkNotNull(result, "result");
+  }
+
+  @Override
+  public String toString() {
+    return "ServerUpdateTabListEvent{"
+        + "player=" + player
+        + ", actions=" + actions
+        + ", entries=" + entries
+        + '}';
+  }
+
+  /**
+   * Represents an action of the {@link ServerUpdateTabListEvent}.
+   */
+  public enum Action {
+    /**
+     * Add new players to the player list.
+     */
+    ADD_PLAYER,
+    /**
+     * Initialize the chat session for the entries.
+     */
+    INITIALIZE_CHAT,
+    /**
+     * Update the gamemode for the entries.
+     */
+    UPDATE_GAME_MODE,
+    /**
+     * Update the latency for the entries.
+     */
+    UPDATE_LISTED,
+    /**
+     * Update the latency for the entries.
+     */
+    UPDATE_LATENCY,
+    /**
+     * Update the display name for the specific entries.
+     */
+    UPDATE_DISPLAY_NAME,
+    /**
+     * Remove players from the player list.
+     */
+    REMOVE_PLAYER
+  }
+
+  /**
+   * Represents the result of the {@link ServerUpdateTabListEvent}.
+   */
+  public static final class TabListUpdateResult implements ResultedEvent.Result {
+
+    private static final TabListUpdateResult ALLOWED = new TabListUpdateResult(true);
+    private static final TabListUpdateResult DENIED = new TabListUpdateResult(false);
+
+    private final boolean status;
+    private final Set<UUID> ids;
+
+    public TabListUpdateResult(boolean status) {
+      this.status = status;
+      ids = Collections.emptySet();
+    }
+
+    public TabListUpdateResult(boolean status, Set<UUID> ids) {
+      this.status = status;
+      this.ids = ids;
+    }
+
+    @Override
+    public boolean isAllowed() {
+      return status;
+    }
+
+    public Set<UUID> getIds() {
+      return ids;
+    }
+
+    /**
+     * Allows the {@link TabListEntry}s to be updated, with or without modification.
+     *
+     * @return the allowed result
+     */
+    public static TabListUpdateResult allowed() {
+      return ALLOWED;
+    }
+
+    /**
+     * Prevents the {@link TabListEntry}s from being updated.
+     *
+     * @return the denied result
+     */
+    public static TabListUpdateResult denied() {
+      return DENIED;
+    }
+
+    /**
+     * Only allows specific {@link TabListEntry}s to be updated.
+     * The updates for the remaining entries will be dropped.
+     *
+     * <p>Note: You can get the id of an entry with {@link TabListEntry#getProfile()}{@link com.velocitypowered.api.util.GameProfile#getId() .getId()}
+     *
+     * @param allowedOnly A non-empty set of ids of the entries that should be updated
+     * @return a result with the specified entries to be updated
+     */
+    public static TabListUpdateResult allowedSpecific(final Set<UUID> allowedOnly) {
+      Preconditions.checkNotNull(allowedOnly, "allowedOnly");
+      Preconditions.checkArgument(!allowedOnly.isEmpty(), "allowedOnly empty");
+      return new TabListUpdateResult(true, allowedOnly);
+    }
+
+  }
+
+}

--- a/api/src/main/java/com/velocitypowered/api/event/player/ServerUpdateTabListEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/ServerUpdateTabListEvent.java
@@ -18,7 +18,8 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- * This event is fired, when a {@link com.velocitypowered.api.proxy.player.TabList Tablist} is updated by a {@link com.velocitypowered.api.proxy.ServerConnection server}.
+ * This event is fired, when a {@link com.velocitypowered.api.proxy.player.TabList Tablist} is updated
+ * by a {@link com.velocitypowered.api.proxy.ServerConnection server}.
  * It can be used to override or cancel updates for {@link TabListEntry}s.
  * Velocity will wait for this event to finish firing before forwarding it to the server.
  *

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -334,20 +334,20 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(LegacyPlayerListItemPacket packet) {
-    serverConn.getPlayer().getTabList().processLegacy(packet);
-    return false;
+    serverConn.getPlayer().getTabList().processLegacyUpdate(packet);
+    return true;
   }
 
   @Override
   public boolean handle(UpsertPlayerInfoPacket packet) {
     serverConn.getPlayer().getTabList().processUpdate(packet);
-    return false;
+    return true;
   }
 
   @Override
   public boolean handle(RemovePlayerInfoPacket packet) {
     serverConn.getPlayer().getTabList().processRemove(packet);
-    return false;
+    return true;
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -202,7 +202,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     this.onlineMode = onlineMode;
 
     if (connection.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_19_3)) {
-      this.tabList = new VelocityTabList(this);
+      this.tabList = new VelocityTabList(this, server);
     } else if (connection.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_8)) {
       this.tabList = new KeyedVelocityTabList(this, server);
     } else {

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/InternalTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/InternalTabList.java
@@ -30,7 +30,7 @@ public interface InternalTabList extends TabList {
 
   Player getPlayer();
 
-  default void processLegacy(LegacyPlayerListItemPacket packet) {
+  default void processLegacyUpdate(LegacyPlayerListItemPacket packet) {
   }
 
   default void processUpdate(UpsertPlayerInfoPacket infoPacket) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/KeyedVelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/KeyedVelocityTabList.java
@@ -187,7 +187,7 @@ public class KeyedVelocityTabList implements InternalTabList {
             Set.of(action),
             Collections.unmodifiableList(entries)
         )
-    ).thenAcceptAsync(event -> {
+    ).thenAccept(event -> {
       if (event.getResult().isAllowed()) {
         if (event.getResult().getIds().isEmpty()) {
           boolean rewrite = false;
@@ -242,7 +242,7 @@ public class KeyedVelocityTabList implements InternalTabList {
           }
         }
       }
-    });
+    }).join();
   }
 
   protected ServerUpdateTabListEvent.@Nullable Action mapToEventAction(int action) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/UpdateEventTabListEntry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/UpdateEventTabListEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Velocity Contributors
+ * Copyright (C) 2018-2024 Velocity Contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,35 +17,35 @@
 
 package com.velocitypowered.proxy.tablist;
 
+import com.velocitypowered.api.event.player.ServerUpdateTabListEvent;
 import com.velocitypowered.api.proxy.player.ChatSession;
 import com.velocitypowered.api.proxy.player.TabList;
 import com.velocitypowered.api.proxy.player.TabListEntry;
 import com.velocitypowered.api.util.GameProfile;
-import com.velocitypowered.proxy.protocol.packet.UpsertPlayerInfoPacket;
-import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import java.util.Optional;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Generic tab list entry implementation.
+ * Represents a {@link TabListEntry} of the {@link ServerUpdateTabListEvent}.
  */
-public class VelocityTabListEntry implements TabListEntry {
+public class UpdateEventTabListEntry implements TabListEntry {
 
-  private final VelocityTabList tabList;
+  private final TabList tabList;
   private final GameProfile profile;
   private @Nullable Component displayName;
   private int latency;
   private int gameMode;
   private boolean listed;
   private @Nullable ChatSession session;
+  private boolean rewrite = false;
 
   /**
-   * Constructs the instance.
+   * Constructs an instance.
    */
-  public VelocityTabListEntry(VelocityTabList tabList, GameProfile profile, @Nullable Component displayName,
-                              int latency,
-                              int gameMode, @Nullable ChatSession session, boolean listed) {
+  public UpdateEventTabListEntry(TabList tabList, GameProfile profile, @Nullable Component displayName,
+                                 int latency,
+                                 int gameMode, @Nullable ChatSession session, boolean listed) {
     this.tabList = tabList;
     this.profile = profile;
     this.displayName = displayName;
@@ -78,18 +78,11 @@ public class VelocityTabListEntry implements TabListEntry {
   @Override
   public TabListEntry setDisplayName(@Nullable Component displayName) {
     this.displayName = displayName;
-    UpsertPlayerInfoPacket.Entry upsertEntry = this.tabList.createRawEntry(this);
-    upsertEntry.setDisplayName(
-            displayName == null
-                    ?
-                    null :
-                    new ComponentHolder(this.tabList.getPlayer().getProtocolVersion(), displayName)
-    );
-    this.tabList.emitActionRaw(UpsertPlayerInfoPacket.Action.UPDATE_DISPLAY_NAME, upsertEntry);
+    rewrite = true;
     return this;
   }
 
-  void setDisplayNameWithoutUpdate(@Nullable Component displayName) {
+  void setDisplayNameWithoutRewrite(@Nullable Component displayName) {
     this.displayName = displayName;
   }
 
@@ -101,13 +94,11 @@ public class VelocityTabListEntry implements TabListEntry {
   @Override
   public TabListEntry setLatency(int latency) {
     this.latency = latency;
-    UpsertPlayerInfoPacket.Entry upsertEntry = this.tabList.createRawEntry(this);
-    upsertEntry.setLatency(latency);
-    this.tabList.emitActionRaw(UpsertPlayerInfoPacket.Action.UPDATE_LATENCY, upsertEntry);
+    rewrite = true;
     return this;
   }
 
-  void setLatencyWithoutUpdate(int latency) {
+  void setLatencyWithoutRewrite(int latency) {
     this.latency = latency;
   }
 
@@ -119,17 +110,15 @@ public class VelocityTabListEntry implements TabListEntry {
   @Override
   public TabListEntry setGameMode(int gameMode) {
     this.gameMode = gameMode;
-    UpsertPlayerInfoPacket.Entry upsertEntry = this.tabList.createRawEntry(this);
-    upsertEntry.setGameMode(gameMode);
-    this.tabList.emitActionRaw(UpsertPlayerInfoPacket.Action.UPDATE_GAME_MODE, upsertEntry);
+    rewrite = true;
     return this;
   }
 
-  void setGameModeWithoutUpdate(int gameMode) {
+  void setGameModeWithoutRewrite(int gameMode) {
     this.gameMode = gameMode;
   }
 
-  protected void setChatSession(@Nullable ChatSession session) {
+  void setChatSessionWithoutRewrite(@Nullable ChatSession session) {
     this.session = session;
   }
 
@@ -139,15 +128,18 @@ public class VelocityTabListEntry implements TabListEntry {
   }
 
   @Override
-  public VelocityTabListEntry setListed(boolean listed) {
+  public TabListEntry setListed(boolean listed) {
     this.listed = listed;
-    UpsertPlayerInfoPacket.Entry upsertEntry = this.tabList.createRawEntry(this);
-    upsertEntry.setListed(listed);
-    this.tabList.emitActionRaw(UpsertPlayerInfoPacket.Action.UPDATE_LISTED, upsertEntry);
+    rewrite = true;
     return this;
   }
 
-  void setListedWithoutUpdate(boolean listed) {
+  void setListedWithoutRewrite(boolean listed) {
     this.listed = listed;
   }
+
+  boolean isRewrite() {
+    return rewrite;
+  }
+
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -225,7 +225,7 @@ public class VelocityTabList implements InternalTabList {
     proxyServer.getEventManager().fire(new ServerUpdateTabListEvent(player,
         Collections.unmodifiableSet(mapToEventActions(infoPacket.getActions())),
         Collections.unmodifiableList(entries))
-    ).thenAcceptAsync(event -> {
+    ).thenAccept(event -> {
       if (event.getResult().isAllowed()) {
         if (event.getResult().getIds().isEmpty()) {
           boolean rewrite = false;
@@ -258,7 +258,7 @@ public class VelocityTabList implements InternalTabList {
           }
         }
       }
-    });
+    }).join();
   }
 
   protected UpsertPlayerInfoPacket.Entry createRawEntry(VelocityTabListEntry entry) {
@@ -456,7 +456,7 @@ public class VelocityTabList implements InternalTabList {
             Set.of(ServerUpdateTabListEvent.Action.REMOVE_PLAYER),
             Collections.unmodifiableList(entries)
         )
-    ).thenAcceptAsync(event -> {
+    ).thenAccept(event -> {
       if (event.getResult().isAllowed()) {
         if (event.getResult().getIds().isEmpty()) {
           for (UUID uuid : infoPacket.getProfilesToRemove()) {
@@ -476,6 +476,6 @@ public class VelocityTabList implements InternalTabList {
           this.connection.write(new RemovePlayerInfoPacket(uuids));
         }
       }
-    });
+    }).join();
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -456,7 +456,7 @@ public class VelocityTabList implements InternalTabList {
             Set.of(ServerUpdateTabListEvent.Action.REMOVE_PLAYER),
             Collections.unmodifiableList(entries)
         )
-    ).thenAcceptAsync(event -> { //not sure what should be used here!
+    ).thenAcceptAsync(event -> {
       if (event.getResult().isAllowed()) {
         if (event.getResult().getIds().isEmpty()) {
           for (UUID uuid : infoPacket.getProfilesToRemove()) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -19,7 +19,9 @@ package com.velocitypowered.proxy.tablist;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import com.velocitypowered.api.event.player.ServerUpdateTabListEvent;
 import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.player.ChatSession;
 import com.velocitypowered.api.proxy.player.TabListEntry;
 import com.velocitypowered.api.util.GameProfile;
@@ -32,11 +34,13 @@ import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import com.velocitypowered.proxy.protocol.packet.chat.RemoteChatSession;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import org.apache.logging.log4j.LogManager;
@@ -51,6 +55,7 @@ public class VelocityTabList implements InternalTabList {
   private static final Logger logger = LogManager.getLogger(VelocityConsole.class);
   private final ConnectedPlayer player;
   private final MinecraftConnection connection;
+  protected final ProxyServer proxyServer;
   private final Map<UUID, VelocityTabListEntry> entries;
 
   /**
@@ -58,8 +63,9 @@ public class VelocityTabList implements InternalTabList {
    *
    * @param player player associated with this tab list
    */
-  public VelocityTabList(ConnectedPlayer player) {
+  public VelocityTabList(ConnectedPlayer player, final ProxyServer proxyServer) {
     this.player = player;
+    this.proxyServer = proxyServer;
     this.connection = player.getConnection();
     this.entries = Maps.newConcurrentMap();
   }
@@ -214,9 +220,45 @@ public class VelocityTabList implements InternalTabList {
 
   @Override
   public void processUpdate(UpsertPlayerInfoPacket infoPacket) {
-    for (UpsertPlayerInfoPacket.Entry entry : infoPacket.getEntries()) {
-      processUpsert(infoPacket.getActions(), entry);
-    }
+    List<UpdateEventTabListEntry> entries = mapToEventEntries(infoPacket.getActions(), infoPacket.getEntries());
+
+    proxyServer.getEventManager().fire(new ServerUpdateTabListEvent(player,
+        Collections.unmodifiableSet(mapToEventActions(infoPacket.getActions())),
+        Collections.unmodifiableList(entries))
+    ).thenAcceptAsync(event -> {
+      if (event.getResult().isAllowed()) {
+        if (event.getResult().getIds().isEmpty()) {
+          boolean rewrite = false;
+          for (UpdateEventTabListEntry entry : entries) {
+            if (entry.isRewrite()) {
+              rewrite = true;
+              break;
+            }
+          }
+
+          if (rewrite) {
+            //listeners have modified entries, requires manual processing
+            for (UpdateEventTabListEntry entry : entries) {
+              addEntry(entry);
+            }
+          } else {
+            //listeners haven't modified entries
+            for (UpsertPlayerInfoPacket.Entry entry : infoPacket.getEntries()) {
+              processUpsert(infoPacket.getActions(), entry);
+            }
+
+            connection.write(infoPacket);
+          }
+        } else {
+          //listeners have denied entries (and may have modified others), requires manual processing
+          for (UpdateEventTabListEntry entry : entries) {
+            if (event.getResult().getIds().contains(entry.getProfile().getId())) {
+              addEntry(entry);
+            }
+          }
+        }
+      }
+    });
   }
 
   protected UpsertPlayerInfoPacket.Entry createRawEntry(VelocityTabListEntry entry) {
@@ -229,6 +271,134 @@ public class VelocityTabList implements InternalTabList {
   protected void emitActionRaw(UpsertPlayerInfoPacket.Action action,
                                UpsertPlayerInfoPacket.Entry entry) {
     this.connection.write(new UpsertPlayerInfoPacket(EnumSet.of(action), List.of(entry)));
+  }
+
+  private EnumSet<ServerUpdateTabListEvent.Action> mapToEventActions(EnumSet<UpsertPlayerInfoPacket.Action> packetActions) {
+    EnumSet<ServerUpdateTabListEvent.Action> actions = EnumSet.noneOf(ServerUpdateTabListEvent.Action.class);
+
+    for (UpsertPlayerInfoPacket.Action packetAction : packetActions) {
+      switch (packetAction) {
+        case ADD_PLAYER -> {
+          actions.add(ServerUpdateTabListEvent.Action.ADD_PLAYER);
+        }
+        case INITIALIZE_CHAT -> {
+          actions.add(ServerUpdateTabListEvent.Action.INITIALIZE_CHAT);
+        }
+        case UPDATE_GAME_MODE -> {
+          actions.add(ServerUpdateTabListEvent.Action.UPDATE_GAME_MODE);
+        }
+        case UPDATE_LISTED -> {
+          actions.add(ServerUpdateTabListEvent.Action.UPDATE_LISTED);
+        }
+        case UPDATE_LATENCY -> {
+          actions.add(ServerUpdateTabListEvent.Action.UPDATE_LATENCY);
+        }
+        case UPDATE_DISPLAY_NAME -> {
+          actions.add(ServerUpdateTabListEvent.Action.UPDATE_DISPLAY_NAME);
+        }
+        default -> {
+          // Nothing we can do here
+        }
+      }
+    }
+
+    return actions;
+  }
+
+  private List<UpdateEventTabListEntry> mapToEventEntries(EnumSet<UpsertPlayerInfoPacket.Action> actions,
+                                                          List<UpsertPlayerInfoPacket.Entry> packetEntries) {
+    List<UpdateEventTabListEntry> entries = new ArrayList<>(packetEntries.size());
+
+    for (UpsertPlayerInfoPacket.Entry rawEntry : packetEntries) {
+      Preconditions.checkNotNull(rawEntry.getProfileId(), "Profile ID cannot be null");
+      UUID profileId = rawEntry.getProfileId();
+      UpdateEventTabListEntry currentEntry = null;
+      VelocityTabListEntry oldCurrentEntry = this.entries.get(profileId);
+
+      if (oldCurrentEntry != null) {
+        currentEntry = new UpdateEventTabListEntry(
+            this,
+            oldCurrentEntry.getProfile(),
+            oldCurrentEntry.getDisplayNameComponent().orElse(null),
+            oldCurrentEntry.getLatency(),
+            oldCurrentEntry.getGameMode(),
+            oldCurrentEntry.getChatSession(),
+            oldCurrentEntry.isListed()
+        );
+      }
+
+      if (actions.contains(UpsertPlayerInfoPacket.Action.ADD_PLAYER)) {
+        if (currentEntry == null) {
+          currentEntry = new UpdateEventTabListEntry(
+              this,
+              rawEntry.getProfile(),
+              null,
+              0,
+              -1,
+              null,
+              false
+          );
+        } else {
+          logger.debug("Received an add player packet for an existing entry; this does nothing.");
+        }
+      } else if (currentEntry == null) {
+        logger.debug(
+            "Received a partial player before an ADD_PLAYER action; profile could not be built. {}",
+            rawEntry);
+        continue;
+      } else {
+        currentEntry = new UpdateEventTabListEntry(
+            this,
+            currentEntry.getProfile(),
+            currentEntry.getDisplayNameComponent().orElse(null),
+            currentEntry.getLatency(),
+            currentEntry.getGameMode(),
+            currentEntry.getChatSession(),
+            currentEntry.isListed()
+        );
+      }
+      if (actions.contains(UpsertPlayerInfoPacket.Action.UPDATE_GAME_MODE)) {
+        currentEntry.setGameModeWithoutRewrite(rawEntry.getGameMode());
+      }
+      if (actions.contains(UpsertPlayerInfoPacket.Action.UPDATE_LATENCY)) {
+        currentEntry.setLatencyWithoutRewrite(rawEntry.getLatency());
+      }
+      if (actions.contains(UpsertPlayerInfoPacket.Action.UPDATE_DISPLAY_NAME)) {
+        currentEntry.setDisplayNameWithoutRewrite(rawEntry.getDisplayName() != null
+            ? rawEntry.getDisplayName().getComponent() : null);
+      }
+      if (actions.contains(UpsertPlayerInfoPacket.Action.INITIALIZE_CHAT)) {
+        currentEntry.setChatSessionWithoutRewrite(rawEntry.getChatSession());
+      }
+      if (actions.contains(UpsertPlayerInfoPacket.Action.UPDATE_LISTED)) {
+        currentEntry.setListedWithoutRewrite(rawEntry.isListed());
+      }
+      entries.add(currentEntry);
+    }
+
+    return entries;
+  }
+
+  private List<UpdateEventTabListEntry> mapToEventEntries(Collection<UUID> uuids) {
+    List<UpdateEventTabListEntry> entries = new ArrayList<>();
+
+    for (Map.Entry<UUID, VelocityTabListEntry> entry : this.entries.entrySet()) {
+      if (uuids.contains(entry.getKey())) {
+        entries.add(
+            new UpdateEventTabListEntry(
+                this,
+                entry.getValue().getProfile(),
+                entry.getValue().getDisplayNameComponent().orElse(null),
+                entry.getValue().getLatency(),
+                entry.getValue().getGameMode(),
+                entry.getValue().getChatSession(),
+                entry.getValue().isListed()
+            )
+        );
+      }
+    }
+
+    return entries;
   }
 
   private void processUpsert(EnumSet<UpsertPlayerInfoPacket.Action> actions,
@@ -278,8 +448,34 @@ public class VelocityTabList implements InternalTabList {
 
   @Override
   public void processRemove(RemovePlayerInfoPacket infoPacket) {
-    for (UUID uuid : infoPacket.getProfilesToRemove()) {
-      this.entries.remove(uuid);
-    }
+    List<UpdateEventTabListEntry> entries = mapToEventEntries(infoPacket.getProfilesToRemove());
+
+    proxyServer.getEventManager().fire(
+        new ServerUpdateTabListEvent(
+            player,
+            Set.of(ServerUpdateTabListEvent.Action.REMOVE_PLAYER),
+            Collections.unmodifiableList(entries)
+        )
+    ).thenAcceptAsync(event -> { //not sure what should be used here!
+      if (event.getResult().isAllowed()) {
+        if (event.getResult().getIds().isEmpty()) {
+          for (UUID uuid : infoPacket.getProfilesToRemove()) {
+            this.entries.remove(uuid);
+          }
+
+          connection.write(infoPacket);
+        } else {
+          List<UUID> uuids = new ArrayList<>();
+          for (UUID uuid : infoPacket.getProfilesToRemove()) {
+            if (event.getResult().getIds().contains(uuid)) {
+              this.entries.remove(uuid);
+              uuids.add(uuid);
+            }
+          }
+
+          this.connection.write(new RemovePlayerInfoPacket(uuids));
+        }
+      }
+    });
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListLegacy.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListLegacy.java
@@ -96,7 +96,7 @@ public class VelocityTabListLegacy extends KeyedVelocityTabList {
             Set.of(action),
             Collections.singletonList(entry)
         )
-    ).thenAcceptAsync(event -> {
+    ).thenAccept(event -> {
       if (event.getResult().isAllowed()) {
         if (event.getResult().getIds().isEmpty()) {
           if (entry.isRewrite()) {
@@ -134,7 +134,7 @@ public class VelocityTabListLegacy extends KeyedVelocityTabList {
           }
         }
       }
-    });
+    }).join();
   }
 
   private UpdateEventTabListEntry mapToEventEntry(int action, LegacyPlayerListItemPacket.Item packetItem) {


### PR DESCRIPTION
This is a *concept* implementation to allow plugins to modify the tablist that is sent by the backend server.
While it is completly functional, there are aspects I'm not quite fond about, for example that there's a bit of duplicate code now.
Please let me know if you think there's a better design that could be implemented!
Also, if you think the version-specific behavior should *somehow* be handled internally, please let me know.

Should fix https://github.com/PaperMC/Velocity/issues/870
Inspired by https://github.com/PaperMC/Velocity/pull/874