### PR TITLE
docs: Remove beta annotations on events

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/command/PlayerAvailableCommandsEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/command/PlayerAvailableCommandsEvent.java
@@ -9,7 +9,6 @@ package com.velocitypowered.api.event.command;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.annotations.Beta;
 import com.mojang.brigadier.tree.RootCommandNode;
 import com.velocitypowered.api.event.annotation.AwaitingEvent;
 import com.velocitypowered.api.proxy.Player;
@@ -21,7 +20,6 @@ import com.velocitypowered.api.proxy.Player;
  * client.
  */
 @AwaitingEvent
-@Beta
 public class PlayerAvailableCommandsEvent {
 
   private final Player player;

--- a/api/src/main/java/com/velocitypowered/api/event/player/ServerPostConnectEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/ServerPostConnectEvent.java
@@ -7,7 +7,6 @@
 
 package com.velocitypowered.api.event.player;
 
-import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
@@ -18,7 +17,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * available in {@link Player#getCurrentServer()}. Velocity will not wait on this event to finish
  * firing.
  */
-@Beta
 public class ServerPostConnectEvent {
   private final Player player;
   private final RegisteredServer previousServer;

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
@@ -7,7 +7,6 @@
 
 package com.velocitypowered.api.event.proxy.server;
 
-import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
@@ -23,7 +22,6 @@ import org.jetbrains.annotations.NotNull;
  * @param registeredServer A {@link RegisteredServer} that has been registered.
  * @since 3.3.0
  */
-@Beta
 public record ServerRegisteredEvent(@NotNull RegisteredServer registeredServer) {
   public ServerRegisteredEvent {
     Preconditions.checkNotNull(registeredServer, "registeredServer");

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
@@ -7,7 +7,6 @@
 
 package com.velocitypowered.api.event.proxy.server;
 
-import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
@@ -23,7 +22,6 @@ import org.jetbrains.annotations.NotNull;
  * @param unregisteredServer A {@link RegisteredServer} that has been unregistered.
  * @since 3.3.0
  */
-@Beta
 public record ServerUnregisteredEvent(@NotNull RegisteredServer unregisteredServer) {
   public ServerUnregisteredEvent {
     Preconditions.checkNotNull(unregisteredServer, "unregisteredServer");


### PR DESCRIPTION
These events aren't in beta, some of them have been stable for years now.