### PR TITLE
Fix SystemChatPacket: read boolean instead of varint

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/SystemChatPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/SystemChatPacket.java
@@ -47,8 +47,7 @@ public class SystemChatPacket implements MinecraftPacket {
   @Override
   public void decode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion version) {
     component = ComponentHolder.read(buf, version);
-    // System chat is never decoded so this doesn't matter for now
-    type = ChatType.values()[ProtocolUtils.readVarInt(buf)];
+    type = buf.readBoolean() ? ChatType.GAME_INFO : ChatType.SYSTEM;
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/SystemChatPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/SystemChatPacket.java
@@ -47,7 +47,11 @@ public class SystemChatPacket implements MinecraftPacket {
   @Override
   public void decode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion version) {
     component = ComponentHolder.read(buf, version);
-    type = buf.readBoolean() ? ChatType.GAME_INFO : ChatType.SYSTEM;
+    if (version.noLessThan(ProtocolVersion.MINECRAFT_1_19_1)){
+      type = buf.readBoolean() ? ChatType.GAME_INFO : ChatType.SYSTEM;
+    } else {
+      type = ChatType.values()[ProtocolUtils.readVarInt(buf)];
+    }
   }
 
   @Override


### PR DESCRIPTION
Since Velocity does not use SystemChatPacket's decode, it's missing proper attention and has a mistake in decoding.
But plugins managing protocol changes on proxy rely on it, so it's better to keep it working (working code is better than non-working code, right?).

The packet provides a boolean which determines if it is an actionbar message or a chat message, but for some reason SystemChatPacket reads varint which breaks ChatType determination during decode.