### PR TITLE
fix: server link's custom labels not being translated

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1101,8 +1101,14 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       throw new IllegalStateException("Can only send server links in CONFIGURATION or PLAY protocol");
     }
 
-    connection.write(new ClientboundServerLinksPacket(List.copyOf(links).stream()
-        .map(l -> new ClientboundServerLinksPacket.ServerLink(l, getProtocolVersion())).toList()));
+    connection.write(new ClientboundServerLinksPacket(links.stream()
+        .map(l -> new ClientboundServerLinksPacket.ServerLink(
+            l.getBuiltInType().map(Enum::ordinal).orElse(-1),
+            l.getCustomLabel()
+                .map(c -> new ComponentHolder(getProtocolVersion(), translateMessage(c)))
+                .orElse(null),
+            l.getUrl().toString()))
+        .toList()));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/ClientboundServerLinksPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/ClientboundServerLinksPacket.java
@@ -68,12 +68,6 @@ public class ClientboundServerLinksPacket implements MinecraftPacket {
 
     public record ServerLink(int id, ComponentHolder displayName, String url) {
 
-        public ServerLink(com.velocitypowered.api.util.ServerLink link, ProtocolVersion protocolVersion) {
-            this(link.getBuiltInType().map(Enum::ordinal).orElse(-1),
-                link.getCustomLabel().map(c -> new ComponentHolder(protocolVersion, c)).orElse(null),
-                link.getUrl().toString());
-        }
-
         private static ServerLink read(ByteBuf buf, ProtocolVersion version) {
             if (buf.readBoolean()) {
                 return new ServerLink(ProtocolUtils.readVarInt(buf), null, ProtocolUtils.readString(buf));


### PR DESCRIPTION
Fixes: #1483

move api ServerLink > packet ServerLink conversion up into the ConnectedPlayer