### PR TITLE
respect log-player-connections config value for connection messages

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
@@ -106,7 +106,9 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
         return CompletableFuture.completedFuture(null);
       }
 
-      logger.info("{} has connected", player);
+      if (server.getConfiguration().isLogPlayerConnections()) {
+        logger.info("{} has connected", player);
+      }
 
       return server.getEventManager()
           .fire(new PermissionsSetupEvent(player, ConnectedPlayer.DEFAULT_PERMISSIONS))


### PR DESCRIPTION
Currently the `log-player-connections` configuration value is being respected in most places (e.g. `MinecraftConnection#L131`), but is not being respected in `AuthSessionHandler#L109`. 