### PR TITLE
feat: expose list order in TabListEntry

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/player/TabList.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/TabList.java
@@ -168,6 +168,25 @@ public interface TabList {
    * @deprecated Internal usage. Use {@link TabListEntry.Builder} instead.
    */
   @Deprecated
+  default TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency,
+                          int gameMode, @Nullable ChatSession chatSession, boolean listed) {
+    return buildEntry(profile, displayName, latency, gameMode, chatSession, listed, 0);
+  }
+
+  /**
+   * Represents an entry in a {@link Player}'s tab list.
+   *
+   * @param profile     the profile
+   * @param displayName the display name
+   * @param latency     the latency
+   * @param gameMode    the game mode
+   * @param chatSession the chat session
+   * @param listed      the visible status of entry
+   * @param listOrder   the order/priority of entry in the tab list
+   * @return the entry
+   * @deprecated Internal usage. Use {@link TabListEntry.Builder} instead.
+   */
+  @Deprecated
   TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency,
-                          int gameMode, @Nullable ChatSession chatSession, boolean listed);
+                          int gameMode, @Nullable ChatSession chatSession, boolean listed, int listOrder);
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/player/TabListEntry.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/TabListEntry.java
@@ -140,6 +140,27 @@ public interface TabListEntry extends KeyIdentifiable {
   }
 
   /**
+   * Returns the order/priority of this entry in the tab list.
+   *
+   * @return order of this entry
+   * @sinceMinecraft 1.21.2
+   */
+  default int getListOrder() {
+    return 0;
+  }
+
+  /**
+   * Sets the order/priority of this entry in the tab list.
+   *
+   * @param order order of this entry
+   * @return {@code this}, for chaining
+   * @sinceMinecraft 1.21.2
+   */
+  default TabListEntry setListOrder(int order) {
+    return this;
+  }
+
+  /**
    * Returns a {@link Builder} to create a {@link TabListEntry}.
    *
    * @return {@link TabListEntry} builder
@@ -161,6 +182,7 @@ public interface TabListEntry extends KeyIdentifiable {
     private int latency = 0;
     private int gameMode = 0;
     private boolean listed = true;
+    private int listOrder = 0;
 
     private @Nullable ChatSession chatSession;
 
@@ -243,7 +265,7 @@ public interface TabListEntry extends KeyIdentifiable {
     }
 
     /**
-     * Sets wether this entry should be visible.
+     * Sets whether this entry should be visible.
      *
      * @param listed to set
      * @return ${code this}, for chaining
@@ -251,6 +273,19 @@ public interface TabListEntry extends KeyIdentifiable {
      */
     public Builder listed(boolean listed) {
       this.listed = listed;
+      return this;
+    }
+
+    /**
+     * Sets the order/priority of this entry in the tab list.
+     *
+     * @param order to set
+     * @return ${code this}, for chaining
+     * @sinceMinecraft 1.21.2
+     * @see TabListEntry#getListOrder()
+     */
+    public Builder listOrder(int order) {
+      this.listOrder = order;
       return this;
     }
 
@@ -266,7 +301,7 @@ public interface TabListEntry extends KeyIdentifiable {
       if (profile == null) {
         throw new IllegalStateException("The GameProfile must be set when building a TabListEntry");
       }
-      return tabList.buildEntry(profile, displayName, latency, gameMode, chatSession, listed);
+      return tabList.buildEntry(profile, displayName, latency, gameMode, chatSession, listed, listOrder);
     }
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/KeyedVelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/KeyedVelocityTabList.java
@@ -159,10 +159,15 @@ public class KeyedVelocityTabList implements InternalTabList {
 
   @Override
   public TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency,
-      int gameMode,
-      @Nullable ChatSession chatSession, boolean listed) {
+      int gameMode, @Nullable ChatSession chatSession, boolean listed) {
     return new KeyedVelocityTabListEntry(this, profile, displayName, latency, gameMode,
         chatSession == null ? null : chatSession.getIdentifiedKey());
+  }
+
+  @Override
+  public TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency,
+                                 int gameMode, @Nullable ChatSession chatSession, boolean listed, int listOrder) {
+    return buildEntry(profile, displayName, latency, gameMode, chatSession, listed);
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -19,6 +19,7 @@ package com.velocitypowered.proxy.tablist;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.player.ChatSession;
 import com.velocitypowered.api.proxy.player.TabListEntry;
@@ -127,6 +128,11 @@ public class VelocityTabList implements InternalTabList {
         if (!Objects.equals(previousEntry.isListed(), entry.isListed())) {
           actions.add(UpsertPlayerInfoPacket.Action.UPDATE_LISTED);
           playerInfoEntry.setListed(entry.isListed());
+        }
+        if (!Objects.equals(previousEntry.getListOrder(), entry.getListOrder())
+            && player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
+          actions.add(UpsertPlayerInfoPacket.Action.UPDATE_LIST_ORDER);
+          playerInfoEntry.setListOrder(entry.getListOrder());
         }
         if (!Objects.equals(previousEntry.getChatSession(), entry.getChatSession())) {
           ChatSession from = entry.getChatSession();

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -89,7 +89,7 @@ public class VelocityTabList implements InternalTabList {
     } else {
       entry = new VelocityTabListEntry(this, entry1.getProfile(),
           entry1.getDisplayNameComponent().orElse(null),
-          entry1.getLatency(), entry1.getGameMode(), entry1.getChatSession(), entry1.isListed());
+          entry1.getLatency(), entry1.getGameMode(), entry1.getChatSession(), entry1.isListed(), entry1.getListOrder());
     }
 
     EnumSet<UpsertPlayerInfoPacket.Action> actions = EnumSet
@@ -207,9 +207,9 @@ public class VelocityTabList implements InternalTabList {
   @Override
   public TabListEntry buildEntry(GameProfile profile, @Nullable Component displayName, int latency,
       int gameMode,
-      @Nullable ChatSession chatSession, boolean listed) {
+      @Nullable ChatSession chatSession, boolean listed, int listOrder) {
     return new VelocityTabListEntry(this, profile, displayName, latency, gameMode, chatSession,
-        listed);
+        listed, listOrder);
   }
 
   @Override
@@ -246,7 +246,8 @@ public class VelocityTabList implements InternalTabList {
                 0,
                 -1,
                 null,
-                false
+                false,
+                0
             )
         );
       } else {
@@ -273,6 +274,9 @@ public class VelocityTabList implements InternalTabList {
     }
     if (actions.contains(UpsertPlayerInfoPacket.Action.UPDATE_LISTED)) {
       currentEntry.setListedWithoutUpdate(entry.isListed());
+    }
+    if (actions.contains(UpsertPlayerInfoPacket.Action.UPDATE_LIST_ORDER)) {
+      currentEntry.setListOrderWithoutUpdate(entry.getListOrder());
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -168,6 +168,11 @@ public class VelocityTabList implements InternalTabList {
         }
         playerInfoEntry.setLatency(entry.getLatency());
         playerInfoEntry.setListed(entry.isListed());
+        if (entry.getListOrder() != 0
+            && player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
+          actions.add(UpsertPlayerInfoPacket.Action.UPDATE_LIST_ORDER);
+          playerInfoEntry.setListOrder(entry.getListOrder());
+        }
       }
       return entry;
     });

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListEntry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListEntry.java
@@ -38,6 +38,7 @@ public class VelocityTabListEntry implements TabListEntry {
   private int latency;
   private int gameMode;
   private boolean listed;
+  private int listOrder;
   private @Nullable ChatSession session;
 
   /**
@@ -45,7 +46,7 @@ public class VelocityTabListEntry implements TabListEntry {
    */
   public VelocityTabListEntry(VelocityTabList tabList, GameProfile profile, Component displayName,
                               int latency,
-                              int gameMode, @Nullable ChatSession session, boolean listed) {
+                              int gameMode, @Nullable ChatSession session, boolean listed, int listOrder) {
     this.tabList = tabList;
     this.profile = profile;
     this.displayName = displayName;
@@ -53,6 +54,7 @@ public class VelocityTabListEntry implements TabListEntry {
     this.gameMode = gameMode;
     this.session = session;
     this.listed = listed;
+    this.listOrder = listOrder;
   }
 
   @Override
@@ -149,5 +151,23 @@ public class VelocityTabListEntry implements TabListEntry {
 
   void setListedWithoutUpdate(boolean listed) {
     this.listed = listed;
+  }
+
+  @Override
+  public int getListOrder() {
+    return listOrder;
+  }
+
+  @Override
+  public VelocityTabListEntry setListOrder(int listOrder) {
+    this.listOrder = listOrder;
+    UpsertPlayerInfoPacket.Entry upsertEntry = this.tabList.createRawEntry(this);
+    upsertEntry.setListOrder(listOrder);
+    this.tabList.emitActionRaw(UpsertPlayerInfoPacket.Action.UPDATE_LIST_ORDER, upsertEntry);
+    return this;
+  }
+
+  void setListOrderWithoutUpdate(int listOrder) {
+    this.listOrder = listOrder;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListEntry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListEntry.java
@@ -17,6 +17,7 @@
 
 package com.velocitypowered.proxy.tablist;
 
+import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.player.ChatSession;
 import com.velocitypowered.api.proxy.player.TabList;
 import com.velocitypowered.api.proxy.player.TabListEntry;
@@ -161,9 +162,11 @@ public class VelocityTabListEntry implements TabListEntry {
   @Override
   public VelocityTabListEntry setListOrder(int listOrder) {
     this.listOrder = listOrder;
-    UpsertPlayerInfoPacket.Entry upsertEntry = this.tabList.createRawEntry(this);
-    upsertEntry.setListOrder(listOrder);
-    this.tabList.emitActionRaw(UpsertPlayerInfoPacket.Action.UPDATE_LIST_ORDER, upsertEntry);
+    if (tabList.getPlayer().getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
+      UpsertPlayerInfoPacket.Entry upsertEntry = this.tabList.createRawEntry(this);
+      upsertEntry.setListOrder(listOrder);
+      tabList.emitActionRaw(UpsertPlayerInfoPacket.Action.UPDATE_LIST_ORDER, upsertEntry);
+    }
     return this;
   }
 


### PR DESCRIPTION
Exposes the tab list ordering introduced in 1.21.2.

Fixes: https://github.com/PaperMC/Velocity/issues/1450