### PR TITLE
Fix extra respawn packet byte on <1.21.2

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/RespawnPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/RespawnPacket.java
@@ -278,7 +278,7 @@ public class RespawnPacket implements MinecraftPacket {
       ProtocolUtils.writeVarInt(buf, portalCooldown);
     }
 
-    if (version.noLessThan(ProtocolVersion.MINECRAFT_1_12_1)) {
+    if (version.noLessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
       ProtocolUtils.writeVarInt(buf, seaLevel);
     }
 


### PR DESCRIPTION
On a 1.21 client

```
---- Minecraft Network Protocol Error Report ----
// All lines are down!
Time: 2024-10-22 17:35:46
Description: Packet handling error

io.netty.handler.codec.DecoderException: java.io.IOException: Packet play/clientbound/minecraft:respawn (ClientboundRespawnPacket) was larger than I expected, found 1 bytes extra whilst reading packet clientbound/minecraft:respawn
```