### PR TITLE
Allow responding to cookie requests

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/player/CookieRequestEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/CookieRequestEvent.java
@@ -68,15 +68,19 @@ public final class CookieRequestEvent implements ResultedEvent<CookieRequestEven
    */
   public static final class ForwardResult implements Result {
 
-    private static final ForwardResult ALLOWED = new ForwardResult(true, null);
-    private static final ForwardResult DENIED = new ForwardResult(false, null);
+    private static final ForwardResult ALLOWED = new ForwardResult(true, null, false, null);
+    private static final ForwardResult DENIED = new ForwardResult(false, null, false, null);
 
     private final boolean status;
     private final Key key;
+    private final boolean respond;
+    private final byte[] data;
 
-    private ForwardResult(final boolean status, final Key key) {
+    private ForwardResult(final boolean status, final Key key, boolean respond, byte[] data) {
       this.status = status;
       this.key = key;
+      this.respond = respond;
+      this.data = data;
     }
 
     @Override
@@ -86,6 +90,14 @@ public final class CookieRequestEvent implements ResultedEvent<CookieRequestEven
 
     public Key getKey() {
       return key;
+    }
+
+    public boolean shouldRespond() {
+      return respond;
+    }
+
+    public byte[] getData() {
+      return data;
     }
 
     @Override
@@ -113,6 +125,16 @@ public final class CookieRequestEvent implements ResultedEvent<CookieRequestEven
     }
 
     /**
+     * Sends this response to the request to the server
+     *
+     * @param data the data to send, null will mean missing data
+     * @return a result with the data
+     */
+    public static ForwardResult respond(final byte [] data) {
+      return new ForwardResult(false, null, true, data);
+    }
+
+    /**
      * Allows the cookie request to be forwarded to the client, but silently replaces the
      * identifier of the cookie with another.
      *
@@ -121,7 +143,7 @@ public final class CookieRequestEvent implements ResultedEvent<CookieRequestEven
      */
     public static ForwardResult key(final Key key) {
       Preconditions.checkNotNull(key, "key");
-      return new ForwardResult(true, key);
+      return new ForwardResult(true, key, false, null);
     }
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/event/player/CookieRequestEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/CookieRequestEvent.java
@@ -11,6 +11,7 @@ import com.google.common.base.Preconditions;
 import com.velocitypowered.api.event.ResultedEvent;
 import com.velocitypowered.api.event.annotation.AwaitingEvent;
 import com.velocitypowered.api.proxy.Player;
+import java.util.Base64;
 import net.kyori.adventure.key.Key;
 
 /**
@@ -102,7 +103,13 @@ public final class CookieRequestEvent implements ResultedEvent<CookieRequestEven
 
     @Override
     public String toString() {
-      return status ? "forward to client" : "handled by proxy";
+      if (status) {
+        return "Forward to client";
+      }
+      if (respond) {
+        return "Respond with " + Base64.getEncoder().encodeToString(data);
+      }
+      return "Handled by proxy";
     }
 
     /**

--- a/api/src/main/java/com/velocitypowered/api/event/player/CookieRequestEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/CookieRequestEvent.java
@@ -125,7 +125,7 @@ public final class CookieRequestEvent implements ResultedEvent<CookieRequestEven
     }
 
     /**
-     * Sends this response to the request to the server
+     * Sends this response to the request to the server.
      *
      * @param data the data to send, null will mean missing data
      * @return a result with the data

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -62,6 +62,7 @@ import com.velocitypowered.proxy.protocol.packet.RemoveResourcePackPacket;
 import com.velocitypowered.proxy.protocol.packet.ResourcePackRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.ResourcePackResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.ServerDataPacket;
+import com.velocitypowered.proxy.protocol.packet.ServerboundCookieResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.TabCompleteResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.TransferPacket;
 import com.velocitypowered.proxy.protocol.packet.UpsertPlayerInfoPacket;
@@ -435,6 +436,8 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
                 ? event.getOriginalKey() : event.getResult().getKey();
 
             playerConnection.write(new ClientboundCookieRequestPacket(resultedKey));
+          } else if (event.getResult().shouldRespond()) {
+            serverConn.ensureConnected().write(new ServerboundCookieResponsePacket(packet.getKey(), event.getResult().getData()));
           }
         }, playerConnection.eventLoop());
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -46,6 +46,7 @@ import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
 import com.velocitypowered.proxy.protocol.packet.RemoveResourcePackPacket;
 import com.velocitypowered.proxy.protocol.packet.ResourcePackRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.ResourcePackResponsePacket;
+import com.velocitypowered.proxy.protocol.packet.ServerboundCookieResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.TransferPacket;
 import com.velocitypowered.proxy.protocol.packet.config.ClientboundCustomReportDetailsPacket;
 import com.velocitypowered.proxy.protocol.packet.config.ClientboundServerLinksPacket;
@@ -324,6 +325,8 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
                 ? event.getOriginalKey() : event.getResult().getKey();
 
             serverConn.getPlayer().getConnection().write(new ClientboundCookieRequestPacket(resultedKey));
+          } else if (event.getResult().shouldRespond()) {
+            serverConn.ensureConnected().write(new ServerboundCookieResponsePacket(event.getOriginalKey(), event.getResult().getData()));
           }
         }, serverConn.ensureConnected().eventLoop());
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
@@ -41,6 +41,7 @@ import com.velocitypowered.proxy.protocol.packet.LoginAcknowledgedPacket;
 import com.velocitypowered.proxy.protocol.packet.LoginPluginMessagePacket;
 import com.velocitypowered.proxy.protocol.packet.LoginPluginResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.ServerLoginSuccessPacket;
+import com.velocitypowered.proxy.protocol.packet.ServerboundCookieResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.SetCompressionPacket;
 import com.velocitypowered.proxy.util.except.QuietRuntimeException;
 import io.netty.buffer.ByteBuf;
@@ -189,6 +190,8 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
                 ? event.getOriginalKey() : event.getResult().getKey();
 
             serverConn.getPlayer().getConnection().write(new ClientboundCookieRequestPacket(resultedKey));
+          } else if (event.getResult().shouldRespond()) {
+            serverConn.ensureConnected().write(new ServerboundCookieResponsePacket(event.getOriginalKey(), event.getResult().getData()));
           }
         }, serverConn.ensureConnected().eventLoop());
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -78,6 +78,7 @@ import com.velocitypowered.proxy.protocol.packet.HeaderAndFooterPacket;
 import com.velocitypowered.proxy.protocol.packet.KeepAlivePacket;
 import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
 import com.velocitypowered.proxy.protocol.packet.RemoveResourcePackPacket;
+import com.velocitypowered.proxy.protocol.packet.ServerboundCookieResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.TransferPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatQueue;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatType;
@@ -1071,6 +1072,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
                 ? event.getOriginalKey() : event.getResult().getKey();
 
             connection.write(new ClientboundCookieRequestPacket(resultedKey));
+          } else if (event.getResult().shouldRespond()) {
+            this.ensureBackendConnection().write(new ServerboundCookieResponsePacket(event.getOriginalKey(), event.getResult().getData()));
           }
         }, connection.eventLoop());
   }


### PR DESCRIPTION
Currently, if a server is awaiting the cookie response, it is impossible to block the request without forcing the server to wait indefinably, as <https://jd.papermc.io/velocity/3.4.0/com/velocitypowered/api/event/player/CookieRequestEvent.ForwardResult.html#handled()> just discards any requests without sending any responses and there is no api to manually send a response.


The current approach is similar to <https://jd.papermc.io/velocity/3.4.0/com/velocitypowered/api/event/player/ServerLoginPluginMessageEvent.html>, but if you consider that instead of this, it would be better to add a method in <https://jd.papermc.io/velocity/3.4.0/com/velocitypowered/api/proxy/ServerConnection.html> to send a response then I would change it