### PR TITLE
Expose shutdownInProgress to the API.

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
@@ -42,6 +42,13 @@ public interface ProxyServer extends Audience {
   void shutdown();
 
   /**
+   * Returns whether the proxy is currently shutting down.
+   *
+   * @return {@code true} if the proxy is shutting down, {@code false} otherwise
+   */
+  boolean isShuttingDown();
+
+  /**
    * Closes all listening endpoints for this server.
    * This includes the main minecraft listener and query channel.
    */

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -803,6 +803,11 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
   public VelocityChannelRegistrar getChannelRegistrar() {
     return channelRegistrar;
   }
+  
+  @Override
+  public boolean isShuttingDown() {
+    return shutdownInProgress.get();
+  }
 
   @Override
   public InetSocketAddress getBoundAddress() {


### PR DESCRIPTION
This is a simple PR to expose whether the proxy is currently shutting down or not.
This can be useful for example in the listener for a DisconnectEvent, which is called for every player on proxy shutdown.

If this is intentional and you have no intent of changing this, close this PR.

*The ProxyShutdownEvent is not a substitute for this, as it gets called after all players have been kicked when the proxy shuts down.*