### PR TITLE
Validate uncompressed packet size

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
@@ -52,6 +52,8 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
   protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
     int claimedUncompressedSize = ProtocolUtils.readVarInt(in);
     if (claimedUncompressedSize == 0) {
+      checkFrame(in.readableBytes() < threshold, "Actual uncompressed size %s is greater than"
+              + " threshold %s", claimedUncompressedSize, threshold);
       // This message is not compressed.
       out.add(in.retain());
       return;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java
@@ -52,8 +52,9 @@ public class MinecraftCompressDecoder extends MessageToMessageDecoder<ByteBuf> {
   protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
     int claimedUncompressedSize = ProtocolUtils.readVarInt(in);
     if (claimedUncompressedSize == 0) {
-      checkFrame(in.readableBytes() < threshold, "Actual uncompressed size %s is greater than"
-              + " threshold %s", claimedUncompressedSize, threshold);
+      int actualUncompressedSize = in.readableBytes();
+      checkFrame(actualUncompressedSize < threshold, "Actual uncompressed size %s is greater than"
+              + " threshold %s", actualUncompressedSize, threshold);
       // This message is not compressed.
       out.add(in.retain());
       return;


### PR DESCRIPTION
In Minecraft, the client never sends a claimed uncompressed packet size of 0 if the actual size of the packet exceeds the compression threshold. In Velocity, there is no check to confirm that packets are the size they claim to be.

While this is not a huge vulnerability, it can be used to force Velocity to skip packets during compression, therefore potentially allowing people to send arbitrarily large packets.

For reference, this is the decompiled code of MCP for 1.19.2 and 1.21.4 (it's the same for all other version as well):
![image](https://github.com/user-attachments/assets/f45694f8-3ef3-4f30-a072-4847e8f94f91)
![image](https://github.com/user-attachments/assets/03e27f79-c5cb-4a8d-a7e9-45b6f4edb64a)

As you can see, the client uses the actual packet size to determine whether to compress the packet or not. Velocity simply relies on the `claimedUncompressedSize`, which can simply be set to `0` to skip the entire compression process.
https://github.com/PaperMC/Velocity/blob/c9aa1cca09313b71ead6309ecd85b59867df4183/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftCompressDecoder.java#L53-L58