### PR TITLE
Enable use tab in javadocs

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -61,6 +61,7 @@ tasks {
         o.encoding = "UTF-8"
         o.source = "17"
 
+        o.use()
         o.links(
             "https://www.slf4j.org/apidocs/",
             "https://guava.dev/releases/${libs.guava.get().version}/api/docs/",


### PR DESCRIPTION
Adds the use tab to the javadocs, making it easier to find usages of packages/classes. It uses ~1.5mb of extra disk space which is nothing