### PR TITLE
Fix MinecraftChannelIdentifier parsing to align with vanilla

### DIFF
--- a/api/src/test/java/com/velocitypowered/api/proxy/messages/MinecraftChannelIdentifierTest.java
+++ b/api/src/test/java/com/velocitypowered/api/proxy/messages/MinecraftChannelIdentifierTest.java
@@ -48,16 +48,24 @@ class MinecraftChannelIdentifierTest {
   }
 
   @Test
+  void fromIdentifierDefaultNamespace() {
+    assertEquals("minecraft", from("test").getNamespace());
+    assertEquals("minecraft", from(":test").getNamespace());
+  }
+
+  @Test
+  void fromIdentifierAllowsEmptyName() {
+    from("minecraft:");
+    from(":");
+    from("");
+  }
+
+  @Test
   void fromIdentifierThrowsOnBadValues() {
     assertAll(
-        () -> assertThrows(IllegalArgumentException.class, () -> from("")),
-        () -> assertThrows(IllegalArgumentException.class, () -> from(":")),
-        () -> assertThrows(IllegalArgumentException.class, () -> from(":a")),
-        () -> assertThrows(IllegalArgumentException.class, () -> from("a:")),
         () -> assertThrows(IllegalArgumentException.class, () -> from("hello:$$$$$$")),
+        () -> assertThrows(IllegalArgumentException.class, () -> from("he/llo:wor/ld")),
         () -> assertThrows(IllegalArgumentException.class, () -> from("hello::"))
     );
   }
-
-
 }


### PR DESCRIPTION
As of 163a85a46834dbe5075c1e77fa838c71b57a59e2, Velocity will attempt to parse all custom payload channels registered/unregistered by clients and kick the client if it appears to be "invalid".
Because of this change, some minor differences between vanilla's `ResourceLocation` and Velocity's `MinecraftChannelIdentifier` caused players using certain mods to be kicked on login.

This PR fixes the parsing of `MinecraftChannelIdentifier` to match vanilla.