### PR TITLE
Improving the API of event priorities

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/EventManager.java
+++ b/api/src/main/java/com/velocitypowered/api/event/EventManager.java
@@ -40,21 +40,6 @@ public interface EventManager {
    * Requests that the specified {@code handler} listen for events and associate it with the {@code
    * plugin}.
    *
-   * @param plugin the plugin to associate with the handler
-   * @param eventClass the class for the event handler to register
-   * @param postOrder the order in which events should be posted to the handler
-   * @param handler the handler to register
-   * @param <E> the event type to handle
-   * @deprecated use {@link #register(Object, Class, short, EventHandler)} instead
-   */
-  @Deprecated
-  <E> void register(Object plugin, Class<E> eventClass, PostOrder postOrder,
-      EventHandler<E> handler);
-
-  /**
-   * Requests that the specified {@code handler} listen for events and associate it with the {@code
-   * plugin}.
-   *
    * <p>Note that this method will register a non-asynchronous listener by default. If you want to
    * use an asynchronous event handler, return {@link EventTask#async(Runnable)} from the handler.</p>
    *

--- a/api/src/main/java/com/velocitypowered/api/event/PostOrder.java
+++ b/api/src/main/java/com/velocitypowered/api/event/PostOrder.java
@@ -7,12 +7,23 @@
 
 package com.velocitypowered.api.event;
 
+import com.google.common.base.Preconditions;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents the order an event will be posted to a listener method, relative to other listeners.
+ *
+ * <p>Listeners are called in following order: {@link #FIRST} -> {@link #EARLY} ->
+ * {@link #NORMAL} -> {@link #LATE} -> {@link #LAST}</p>
  */
-public enum PostOrder {
+public interface PostOrder {
 
-  FIRST, EARLY, NORMAL, LATE, LAST,
+  short FIRST = Short.MAX_VALUE - 1;
+  short EARLY = Short.MAX_VALUE / 2;
+  short NORMAL = 0;
+  short LATE = Short.MIN_VALUE / 2;
+  short LAST = Short.MIN_VALUE + 1;
 
   /**
    * Previously used to specify that {@link Subscribe#priority()} should be used.
@@ -20,6 +31,56 @@ public enum PostOrder {
    * @deprecated No longer required, you only need to specify {@link Subscribe#priority()}.
    */
   @Deprecated
-  CUSTOM
+  @ApiStatus.ScheduledForRemoval(inVersion = "3.6.0")
+  short CUSTOM = 0;
+
+  /**
+   * Only for backwards compatibility.
+   *
+   * @deprecated It is necessary only for backwards compatibility. Do not use this method.
+   */
+  @Deprecated(forRemoval = true)
+  @ApiStatus.ScheduledForRemoval(inVersion = "3.6.0")
+  int priority();
+
+  /**
+   * Only for backwards compatibility.
+   *
+   * @return PostOrder values
+   * @deprecated It is necessary only for backwards compatibility. Do not use this method.
+   */
+  @Deprecated(forRemoval = true)
+  @ApiStatus.ScheduledForRemoval(inVersion = "3.6.0")
+  static PostOrder[] values() {
+    return new PostOrder[] {
+            () -> FIRST,
+            () -> EARLY,
+            () -> NORMAL,
+            () -> LATE,
+            () -> LAST,
+            () -> CUSTOM
+    };
+  }
+
+  /**
+   * Only for backwards compatibility.
+   *
+   * @param name PostOrder constant name
+   * @return PostOrder with specified name
+   * @deprecated It is necessary only for backwards compatibility. Do not use this method.
+   */
+  @Deprecated(forRemoval = true)
+  @ApiStatus.ScheduledForRemoval(inVersion = "3.6.0")
+  static PostOrder valueOf(@NotNull String name) {
+    Preconditions.checkNotNull(name, "PostOrder name cannot be null");
+    return switch (name.toUpperCase()) {
+      case "FIRST" -> () -> FIRST;
+      case "EARLY" -> () -> EARLY;
+      case "NORMAL" -> () -> NORMAL;
+      case "LAST" -> () -> LAST;
+      case "CUSTOM" -> () -> CUSTOM;
+      default -> throw new IllegalArgumentException("No PostOrder found with the name " + name);
+    };
+  }
 
 }

--- a/api/src/main/java/com/velocitypowered/api/event/Subscribe.java
+++ b/api/src/main/java/com/velocitypowered/api/event/Subscribe.java
@@ -11,6 +11,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * An annotation that indicates that this method can be used to listen for an event from the proxy.
@@ -25,8 +26,9 @@ public @interface Subscribe {
    * @deprecated specify the order using {@link #priority()} instead
    * @return the order
    */
-  @Deprecated
-  PostOrder order() default PostOrder.NORMAL;
+  @Deprecated(forRemoval = true)
+  @ApiStatus.ScheduledForRemoval(inVersion = "3.6.0")
+  short order() default PostOrder.NORMAL;
 
   /**
    * The priority of this event handler. Priorities are used to determine the order in which event
@@ -34,7 +36,7 @@ public @interface Subscribe {
    *
    * @return the priority
    */
-  short priority() default 0;
+  short priority() default PostOrder.NORMAL;
 
   /**
    * Whether the handler must be called asynchronously. By default, all event handlers are called

--- a/proxy/src/main/java/com/velocitypowered/proxy/event/VelocityEventManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/event/VelocityEventManager.java
@@ -29,7 +29,6 @@ import com.velocitypowered.api.event.Continuation;
 import com.velocitypowered.api.event.EventHandler;
 import com.velocitypowered.api.event.EventManager;
 import com.velocitypowered.api.event.EventTask;
-import com.velocitypowered.api.event.PostOrder;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.PluginDescription;
@@ -37,7 +36,6 @@ import com.velocitypowered.api.plugin.PluginManager;
 import com.velocitypowered.proxy.event.UntargetedEventHandler.EventTaskHandler;
 import com.velocitypowered.proxy.event.UntargetedEventHandler.VoidHandler;
 import com.velocitypowered.proxy.event.UntargetedEventHandler.WithContinuationHandler;
-import com.velocitypowered.proxy.util.collect.Enum2IntMap;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -73,14 +71,6 @@ import org.lanternpowered.lmbda.LambdaType;
  */
 public class VelocityEventManager implements EventManager {
 
-  private static final Enum2IntMap<PostOrder> POST_ORDER_MAP = new Enum2IntMap.Builder<>(PostOrder.class)
-      .put(PostOrder.FIRST, Short.MAX_VALUE - 1)
-      .put(PostOrder.EARLY, Short.MAX_VALUE / 2)
-      .put(PostOrder.NORMAL, 0)
-      .put(PostOrder.LATE, Short.MIN_VALUE / 2)
-      .put(PostOrder.LAST, Short.MIN_VALUE + 1)
-      .put(PostOrder.CUSTOM, 0)
-      .build();
   private static final Logger logger = LogManager.getLogger(VelocityEventManager.class);
 
   private static final MethodHandles.Lookup methodHandlesLookup = MethodHandles.lookup();
@@ -352,10 +342,10 @@ public class VelocityEventManager implements EventManager {
 
       // The default value of 0 will fall back to PostOrder, the default PostOrder (NORMAL) is also 0
       final short order;
-      if (subscribe.priority() != 0) {
+      if (subscribe.order() == 0 && subscribe.priority() != 0) {
         order = subscribe.priority();
       } else {
-        order = (short) POST_ORDER_MAP.get(subscribe.order());
+        order = subscribe.order();
       }
       final String errorsJoined = errors.isEmpty() ? null : String.join(",", errors);
       collected.put(key, new MethodHandlerInfo(method, asyncType, eventType, order, errorsJoined,
@@ -391,18 +381,6 @@ public class VelocityEventManager implements EventManager {
       throw new IllegalArgumentException("The plugin main instance is automatically registered.");
     }
     registerInternally(pluginContainer, listener);
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public <E> void register(final Object plugin, final Class<E> eventClass,
-      final PostOrder order, final EventHandler<E> handler) {
-    if (order == PostOrder.CUSTOM) {
-      throw new IllegalArgumentException(
-          "This method does not support custom post orders. Use the overload with short instead."
-      );
-    }
-    register(plugin, eventClass, (short) POST_ORDER_MAP.get(order), handler, AsyncType.ALWAYS);
   }
 
   @Override


### PR DESCRIPTION
In this request, I propose to improve the event priority API. This will allow most users not to get confused in the API changes that was introduced in 2024 and after the changes that were merged: #1491 

In addition to the current changes, I have two more options for fixing the situation with the event order API:

> Create an `EventPriority` class similar to my current `PostOrder` version and return `PostOrder` to the enum type.

**OR**

> Deprecate and then remove the `Subscribe#priority` method and reuse the `Subscribe#order` method.

Perhaps I am not entirely clear why the `Subscribe#order` method was left unchanged and received the deprecated status.

Looking forward to your feedback!