### PR TITLE
Use real vanilla limits for LegacyChat

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyChatPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyChatPacket.java
@@ -91,7 +91,8 @@ public class LegacyChatPacket implements MinecraftPacket {
 
   @Override
   public void decode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion version) {
-    message = ProtocolUtils.readString(buf, 256);
+    message = ProtocolUtils.readString(buf, direction == ProtocolUtils.Direction.CLIENTBOUND
+        ? 262144 : version.noLessThan(ProtocolVersion.MINECRAFT_1_11) ? 256 : 100);
     if (direction == ProtocolUtils.Direction.CLIENTBOUND
         && version.noLessThan(ProtocolVersion.MINECRAFT_1_8)) {
       type = buf.readByte();


### PR DESCRIPTION
Wouldn't https://github.com/PaperMC/Velocity/commit/371e68607695b48117e1cd57d19c67e40384c33a break the chat with this limit??

If the proxy reads a message from the backend that is longer than 256 it would disconnect.

Client -> server
< 1.11 has 100
| >= 1.11 has 256

Server -> client has always 262144