### PR TITLE
Add deprecation notice for `setResult` in `PlayerChatEvent`

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/player/PlayerChatEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/PlayerChatEvent.java
@@ -51,6 +51,13 @@ public final class PlayerChatEvent implements ResultedEvent<PlayerChatEvent.Chat
     return result;
   }
 
+  /**
+   * Set result for the event.
+   *
+   * @param result the result of event
+   * @deprecated for 1.19.1 and newer, set this as denied will kick users
+   */
+  @Deprecated
   @Override
   public void setResult(ChatResult result) {
     this.result = Preconditions.checkNotNull(result, "result");


### PR DESCRIPTION
It's a suggestion. I understand if it's refused.

This PR add a deprecation notice for the method `setResult` for `PlayerChatEvent`.

As developer, I think it's better to have a "warn" for this before it will happen.