### PR TITLE
Fix forcedHosts for Cloudflare proxy + SRV record.

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -860,6 +860,10 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       String virtualHostStr = getVirtualHost().map(InetSocketAddress::getHostString)
           .orElse("")
           .toLowerCase(Locale.ROOT);
+      String srvPrefixStr = "_minecraft._tcp.";
+      if (virtualHostStr.contains(srvPrefixStr)) {
+        virtualHostStr = virtualHostStr.split(srvPrefixStr)[1];
+      }
       serversToTry = server.getConfiguration().getForcedHosts().getOrDefault(virtualHostStr,
           Collections.emptyList());
     }


### PR DESCRIPTION
Quick little patch that lets forcedHosts work when things like Cloudflare add extra junk to the HostString as they pass it along. 

This is cool because now I can have an A record proxied over Cloudflare and an accompanying minecraft SRV record, which is a nice bit of hardening for no work or cost against random HTTP scrapes as they will all return the Cloudflare IP.

I haven't tested this with any other services. Obvious enhancements would be letting this be configurable with something like a user defined regex parsing string defined in the toml since I've seen other users talking about similar issues with other services. I feel like another enhancement on this concept would be a debug option to print out the HostString to console, so people could figure out what's going wrong on their own.

