### PR TITLE
feat: implement command rate limiter

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -61,6 +61,7 @@ tasks {
         o.encoding = "UTF-8"
         o.source = "17"
 
+        o.use()
         o.links(
             "https://www.slf4j.org/apidocs/",
             "https://guava.dev/releases/${libs.guava.get().version}/api/docs/",

--- a/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
@@ -164,7 +164,7 @@ public interface ProxyConfig {
   boolean isCancelCommandsIfRateLimited();
 
   /**
-   * Get the rate limit for commands that are rate limited.
+   * Get the kick limit for commands that are rate limited.
    * If this limit is 0 or less, the player will be not be kicked.
    *
    * @return the rate limited command rate limit
@@ -178,5 +178,29 @@ public interface ProxyConfig {
    */
   default boolean isKickOnCommandRateLimit() {
     return getKickAfterRateLimitedCommands() > 0;
+  }
+
+  /**
+   * Get the rate limit for how fast a player can tab complete.
+   *
+   * @return the tab complete rate limit (in milliseconds)
+   */
+  int getTabCompleteRatelimit();
+
+  /**
+   * Get the kick limit for tab completes that are rate limited.
+   * If this limit is 0 or less, the player will be not be kicked.
+   *
+   * @return the rate limited command rate limit
+   */
+  int getKickAfterRateLimitedTabCompletes();
+
+  /**
+   * Get whether the proxy should kick players who are tab complete rate limited.
+   *
+   * @return whether to kick players who are rate limited
+   */
+  default boolean isKickOnTabCompleteRateLimit() {
+    return getKickAfterRateLimitedTabCompletes() > 0;
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
@@ -148,4 +148,35 @@ public interface ProxyConfig {
    * @return read timeout (in milliseconds)
    */
   int getReadTimeout();
+
+  /**
+   * Get the rate limit for how fast a player can execute commands.
+   *
+   * @return the command rate limit (in milliseconds)
+   */
+  int getCommandRatelimit();
+
+  /**
+   * Get whether we should not process commands if the player is rate limited.
+   *
+   * @return whether to cancel commands if rate limited
+   */
+  boolean isCancelCommandsIfRateLimited();
+
+  /**
+   * Get the rate limit for commands that are rate limited.
+   * If this limit is 0 or less, the player will be not be kicked.
+   *
+   * @return the rate limited command rate limit
+   */
+  int getKickAfterRateLimitedCommands();
+
+  /**
+   * Get whether the proxy should kick players who are command rate limited.
+   *
+   * @return whether to kick players who are rate limited
+   */
+  default boolean isKickOnCommandRateLimit() {
+    return getKickAfterRateLimitedCommands() > 0;
+  }
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
@@ -157,11 +157,11 @@ public interface ProxyConfig {
   int getCommandRatelimit();
 
   /**
-   * Get whether we should not process commands if the player is rate limited.
+   * Get whether we should forward commands to the backend if the player is rate limited.
    *
-   * @return whether to cancel commands if rate limited
+   * @return whether to forward commands if rate limited
    */
-  boolean isCancelCommandsIfRateLimited();
+  boolean isForwardCommandsIfRateLimited();
 
   /**
    * Get the kick limit for commands that are rate limited.

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -165,6 +165,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
   private final VelocityConsole console;
   private @MonotonicNonNull Ratelimiter<InetAddress> ipAttemptLimiter;
   private @MonotonicNonNull Ratelimiter<UUID> commandRateLimiter;
+  private @MonotonicNonNull Ratelimiter<UUID> tabCompleteRateLimiter;
   private final VelocityEventManager eventManager;
   private final VelocityScheduler scheduler;
   private final VelocityChannelRegistrar channelRegistrar = new VelocityChannelRegistrar();
@@ -298,6 +299,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
 
     ipAttemptLimiter = Ratelimiters.createWithMilliseconds(configuration.getLoginRatelimit());
     commandRateLimiter = Ratelimiters.createWithMilliseconds(configuration.getCommandRatelimit());
+    tabCompleteRateLimiter = Ratelimiters.createWithMilliseconds(configuration.getTabCompleteRatelimit());
     loadPlugins();
 
     // Go ahead and fire the proxy initialization event. We block since plugins should have a chance
@@ -657,12 +659,16 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     return cm.createHttpClient();
   }
 
-  public Ratelimiter<InetAddress> getIpAttemptLimiter() {
+  public @MonotonicNonNull Ratelimiter<InetAddress> getIpAttemptLimiter() {
     return ipAttemptLimiter;
   }
 
   public @MonotonicNonNull Ratelimiter<UUID> getCommandRateLimiter() {
     return commandRateLimiter;
+  }
+
+  public @MonotonicNonNull Ratelimiter<UUID> getTabCompleteRateLimiter() {
+    return tabCompleteRateLimiter;
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -75,6 +75,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.http.HttpClient;
 import java.nio.file.Files;
@@ -162,7 +163,8 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
   private final Map<UUID, ConnectedPlayer> connectionsByUuid = new ConcurrentHashMap<>();
   private final Map<String, ConnectedPlayer> connectionsByName = new ConcurrentHashMap<>();
   private final VelocityConsole console;
-  private @MonotonicNonNull Ratelimiter ipAttemptLimiter;
+  private @MonotonicNonNull Ratelimiter<InetAddress> ipAttemptLimiter;
+  private @MonotonicNonNull Ratelimiter<UUID> commandRateLimiter;
   private final VelocityEventManager eventManager;
   private final VelocityScheduler scheduler;
   private final VelocityChannelRegistrar channelRegistrar = new VelocityChannelRegistrar();
@@ -295,6 +297,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     }
 
     ipAttemptLimiter = Ratelimiters.createWithMilliseconds(configuration.getLoginRatelimit());
+    commandRateLimiter = Ratelimiters.createWithMilliseconds(configuration.getCommandRatelimit());
     loadPlugins();
 
     // Go ahead and fire the proxy initialization event. We block since plugins should have a chance
@@ -654,8 +657,12 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     return cm.createHttpClient();
   }
 
-  public Ratelimiter getIpAttemptLimiter() {
+  public Ratelimiter<InetAddress> getIpAttemptLimiter() {
     return ipAttemptLimiter;
+  }
+
+  public @MonotonicNonNull Ratelimiter<UUID> getCommandRateLimiter() {
+    return commandRateLimiter;
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -788,11 +788,11 @@ public class VelocityConfiguration implements ProxyConfig {
         this.logPlayerConnections = config.getOrElse("log-player-connections", true);
         this.acceptTransfers = config.getOrElse("accepts-transfers", false);
         this.enableReusePort = config.getOrElse("enable-reuse-port", false);
-        this.commandRateLimit = config.getIntOrElse("command-rate-limit", 50);
+        this.commandRateLimit = config.getIntOrElse("command-rate-limit", 25);
         this.cancelCommandsIfRateLimited = config.getOrElse("cancel-commands-if-rate-limited", true);
-        this.kickAfterRateLimitedCommands = config.getIntOrElse("kick-after-rate-limited-commands", 5);
-        this.tabCompleteRateLimit = config.getIntOrElse("tab-complete-rate-limit", 25); // very lenient
-        this.kickAfterRateLimitedTabCompletes = config.getIntOrElse("kick-after-rate-limited-tab-completes", 10);
+        this.kickAfterRateLimitedCommands = config.getIntOrElse("kick-after-rate-limited-commands", 0);
+        this.tabCompleteRateLimit = config.getIntOrElse("tab-complete-rate-limit", 10); // very lenient
+        this.kickAfterRateLimitedTabCompletes = config.getIntOrElse("kick-after-rate-limited-tab-completes", 0);
       }
     }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -372,8 +372,8 @@ public class VelocityConfiguration implements ProxyConfig {
   }
 
   @Override
-  public boolean isCancelCommandsIfRateLimited() {
-    return advanced.isCancelCommandsIfRateLimited();
+  public boolean isForwardCommandsIfRateLimited() {
+    return advanced.isForwardCommandsIfRateLimited();
   }
 
   @Override
@@ -755,7 +755,7 @@ public class VelocityConfiguration implements ProxyConfig {
     @Expose
     private int commandRateLimit = 50;
     @Expose
-    private boolean cancelCommandsIfRateLimited = true;
+    private boolean forwardCommandsIfRateLimited = true;
     @Expose
     private int kickAfterRateLimitedCommands = 5;
     @Expose
@@ -789,7 +789,7 @@ public class VelocityConfiguration implements ProxyConfig {
         this.acceptTransfers = config.getOrElse("accepts-transfers", false);
         this.enableReusePort = config.getOrElse("enable-reuse-port", false);
         this.commandRateLimit = config.getIntOrElse("command-rate-limit", 25);
-        this.cancelCommandsIfRateLimited = config.getOrElse("cancel-commands-if-rate-limited", true);
+        this.forwardCommandsIfRateLimited = config.getOrElse("forward-commands-if-rate-limited", true);
         this.kickAfterRateLimitedCommands = config.getIntOrElse("kick-after-rate-limited-commands", 0);
         this.tabCompleteRateLimit = config.getIntOrElse("tab-complete-rate-limit", 10); // very lenient
         this.kickAfterRateLimitedTabCompletes = config.getIntOrElse("kick-after-rate-limited-tab-completes", 0);
@@ -864,8 +864,8 @@ public class VelocityConfiguration implements ProxyConfig {
       return commandRateLimit;
     }
 
-    public boolean isCancelCommandsIfRateLimited() {
-      return cancelCommandsIfRateLimited;
+    public boolean isForwardCommandsIfRateLimited() {
+      return forwardCommandsIfRateLimited;
     }
 
     public int getKickAfterRateLimitedCommands() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -362,6 +362,16 @@ public class VelocityConfiguration implements ProxyConfig {
   }
 
   @Override
+  public int getTabCompleteRatelimit() {
+    return advanced.getTabCompleteRateLimit();
+  }
+
+  @Override
+  public int getKickAfterRateLimitedTabCompletes() {
+    return advanced.getKickAfterRateLimitedTabCompletes();
+  }
+
+  @Override
   public boolean isCancelCommandsIfRateLimited() {
     return advanced.isCancelCommandsIfRateLimited();
   }
@@ -748,6 +758,10 @@ public class VelocityConfiguration implements ProxyConfig {
     private boolean cancelCommandsIfRateLimited = true;
     @Expose
     private int kickAfterRateLimitedCommands = 5;
+    @Expose
+    private int tabCompleteRateLimit = 50;
+    @Expose
+    private int kickAfterRateLimitedTabCompletes = 10;
 
     private Advanced() {
     }
@@ -777,6 +791,8 @@ public class VelocityConfiguration implements ProxyConfig {
         this.commandRateLimit = config.getIntOrElse("command-rate-limit", 50);
         this.cancelCommandsIfRateLimited = config.getOrElse("cancel-commands-if-rate-limited", true);
         this.kickAfterRateLimitedCommands = config.getIntOrElse("kick-after-rate-limited-commands", 5);
+        this.tabCompleteRateLimit = config.getIntOrElse("tab-complete-rate-limit", 25); // very lenient
+        this.kickAfterRateLimitedTabCompletes = config.getIntOrElse("kick-after-rate-limited-tab-completes", 10);
       }
     }
 
@@ -854,6 +870,14 @@ public class VelocityConfiguration implements ProxyConfig {
 
     public int getKickAfterRateLimitedCommands() {
       return kickAfterRateLimitedCommands;
+    }
+
+    public int getTabCompleteRateLimit() {
+      return tabCompleteRateLimit;
+    }
+
+    public int getKickAfterRateLimitedTabCompletes() {
+      return kickAfterRateLimitedTabCompletes;
     }
 
     @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -230,6 +230,11 @@ public class VelocityConfiguration implements ProxyConfig {
       valid = false;
     }
 
+    if (advanced.commandRateLimit < 0) {
+      logger.error("Invalid command rate limit {}", advanced.commandRateLimit);
+      valid = false;
+    }
+
     loadFavicon();
 
     return valid;
@@ -349,6 +354,21 @@ public class VelocityConfiguration implements ProxyConfig {
   @Override
   public int getReadTimeout() {
     return advanced.getReadTimeout();
+  }
+
+  @Override
+  public int getCommandRatelimit() {
+    return advanced.getCommandRateLimit();
+  }
+
+  @Override
+  public boolean isCancelCommandsIfRateLimited() {
+    return advanced.isCancelCommandsIfRateLimited();
+  }
+
+  @Override
+  public int getKickAfterRateLimitedCommands() {
+    return advanced.getKickAfterRateLimitedCommands();
   }
 
   public boolean isProxyProtocol() {
@@ -722,6 +742,12 @@ public class VelocityConfiguration implements ProxyConfig {
     private boolean acceptTransfers = false;
     @Expose
     private boolean enableReusePort = false;
+    @Expose
+    private int commandRateLimit = 50;
+    @Expose
+    private boolean cancelCommandsIfRateLimited = true;
+    @Expose
+    private int kickAfterRateLimitedCommands = 5;
 
     private Advanced() {
     }
@@ -748,6 +774,9 @@ public class VelocityConfiguration implements ProxyConfig {
         this.logPlayerConnections = config.getOrElse("log-player-connections", true);
         this.acceptTransfers = config.getOrElse("accepts-transfers", false);
         this.enableReusePort = config.getOrElse("enable-reuse-port", false);
+        this.commandRateLimit = config.getIntOrElse("command-rate-limit", 50);
+        this.cancelCommandsIfRateLimited = config.getOrElse("cancel-commands-if-rate-limited", true);
+        this.kickAfterRateLimitedCommands = config.getIntOrElse("kick-after-rate-limited-commands", 5);
       }
     }
 
@@ -813,6 +842,18 @@ public class VelocityConfiguration implements ProxyConfig {
 
     public boolean isEnableReusePort() {
       return enableReusePort;
+    }
+
+    public int getCommandRateLimit() {
+      return commandRateLimit;
+    }
+
+    public boolean isCancelCommandsIfRateLimited() {
+      return cancelCommandsIfRateLimited;
+    }
+
+    public int getKickAfterRateLimitedCommands() {
+      return kickAfterRateLimitedCommands;
     }
 
     @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -113,6 +113,8 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
 
   private CompletableFuture<Void> configSwitchFuture;
 
+  private int failedTabCompleteAttempts;
+
   /**
    * Constructs a client play session handler.
    *
@@ -661,6 +663,15 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
         outstandingTabComplete = packet;
       }
       return false;
+    }
+
+    if (!server.getTabCompleteRateLimiter().attempt(player.getUniqueId())) {
+      if (server.getConfiguration().isKickOnTabCompleteRateLimit()
+              && failedTabCompleteAttempts++ >= server.getConfiguration().getKickAfterRateLimitedTabCompletes()) {
+        player.disconnect(Component.text("You are sending tab completes too quickly."));
+      }
+
+      return true;
     }
 
     server.getCommandManager().offerBrigadierSuggestions(player, command)

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -668,7 +668,7 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
     if (!server.getTabCompleteRateLimiter().attempt(player.getUniqueId())) {
       if (server.getConfiguration().isKickOnTabCompleteRateLimit()
               && failedTabCompleteAttempts++ >= server.getConfiguration().getKickAfterRateLimitedTabCompletes()) {
-        player.disconnect(Component.text("You are sending tab completes too quickly."));
+        player.disconnect(Component.translatable("velocity.kick.tab-complete-rate-limit"));
       }
 
       return true;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -674,6 +674,8 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
       return true;
     }
 
+    failedTabCompleteAttempts = 0;
+
     server.getCommandManager().offerBrigadierSuggestions(player, command)
         .thenAcceptAsync(suggestions -> {
           if (suggestions.isEmpty()) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
@@ -52,6 +52,9 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
   protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
     int claimedUncompressedSize = ProtocolUtils.readVarInt(in);
     if (claimedUncompressedSize == 0) {
+      int actualUncompressedSize = in.readableBytes();
+      checkFrame(actualUncompressedSize < threshold, "Actual uncompressed size %s is greater than"
+              + " threshold %s", actualUncompressedSize, threshold);
       // This message is not compressed.
       out.add(in.retain());
       return;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
@@ -41,7 +41,7 @@ public abstract class RateLimitedCommandHandler<T extends MinecraftPacket> imple
                 failedAttempts++;
                 if (velocityServer.getConfiguration().isKickOnCommandRateLimit()
                         && failedAttempts >= velocityServer.getConfiguration().getKickAfterRateLimitedCommands()) {
-                    player.disconnect(Component.text("You are sending commands too quickly."));
+                    player.disconnect(Component.translatable("velocity.kick.command-rate-limit"));
                 }
 
                 if (velocityServer.getConfiguration().isCancelCommandsIfRateLimited()) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
@@ -38,8 +38,7 @@ public abstract class RateLimitedCommandHandler<T extends MinecraftPacket> imple
     public boolean handlePlayerCommand(MinecraftPacket packet) {
         if (packetClass().isInstance(packet)) {
             if (!velocityServer.getCommandRateLimiter().attempt(player.getUniqueId())) {
-                failedAttempts++;
-                if (failedAttempts >= velocityServer.getConfiguration().getKickAfterRateLimitedCommands()) {
+                if (failedAttempts++ >= velocityServer.getConfiguration().getKickAfterRateLimitedCommands()) {
                     player.disconnect(Component.translatable("velocity.kick.command-rate-limit"));
                 }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.protocol.packet.chat;
+
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.proxy.VelocityServer;
+import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import net.kyori.adventure.text.Component;
+
+public abstract class RateLimitedCommandHandler<T extends MinecraftPacket> implements CommandHandler<T> {
+
+    private final Player player;
+    private final VelocityServer velocityServer;
+
+    private int failedAttempts;
+
+    protected RateLimitedCommandHandler(Player player, VelocityServer velocityServer) {
+        this.player = player;
+        this.velocityServer = velocityServer;
+    }
+
+    @Override
+    public boolean handlePlayerCommand(MinecraftPacket packet) {
+        if (packetClass().isInstance(packet)) {
+            if (!velocityServer.getCommandRateLimiter().attempt(player.getUniqueId())) {
+                failedAttempts++;
+                if (velocityServer.getConfiguration().isKickOnCommandRateLimit()
+                        && failedAttempts >= velocityServer.getConfiguration().getKickAfterRateLimitedCommands()) {
+                    player.disconnect(Component.text("You are sending commands too quickly."));
+                }
+
+                if (velocityServer.getConfiguration().isCancelCommandsIfRateLimited()) {
+                    return true;
+                }
+            } else {
+                failedAttempts = 0;
+            }
+
+            handlePlayerCommandInternal(packetClass().cast(packet));
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
@@ -39,13 +39,12 @@ public abstract class RateLimitedCommandHandler<T extends MinecraftPacket> imple
         if (packetClass().isInstance(packet)) {
             if (!velocityServer.getCommandRateLimiter().attempt(player.getUniqueId())) {
                 failedAttempts++;
-                if (velocityServer.getConfiguration().isKickOnCommandRateLimit()
-                        && failedAttempts >= velocityServer.getConfiguration().getKickAfterRateLimitedCommands()) {
+                if (failedAttempts >= velocityServer.getConfiguration().getKickAfterRateLimitedCommands()) {
                     player.disconnect(Component.translatable("velocity.kick.command-rate-limit"));
                 }
 
                 if (velocityServer.getConfiguration().isCancelCommandsIfRateLimited()) {
-                    return true;
+                    return false; // Send the packet to the server
                 }
             } else {
                 failedAttempts = 0;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
@@ -43,7 +43,7 @@ public abstract class RateLimitedCommandHandler<T extends MinecraftPacket> imple
                     player.disconnect(Component.translatable("velocity.kick.command-rate-limit"));
                 }
 
-                if (velocityServer.getConfiguration().isCancelCommandsIfRateLimited()) {
+                if (velocityServer.getConfiguration().isForwardCommandsIfRateLimited()) {
                     return false; // Send the packet to the server
                 }
             } else {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedCommandHandler.java
@@ -21,17 +21,18 @@ import com.velocitypowered.api.event.command.CommandExecuteEvent;
 import com.velocitypowered.api.proxy.crypto.IdentifiedKey;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
-import com.velocitypowered.proxy.protocol.packet.chat.CommandHandler;
+import com.velocitypowered.proxy.protocol.packet.chat.RateLimitedCommandHandler;
 import com.velocitypowered.proxy.protocol.packet.chat.builder.ChatBuilderV2;
 import java.util.concurrent.CompletableFuture;
 import net.kyori.adventure.text.Component;
 
-public class KeyedCommandHandler implements CommandHandler<KeyedPlayerCommandPacket> {
+public class KeyedCommandHandler extends RateLimitedCommandHandler<KeyedPlayerCommandPacket> {
 
   private final ConnectedPlayer player;
   private final VelocityServer server;
 
   public KeyedCommandHandler(ConnectedPlayer player, VelocityServer server) {
+    super(player, server);
     this.player = player;
     this.server = server;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyCommandHandler.java
@@ -20,16 +20,18 @@ package com.velocitypowered.proxy.protocol.packet.chat.legacy;
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
-import com.velocitypowered.proxy.protocol.packet.chat.CommandHandler;
+import com.velocitypowered.proxy.protocol.packet.chat.RateLimitedCommandHandler;
+
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 
-public class LegacyCommandHandler implements CommandHandler<LegacyChatPacket> {
+public class LegacyCommandHandler extends RateLimitedCommandHandler<LegacyChatPacket> {
 
   private final ConnectedPlayer player;
   private final VelocityServer server;
 
   public LegacyCommandHandler(ConnectedPlayer player, VelocityServer server) {
+    super(player, server);
     this.player = player;
     this.server = server;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
@@ -22,17 +22,19 @@ import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ChatAcknowledgementPacket;
-import com.velocitypowered.proxy.protocol.packet.chat.CommandHandler;
 import java.util.concurrent.CompletableFuture;
+
+import com.velocitypowered.proxy.protocol.packet.chat.RateLimitedCommandHandler;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class SessionCommandHandler implements CommandHandler<SessionPlayerCommandPacket> {
+public class SessionCommandHandler extends RateLimitedCommandHandler<SessionPlayerCommandPacket> {
 
   private final ConnectedPlayer player;
   private final VelocityServer server;
 
   public SessionCommandHandler(ConnectedPlayer player, VelocityServer server) {
+    super(player, server);
     this.player = player;
     this.server = server;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/CaffeineCacheRatelimiter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/CaffeineCacheRatelimiter.java
@@ -22,15 +22,15 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import java.net.InetAddress;
 import java.util.concurrent.TimeUnit;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A simple rate-limiter based on a Caffeine {@link Cache}.
  */
-public class CaffeineCacheRatelimiter implements Ratelimiter {
+public class CaffeineCacheRatelimiter<T> implements Ratelimiter<T> {
 
-  private final Cache<InetAddress, Long> expiringCache;
+  private final Cache<T, Long> expiringCache;
   private final long timeoutNanos;
 
   CaffeineCacheRatelimiter(long time, TimeUnit unit) {
@@ -49,16 +49,15 @@ public class CaffeineCacheRatelimiter implements Ratelimiter {
   }
 
   /**
-   * Attempts to rate-limit the client.
+   * Attempts to rate-limit the object.
    *
-   * @param address the address to rate limit
-   * @return true if we should allow the client, false if we should rate-limit
+   * @param key the object to rate limit
+   * @return true if we should allow the object, false if we should rate-limit
    */
   @Override
-  public boolean attempt(InetAddress address) {
-    Preconditions.checkNotNull(address, "address");
+  public boolean attempt(@NotNull  T key) {
     long expectedNewValue = System.nanoTime() + timeoutNanos;
-    long last = expiringCache.get(address, (address1) -> expectedNewValue);
+    long last = expiringCache.get(key, (key1) -> expectedNewValue);
     return expectedNewValue == last;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/NoopCacheRatelimiter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/NoopCacheRatelimiter.java
@@ -17,16 +17,16 @@
 
 package com.velocitypowered.proxy.util.ratelimit;
 
-import java.net.InetAddress;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A {@link Ratelimiter} that does no rate-limiting.
  */
-enum NoopCacheRatelimiter implements Ratelimiter {
+enum NoopCacheRatelimiter implements Ratelimiter<Object> {
   INSTANCE;
 
   @Override
-  public boolean attempt(InetAddress address) {
+  public boolean attempt(@NotNull Object key) {
     return true;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/Ratelimiter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/Ratelimiter.java
@@ -17,18 +17,18 @@
 
 package com.velocitypowered.proxy.util.ratelimit;
 
-import java.net.InetAddress;
+import org.jetbrains.annotations.NotNull;
 
 /**
- * Allows rate limiting of clients.
+ * Allows rate limiting of objects.
  */
-public interface Ratelimiter {
+public interface Ratelimiter<T> {
 
   /**
-   * Determines whether or not to allow the connection.
-   *
-   * @param address the address to rate limit
-   * @return true if allowed, false if not
-   */
-  boolean attempt(InetAddress address);
+  * Attempts to rate-limit the object.
+  *
+  * @param key the object to rate limit
+  * @return true if we should allow the object, false if we should rate-limit
+  */
+  boolean attempt(@NotNull T key);
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/Ratelimiters.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/Ratelimiters.java
@@ -28,8 +28,9 @@ public final class Ratelimiters {
     throw new AssertionError();
   }
 
-  public static Ratelimiter createWithMilliseconds(long ms) {
-    return ms <= 0 ? NoopCacheRatelimiter.INSTANCE : new CaffeineCacheRatelimiter(ms,
+  @SuppressWarnings("unchecked")
+  public static <T> Ratelimiter<T> createWithMilliseconds(long ms) {
+    return ms <= 0 ? (Ratelimiter<T>) NoopCacheRatelimiter.INSTANCE : new CaffeineCacheRatelimiter(ms,
         TimeUnit.MILLISECONDS);
   }
 }

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
@@ -63,3 +63,5 @@ velocity.command.dump-offline=Likely cause: Invalid system DNS settings or no in
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy shutting down.
+velocity.kick.command-rate-limit=You are sending too many commands too quickly.
+velocity.kick.tab-complete-rate-limit=You are sending too many tab complete requests too quickly.

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -156,6 +156,9 @@ enable-reuse-port = false
 command-rate-limit = 50
 
 # Should we no longer accept commands from a player if they are rate limited?
+# This will forward the command to the server instead of processing it on the proxy.
+# Since most server implementations have a rate limit, this will prevent the player
+# from being able to send excessive commands to the server.
 cancel-commands-if-rate-limited = true
 
 # How many commands are allowed to be sent after the rate limit is hit before the player is kicked?

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -153,7 +153,7 @@ enable-reuse-port = false
 
 # How fast (in milliseconds) are clients allowed to send commands after the last command
 # By default this is 50ms (20 commands per second)
-command-rate-limit = 50
+command-rate-limit = 25
 
 # Should we no longer accept commands from a player if they are rate limited?
 # This will forward the command to the server instead of processing it on the proxy.
@@ -163,14 +163,14 @@ cancel-commands-if-rate-limited = true
 
 # How many commands are allowed to be sent after the rate limit is hit before the player is kicked?
 # Setting this to 0 or lower will disable this feature.
-kick-after-rate-limited-commands = 5
+kick-after-rate-limited-commands = 0
 
 # How fast (in milliseconds) are clients allowed to send tab completions after the last tab completion
-tab-complete-rate-limit = 25
+tab-complete-rate-limit = 10
 
 # How many tab completions are allowed to be sent after the rate limit is hit before the player is kicked?
 # Setting this to 0 or lower will disable this feature.
-kick-after-rate-limited-tab-completes = 5
+kick-after-rate-limited-tab-completes = 0
 
 [query]
 # Whether to enable responding to GameSpy 4 query responses or not.

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -155,11 +155,11 @@ enable-reuse-port = false
 # By default this is 50ms (20 commands per second)
 command-rate-limit = 25
 
-# Should we no longer accept commands from a player if they are rate limited?
+# Should we forward commands to the backend upon being rate limited?
 # This will forward the command to the server instead of processing it on the proxy.
 # Since most server implementations have a rate limit, this will prevent the player
 # from being able to send excessive commands to the server.
-cancel-commands-if-rate-limited = true
+forward-commands-if-rate-limited = true
 
 # How many commands are allowed to be sent after the rate limit is hit before the player is kicked?
 # Setting this to 0 or lower will disable this feature.

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -162,6 +162,13 @@ cancel-commands-if-rate-limited = true
 # Setting this to 0 or lower will disable this feature.
 kick-after-rate-limited-commands = 5
 
+# How fast (in milliseconds) are clients allowed to send tab completions after the last tab completion
+tab-complete-rate-limit = 25
+
+# How many tab completions are allowed to be sent after the rate limit is hit before the player is kicked?
+# Setting this to 0 or lower will disable this feature.
+kick-after-rate-limited-tab-completes = 5
+
 [query]
 # Whether to enable responding to GameSpy 4 query responses or not.
 enabled = false

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -151,6 +151,17 @@ accepts-transfers = false
 # threads. Disabled by default. Requires Linux or macOS.
 enable-reuse-port = false
 
+# How fast (in milliseconds) are clients allowed to send commands after the last command
+# By default this is 50ms (20 commands per second)
+command-rate-limit = 50
+
+# Should we no longer accept commands from a player if they are rate limited?
+cancel-commands-if-rate-limited = true
+
+# How many commands are allowed to be sent after the rate limit is hit before the player is kicked?
+# Setting this to 0 or lower will disable this feature.
+kick-after-rate-limited-commands = 5
+
 [query]
 # Whether to enable responding to GameSpy 4 query responses or not.
 enabled = false


### PR DESCRIPTION
Velocity proxies can still be crashed with any other commands besides `/velocity info`. A proper fix for this is to rate limit the frequency of which a client can send commands to the server. Currently there is none.