### PR TITLE
Add "/velocity:help" command.

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -40,6 +40,7 @@ import com.velocitypowered.api.util.GameProfile;
 import com.velocitypowered.api.util.ProxyVersion;
 import com.velocitypowered.proxy.command.VelocityCommandManager;
 import com.velocitypowered.proxy.command.builtin.CallbackCommand;
+import com.velocitypowered.proxy.command.builtin.HelpCommand;
 import com.velocitypowered.proxy.command.builtin.GlistCommand;
 import com.velocitypowered.proxy.command.builtin.SendCommand;
 import com.velocitypowered.proxy.command.builtin.ServerCommand;
@@ -267,6 +268,13 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
             .plugin(VelocityVirtualPlugin.INSTANCE)
             .build(),
         callbackCommand
+    );
+    final BrigadierCommand helpCommand = HelpCommand.create();
+    commandManager.register(
+            commandManager.metaBuilder(helpCommand)
+                    .plugin(VelocityVirtualPlugin.INSTANCE)
+                    .build(),
+            helpCommand
     );
     final BrigadierCommand serverCommand = ServerCommand.create(this);
     commandManager.register(

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/HelpCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/HelpCommand.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020-2023 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.command.builtin;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.velocitypowered.api.command.BrigadierCommand;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.permission.Tristate;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+/**
+ * Create class for command.
+ */
+public final class HelpCommand {
+
+  public HelpCommand() {
+  }
+
+  /**
+     * Creates a Velocity Help Command.
+     */
+  public static BrigadierCommand create() {
+    return new BrigadierCommand(LiteralArgumentBuilder.<CommandSource>literal("velocity:help")
+            .requires(source ->
+                    source.getPermissionValue("velocity.command.help") == Tristate.TRUE)
+                .executes(context -> {
+                  final CommandSource source = context.getSource();
+                  source.sendMessage(
+                          Component.translatable("velocity.command.help.title", NamedTextColor.WHITE));
+                  source.sendMessage(
+                          Component.translatable("velocity.command.help.end", NamedTextColor.WHITE));
+                  source.sendMessage(
+                          Component.translatable("velocity.command.help.glist", NamedTextColor.WHITE));
+                  source.sendMessage(
+                          Component.translatable("velocity.command.send-usage", NamedTextColor.WHITE));
+                  source.sendMessage(
+                          Component.translatable("velocity.command.help.server", NamedTextColor.WHITE));
+                  source.sendMessage(
+                          Component.translatable("velocity.command.help.shutdown", NamedTextColor.WHITE));
+                  source.sendMessage(
+                          Component.translatable("velocity.command.help.stop", NamedTextColor.WHITE));
+                  source.sendMessage(
+                          Component.translatable("velocity.command.help.velocity", NamedTextColor.WHITE));
+                  source.sendMessage(
+                          Component.translatable("velocity.command.help.velocity-callback", NamedTextColor.WHITE));
+                  source.sendMessage(
+                          Component.translatable("velocity.command.help.help", NamedTextColor.WHITE));
+                  return Command.SINGLE_SUCCESS;
+                }));
+  }
+}

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
@@ -61,6 +61,15 @@ velocity.command.dump-will-expire=This link will expire in a few days.
 velocity.command.dump-server-error=An error occurred on the Velocity servers and the dump could not be completed. Please contact the Velocity staff about this problem and provide the details about this error from the Velocity console or server log.
 velocity.command.dump-offline=Likely cause: Invalid system DNS settings or no internet connection
 velocity.command.send-usage=/send <player> <server>
+velocity.command.help.title=Velocity commands:
+velocity.command.help.end=/end
+velocity.command.help.glist=/glist <[server]/all>
+velocity.command.help.help=/velocity:help
+velocity.command.help.server=/server <server>
+velocity.command.help.shutdown=/shutdown
+velocity.command.help.stop=/stop
+velocity.command.help.velocity=/velocity <dump/heap/info/plugins/reload>
+velocity.command.help.velocity-callback=/velocity:callback
 # Kick
 velocity.kick.shutdown=Proxy shutting down.
 velocity.kick.command-rate-limit=You are sending too many commands too quickly.


### PR DESCRIPTION
I would like to suggest the addition of a "/velocity:help" command. This can be used to list the syntax for commands that are built into Velocity, such as "/server" and "/velocity".