### PR TITLE
Fix nonsensical deprecation for specifying listener priority

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/PostOrder.java
+++ b/api/src/main/java/com/velocitypowered/api/event/PostOrder.java
@@ -12,6 +12,12 @@ package com.velocitypowered.api.event;
  */
 public enum PostOrder {
 
-  FIRST, EARLY, NORMAL, LATE, LAST, CUSTOM
+  FIRST, EARLY, NORMAL, LATE, LAST,
+
+  /**
+   * @deprecated No longer required, you only need to specify {@link Subscribe#priority()}.
+   */
+  @Deprecated
+  CUSTOM
 
 }

--- a/api/src/main/java/com/velocitypowered/api/event/PostOrder.java
+++ b/api/src/main/java/com/velocitypowered/api/event/PostOrder.java
@@ -15,6 +15,8 @@ public enum PostOrder {
   FIRST, EARLY, NORMAL, LATE, LAST,
 
   /**
+   * Previously used to specify that {@link Subscribe#priority()} should be used.
+   *
    * @deprecated No longer required, you only need to specify {@link Subscribe#priority()}.
    */
   @Deprecated

--- a/api/src/main/java/com/velocitypowered/api/event/Subscribe.java
+++ b/api/src/main/java/com/velocitypowered/api/event/Subscribe.java
@@ -32,12 +32,9 @@ public @interface Subscribe {
    * The priority of this event handler. Priorities are used to determine the order in which event
    * handlers are called. The higher the priority, the earlier the event handler will be called.
    *
-   * <p>Note that due to compatibility constraints, you must specify {@link PostOrder#CUSTOM}
-   * in order to use this field.</p>
-   *
    * @return the priority
    */
-  short priority() default Short.MIN_VALUE;
+  short priority() default 0;
 
   /**
    * Whether the handler must be called asynchronously. By default, all event handlers are called

--- a/proxy/src/main/java/com/velocitypowered/proxy/event/VelocityEventManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/event/VelocityEventManager.java
@@ -350,8 +350,9 @@ public class VelocityEventManager implements EventManager {
         asyncType = AsyncType.ALWAYS;
       }
 
+      // The default value of 0 will fall back to PostOrder, the default PostOrder (NORMAL) is also 0
       final short order;
-      if (subscribe.order() == PostOrder.CUSTOM) {
+      if (subscribe.priority() != 0) {
         order = subscribe.priority();
       } else {
         order = (short) POST_ORDER_MAP.get(subscribe.order());


### PR DESCRIPTION
Currently specifying a priority for a listener without getting a deprecation is impossible, and suppressing deprecations causes it's own issues

![Screenshot from 2025-01-11 15-05-10](https://github.com/user-attachments/assets/b542fb5a-9433-467f-b968-36bf044d52c8)