### PR TITLE
Adjust HAProxy's existance to log when the proxy protocol is enabled …

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
@@ -109,7 +109,8 @@ public final class ConnectionManager {
           final Channel channel = future.channel();
           if (future.isSuccess()) {
             this.endpoints.put(address, new Endpoint(channel, ListenerType.MINECRAFT));
-            LOGGER.info("Listening on {}", channel.localAddress());
+            
+            LOGGER.info((this.server.getConfiguration().isProxyProtocol() ? "HAProxy listening on " : "Listening on ") + "{}", channel.localAddress());
 
             // Fire the proxy bound event after the socket is bound
             server.getEventManager().fireAndForget(

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
@@ -110,7 +110,12 @@ public final class ConnectionManager {
           if (future.isSuccess()) {
             this.endpoints.put(address, new Endpoint(channel, ListenerType.MINECRAFT));
             
-            LOGGER.info((this.server.getConfiguration().isProxyProtocol() ? "HAProxy listening on " : "Listening on ") + "{}", channel.localAddress());
+            // Warn people with console access that HAProxy is in use, see PR: #1436
+            if (this.server.getConfiguration().isProxyProtocol()) {
+              LOGGER.warn("Using HAProxy and listening on {}, please ensure this listener is adequately firewalled.", channel.localAddress());
+            }
+
+            LOGGER.info("Listening on {}", channel.localAddress());
 
             // Fire the proxy bound event after the socket is bound
             server.getEventManager().fireAndForget(


### PR DESCRIPTION
This is a VERY minor change, so minimal but VERY useful for system administrators. (I am one, and this was so confusing).
Other proxy softwares log when they enable proxy protocol, but velocity doesn't. I probably had some mandella effect, but it seemed like Velocity never used to do this. 

But as a system administrator, it would be nice to check the console when the server boots to check if HAProxy is enabled. Hence this change.