### PR TITLE
feat: flexible authentication

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/connection/AuthAttemptEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/connection/AuthAttemptEvent.java
@@ -1,0 +1,127 @@
+package com.velocitypowered.api.event.connection;
+
+import com.velocitypowered.api.event.ResultedEvent;
+import com.velocitypowered.api.event.player.GameProfileRequestEvent;
+import com.velocitypowered.api.proxy.InboundConnection;
+import com.velocitypowered.api.util.GameProfile;
+import net.kyori.adventure.text.Component;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * <p>This event is fired when a player attempts to authenticate with the proxy, regardless of whether
+ * the connection is online-mode or offline-mode. The proxy implementation will provide a default
+ * authentication mechanism (using the Mojang session server), but plugins can subscribe to this
+ * event to implement custom authentication logic.</p>
+ *
+ * <p>If the connection is {@linkplain AuthAttemptEvent#isOnlineMode() online-mode}, the
+ * {@linkplain AuthAttemptEvent#getSharedSecret() shared secret} will always be present, as encryption
+ * is always enabled in online-mode. However, in offline-mode, encryption may or may not be enabled
+ * (configurable in proxy config file), and thus the shared secret may be {@code null}.</p>
+ *
+ * <p>If the result of this event is {@code null}, online-mode connections will assume failure, but
+ * offline-mode connections will assume success. The default authentication mechanism will not
+ * provide a result for offline-mode connections.</p>
+ *
+ * <p>Note that a successful result from this event does not necessarily determine the player
+ * profile, as plugins may override this using {@link GameProfileRequestEvent}.</p>
+ */
+public final class AuthAttemptEvent implements ResultedEvent<AuthAttemptEvent.AuthResult> {
+
+  private final @NonNull InboundConnection connection;
+  private final boolean onlineMode;
+  private final byte @Nullable [] sharedSecret;
+  private final @NonNull String attemptedUsername;
+
+  private @Nullable AuthResult result;
+
+  /**
+   * Constructs a new authentication attempt event.
+   *
+   * @param connection the inbound connection attempting to authenticate
+   * @param onlineMode whether the connection is in online-mode
+   * @param sharedSecret the shared secret for online-mode connections, or {@code null} for offline-mode
+   * @param attemptedUsername the username that the player is attempting to authenticate with
+   */
+  public AuthAttemptEvent(@NonNull InboundConnection connection, boolean onlineMode,
+                          byte @Nullable [] sharedSecret, @NonNull String attemptedUsername) {
+    this.connection = connection;
+    this.onlineMode = onlineMode;
+    this.sharedSecret = sharedSecret;
+    this.attemptedUsername = attemptedUsername;
+  }
+
+  /**
+   * Gets the inbound connection that is attempting to authenticate.
+   *
+   * @return the inbound connection
+   */
+  public @NonNull InboundConnection getConnection() {
+    return connection;
+  }
+
+  /**
+   * Gets if the connection is in online-mode.
+   *
+   * @return {@code true} if the connection is in online-mode, {@code false} otherwise
+   */
+  public boolean isOnlineMode() {
+    return onlineMode;
+  }
+
+  /**
+   * Gets the shared secret for online-mode connections, or {@code null} for offline-mode connections.
+   *
+   * @return the shared secret, or {@code null} if not applicable
+   */
+  public byte @Nullable [] getSharedSecret() {
+    return sharedSecret;
+  }
+
+  /**
+   * Gets the username that the player is attempting to authenticate with.
+   *
+   * @return the attempted username
+   */
+  public @NonNull String getAttemptedUsername() {
+    return attemptedUsername;
+  }
+
+  /**
+   * Gets the result of the authentication attempt.
+   *
+   * @return the authentication result, or {@code null} if not set
+   */
+  @Override
+  public @Nullable AuthResult getResult() {
+    return result;
+  }
+
+  /**
+   * Sets the result of the authentication attempt.
+   *
+   * @param result the authentication result, or {@code null} to indicate no result
+   */
+  @Override
+  public void setResult(@Nullable AuthResult result) {
+    this.result = result;
+  }
+
+  public sealed interface AuthResult extends Result permits SuccessResult, FailureResult {
+  }
+
+  public record SuccessResult(@NonNull GameProfile profile) implements AuthResult {
+    @Override
+    public boolean isAllowed() {
+      return true;
+    }
+  }
+
+  public record FailureResult(@NonNull Component reason) implements AuthResult {
+    @Override
+    public boolean isAllowed() {
+      return false;
+    }
+  }
+
+}

--- a/api/src/main/java/com/velocitypowered/api/event/connection/AuthAttemptEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/connection/AuthAttemptEvent.java
@@ -107,9 +107,15 @@ public final class AuthAttemptEvent implements ResultedEvent<AuthAttemptEvent.Au
     this.result = result;
   }
 
+  /**
+   * Interface representing the result of an authentication attempt.
+   */
   public sealed interface AuthResult extends Result permits SuccessResult, FailureResult {
   }
 
+  /**
+   * Represents a successful authentication result, containing the player's profile.
+   */
   public record SuccessResult(@NonNull GameProfile profile) implements AuthResult {
     @Override
     public boolean isAllowed() {
@@ -117,6 +123,9 @@ public final class AuthAttemptEvent implements ResultedEvent<AuthAttemptEvent.Au
     }
   }
 
+  /**
+   * Represents a failed authentication result, containing a reason for the failure.
+   */
   public record FailureResult(@NonNull Component reason) implements AuthResult {
     @Override
     public boolean isAllowed() {

--- a/api/src/main/java/com/velocitypowered/api/event/connection/AuthAttemptEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/connection/AuthAttemptEvent.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2025 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
 package com.velocitypowered.api.event.connection;
 
 import com.velocitypowered.api.event.ResultedEvent;

--- a/api/src/main/java/com/velocitypowered/api/event/connection/PreLoginEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/connection/PreLoginEvent.java
@@ -36,7 +36,7 @@ public final class PreLoginEvent implements ResultedEvent<PreLoginEvent.PreLogin
   private final String username;
   private final @Nullable UUID uuid;
   private PreLoginComponentResult result;
-  private boolean attemptEncryption;
+  private boolean offlineEncryption;
 
   /**
    * Creates a new instance, without an associated UUID.
@@ -71,12 +71,12 @@ public final class PreLoginEvent implements ResultedEvent<PreLoginEvent.PreLogin
    * @param uuid the player's uuid, if known
    */
   public PreLoginEvent(final InboundConnection connection, final String username, final @Nullable UUID uuid,
-                       boolean attemptEncryption) {
+                       boolean offlineEncryption) {
     this.connection = Preconditions.checkNotNull(connection, "connection");
     this.username = Preconditions.checkNotNull(username, "username");
     this.uuid = uuid;
     this.result = PreLoginComponentResult.allowed();
-    this.attemptEncryption = attemptEncryption;
+    this.offlineEncryption = offlineEncryption;
   }
 
   public InboundConnection getConnection() {
@@ -110,29 +110,28 @@ public final class PreLoginEvent implements ResultedEvent<PreLoginEvent.PreLogin
   }
 
   /**
-   * Returns whether the proxy should attempt to encrypt the connection.
-   * This is {@code true} by default, but can be set to {@code false} to skip encryption. In older
-   * game versions (earlier than 1.20.5), offline mode connections will not be encrypted,
-   * regardless of this setting, since support for encrypted offline-mode connections was added
-   * in 1.20.5.
+   * Returns whether the proxy should attempt to encrypt the connection when the player is in
+   * offline mode, {@code false} by default. In older game versions (earlier than 1.20.5), offline
+   * mode connections will not be encrypted, regardless of this setting, since support for
+   * encrypted offline-mode connections was added in 1.20.5.
    *
-   * @return whether the proxy should attempt to encrypt the connection
+   * @return whether the proxy should attempt to encrypt the connection in offline mode
    */
-  public boolean isAttemptEncryption() {
-    return attemptEncryption;
+  public boolean isOfflineEncryption() {
+    return offlineEncryption;
   }
 
   /**
-   * Sets whether the proxy should attempt to encrypt the connection.
-   * This is {@code true} by default, but can be set to {@code false} to skip encryption. In older
-   * game versions (earlier than 1.20.5), offline mode connections will not be encrypted,
-   * regardless of this setting, since support for encrypted offline-mode connections was added
-   * in 1.20.5.
+   * Sets whether the proxy should attempt to encrypt the connection when the player is in
+   * offline mode. This is {@code false} by default. In older game versions (earlier than 1.20.5),
+   * offline mode connections will not be encrypted, regardless of this setting, since support for
+   * encrypted offline-mode connections was added in 1.20.5.
    *
-   * @param attemptEncryption whether the proxy should attempt to encrypt the connection
+   * @param offlineEncryption whether the proxy should attempt to encrypt the connection in offline
+   *                          mode
    */
-  public void setAttemptEncryption(boolean attemptEncryption) {
-    this.attemptEncryption = attemptEncryption;
+  public void setOfflineEncryption(boolean offlineEncryption) {
+    this.offlineEncryption = offlineEncryption;
   }
 
   @Override
@@ -141,7 +140,7 @@ public final class PreLoginEvent implements ResultedEvent<PreLoginEvent.PreLogin
         + "connection=" + connection
         + ", username='" + username + '\''
         + ", result=" + result
-        + ", attemptEncryption=" + attemptEncryption
+        + ", attemptEncryption=" + offlineEncryption
         + '}';
   }
 

--- a/api/src/main/java/com/velocitypowered/api/event/connection/PreLoginEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/connection/PreLoginEvent.java
@@ -36,17 +36,31 @@ public final class PreLoginEvent implements ResultedEvent<PreLoginEvent.PreLogin
   private final String username;
   private final @Nullable UUID uuid;
   private PreLoginComponentResult result;
+  private boolean attemptEncryption;
 
   /**
    * Creates a new instance, without an associated UUID.
    *
    * @param connection the connection logging into the proxy
    * @param username the player's username
-   * @deprecated use {@link #PreLoginEvent(InboundConnection, String, UUID)}
+   * @deprecated use {@link #PreLoginEvent(InboundConnection, String, UUID, boolean)}
    */
   @Deprecated
   public PreLoginEvent(final InboundConnection connection, final String username) {
-    this(connection, username, null);
+    this(connection, username, null, false);
+  }
+
+  /**
+   * Creates a new instance.
+   *
+   * @param connection the connection logging into the proxy
+   * @param username the player's username
+   * @param uuid the player's uuid, if known
+   * @deprecated use {@link #PreLoginEvent(InboundConnection, String, UUID, boolean)}
+   */
+  @Deprecated
+  public PreLoginEvent(final InboundConnection connection, final String username, final @Nullable UUID uuid) {
+    this(connection, username, uuid, false);
   }
 
   /**
@@ -56,11 +70,13 @@ public final class PreLoginEvent implements ResultedEvent<PreLoginEvent.PreLogin
    * @param username the player's username
    * @param uuid the player's uuid, if known
    */
-  public PreLoginEvent(final InboundConnection connection, final String username, final @Nullable UUID uuid) {
+  public PreLoginEvent(final InboundConnection connection, final String username, final @Nullable UUID uuid,
+                       boolean attemptEncryption) {
     this.connection = Preconditions.checkNotNull(connection, "connection");
     this.username = Preconditions.checkNotNull(username, "username");
     this.uuid = uuid;
     this.result = PreLoginComponentResult.allowed();
+    this.attemptEncryption = attemptEncryption;
   }
 
   public InboundConnection getConnection() {
@@ -93,12 +109,39 @@ public final class PreLoginEvent implements ResultedEvent<PreLoginEvent.PreLogin
     this.result = Preconditions.checkNotNull(result, "result");
   }
 
+  /**
+   * Returns whether the proxy should attempt to encrypt the connection.
+   * This is {@code true} by default, but can be set to {@code false} to skip encryption. In older
+   * game versions (earlier than 1.20.5), offline mode connections will not be encrypted,
+   * regardless of this setting, since support for encrypted offline-mode connections was added
+   * in 1.20.5.
+   *
+   * @return whether the proxy should attempt to encrypt the connection
+   */
+  public boolean isAttemptEncryption() {
+    return attemptEncryption;
+  }
+
+  /**
+   * Sets whether the proxy should attempt to encrypt the connection.
+   * This is {@code true} by default, but can be set to {@code false} to skip encryption. In older
+   * game versions (earlier than 1.20.5), offline mode connections will not be encrypted,
+   * regardless of this setting, since support for encrypted offline-mode connections was added
+   * in 1.20.5.
+   *
+   * @param attemptEncryption whether the proxy should attempt to encrypt the connection
+   */
+  public void setAttemptEncryption(boolean attemptEncryption) {
+    this.attemptEncryption = attemptEncryption;
+  }
+
   @Override
   public String toString() {
     return "PreLoginEvent{"
         + "connection=" + connection
         + ", username='" + username + '\''
         + ", result=" + result
+        + ", attemptEncryption=" + attemptEncryption
         + '}';
   }
 

--- a/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
@@ -69,6 +69,14 @@ public interface ProxyConfig {
   boolean isOnlineMode();
 
   /**
+   * Get whether the proxy will attempt to encrypt offline-mode connections. This can only
+   * be performed on 1.20.5+ clients.
+   *
+   * @return whether offline encryption is enabled
+   */
+  boolean isOfflineEncryptionEnabled();
+
+  /**
    * If client's ISP/AS sent from this proxy is different from the one from Mojang's
    * authentication server, the player is kicked. This disallows some VPN and proxy
    * connections but is a weak form of protection.

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -46,6 +46,7 @@ import com.velocitypowered.proxy.command.builtin.ServerCommand;
 import com.velocitypowered.proxy.command.builtin.ShutdownCommand;
 import com.velocitypowered.proxy.command.builtin.VelocityCommand;
 import com.velocitypowered.proxy.config.VelocityConfiguration;
+import com.velocitypowered.proxy.connection.auth.DefaultPlayerAuthenticator;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.connection.player.resourcepack.VelocityResourcePackInfo;
 import com.velocitypowered.proxy.connection.util.ServerListPingHandler;
@@ -236,7 +237,9 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
   void start() {
     logger.info("Booting up {} {}...", getVersion().getName(), getVersion().getVersion());
     console.setupStreams();
-    pluginManager.registerPlugin(this.createVirtualPlugin());
+
+    PluginContainer virtualPlugin = createVirtualPlugin();
+    pluginManager.registerPlugin(virtualPlugin);
 
     registerTranslations();
 
@@ -250,6 +253,10 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     //
     // If you are using Minecraft in a security-sensitive application, *I don't know what to say.*
     serverKeyPair = EncryptionUtils.createRsaKeyPair(1024);
+
+    // initialize the default online-mode authenticator
+    DefaultPlayerAuthenticator authenticator = new DefaultPlayerAuthenticator(this);
+    eventManager.registerInternally(virtualPlugin, authenticator);
 
     cm.logChannelInformation();
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -68,6 +68,8 @@ public class VelocityConfiguration implements ProxyConfig {
   @Expose
   private boolean onlineMode = true;
   @Expose
+  private boolean offlineEncryption = false;
+  @Expose
   private boolean preventClientProxyConnections = false;
   @Expose
   private PlayerInfoForwarding playerInfoForwardingMode = PlayerInfoForwarding.NONE;
@@ -104,7 +106,7 @@ public class VelocityConfiguration implements ProxyConfig {
   }
 
   private VelocityConfiguration(String bind, String motd, int showMaxPlayers, boolean onlineMode,
-      boolean preventClientProxyConnections, boolean announceForge,
+      boolean offlineEncryption, boolean preventClientProxyConnections, boolean announceForge,
       PlayerInfoForwarding playerInfoForwardingMode, byte[] forwardingSecret,
       boolean onlineModeKickExistingPlayers, PingPassthroughMode pingPassthrough,
       boolean samplePlayersInPing, boolean enablePlayerAddressLogging, Servers servers,
@@ -114,6 +116,7 @@ public class VelocityConfiguration implements ProxyConfig {
     this.motd = motd;
     this.showMaxPlayers = showMaxPlayers;
     this.onlineMode = onlineMode;
+    this.offlineEncryption = offlineEncryption;
     this.preventClientProxyConnections = preventClientProxyConnections;
     this.announceForge = announceForge;
     this.playerInfoForwardingMode = playerInfoForwardingMode;
@@ -295,6 +298,11 @@ public class VelocityConfiguration implements ProxyConfig {
   @Override
   public boolean isOnlineMode() {
     return onlineMode;
+  }
+
+  @Override
+  public boolean isOfflineEncryptionEnabled() {
+    return offlineEncryption;
   }
 
   @Override
@@ -550,6 +558,7 @@ public class VelocityConfiguration implements ProxyConfig {
       final String bind = config.getOrElse("bind", "0.0.0.0:25565");
       final int maxPlayers = config.getIntOrElse("show-max-players", 500);
       final boolean onlineMode = config.getOrElse("online-mode", true);
+      final boolean offlineEncryption = config.getOrElse("offline-encryption", false);
       final boolean forceKeyAuthentication = config.getOrElse("force-key-authentication", true);
       final boolean announceForge = config.getOrElse("announce-forge", true);
       final boolean preventClientProxyConnections = config.getOrElse(
@@ -571,6 +580,7 @@ public class VelocityConfiguration implements ProxyConfig {
               motd,
               maxPlayers,
               onlineMode,
+              offlineEncryption,
               preventClientProxyConnections,
               announceForge,
               forwardingMode,

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/auth/DefaultPlayerAuthenticator.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/auth/DefaultPlayerAuthenticator.java
@@ -17,6 +17,10 @@
 
 package com.velocitypowered.proxy.connection.auth;
 
+import static com.google.common.net.UrlEscapers.urlFormParameterEscaper;
+import static com.velocitypowered.proxy.VelocityServer.GENERAL_GSON;
+import static com.velocitypowered.proxy.crypto.EncryptionUtils.generateServerId;
+
 import com.google.gson.JsonParseException;
 import com.velocitypowered.api.event.Continuation;
 import com.velocitypowered.api.event.Subscribe;
@@ -24,21 +28,19 @@ import com.velocitypowered.api.event.connection.AuthAttemptEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.util.GameProfile;
 import com.velocitypowered.proxy.VelocityServer;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.security.PublicKey;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import static com.google.common.net.UrlEscapers.urlFormParameterEscaper;
-import static com.velocitypowered.proxy.VelocityServer.GENERAL_GSON;
-import static com.velocitypowered.proxy.crypto.EncryptionUtils.generateServerId;
-
+/**
+ * Default implementation of player authentication that uses the Mojang session server.
+ */
 public class DefaultPlayerAuthenticator {
 
   private static final Logger logger = LogManager.getLogger(DefaultPlayerAuthenticator.class);
@@ -51,13 +53,18 @@ public class DefaultPlayerAuthenticator {
   private final VelocityServer server;
   private final HttpClient httpClient;
 
+  /**
+   * Creates a new instance of the default player authenticator.
+   *
+   * @param server the Velocity server instance
+   */
   public DefaultPlayerAuthenticator(VelocityServer server) {
     this.server = server;
     this.httpClient = server.createHttpClient();
   }
 
   @Subscribe(priority = 1) // low priority to allow plugins to override this
-  public void onAuthAttempt(AuthAttemptEvent event, Continuation continuation) {
+  private void onAuthAttempt(AuthAttemptEvent event, Continuation continuation) {
     if (event.getResult() != null || !event.isOnlineMode() || event.getSharedSecret() == null) {
       continuation.resume();
       return;
@@ -78,7 +85,7 @@ public class DefaultPlayerAuthenticator {
   }
 
   @Subscribe
-  public void onShutdown(ProxyShutdownEvent event) throws Exception {
+  private void onShutdown(ProxyShutdownEvent event) throws Exception {
     if (httpClient instanceof AutoCloseable c) {
       c.close();
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/auth/DefaultPlayerAuthenticator.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/auth/DefaultPlayerAuthenticator.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2025 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.velocitypowered.proxy.connection.auth;
 
 import com.google.gson.JsonParseException;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/auth/DefaultPlayerAuthenticator.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/auth/DefaultPlayerAuthenticator.java
@@ -1,0 +1,120 @@
+package com.velocitypowered.proxy.connection.auth;
+
+import com.google.gson.JsonParseException;
+import com.velocitypowered.api.event.Continuation;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.AuthAttemptEvent;
+import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
+import com.velocitypowered.api.util.GameProfile;
+import com.velocitypowered.proxy.VelocityServer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.PublicKey;
+
+import static com.google.common.net.UrlEscapers.urlFormParameterEscaper;
+import static com.velocitypowered.proxy.VelocityServer.GENERAL_GSON;
+import static com.velocitypowered.proxy.crypto.EncryptionUtils.generateServerId;
+
+public class DefaultPlayerAuthenticator {
+
+  private static final Logger logger = LogManager.getLogger(DefaultPlayerAuthenticator.class);
+
+  private static final String MOJANG_HASJOINED_URL = System.getProperty(
+      "mojang.sessionserver",
+      "https://sessionserver.mojang.com/session/minecraft/hasJoined"
+  ).concat("?username=%s&serverId=%s");
+
+  private final VelocityServer server;
+  private final HttpClient httpClient;
+
+  public DefaultPlayerAuthenticator(VelocityServer server) {
+    this.server = server;
+    this.httpClient = server.createHttpClient();
+  }
+
+  @Subscribe(priority = 1) // low priority to allow plugins to override this
+  public void onAuthAttempt(AuthAttemptEvent event, Continuation continuation) {
+    if (event.getResult() != null || !event.isOnlineMode() || event.getSharedSecret() == null) {
+      continuation.resume();
+      return;
+    }
+
+    String username = event.getAttemptedUsername();
+    String playerIp = event.getConnection().getRemoteAddress().getHostString();
+
+    HttpRequest httpRequest = buildHttpRequest(event.getSharedSecret(),
+        server.getServerKeyPair().getPublic(), username, playerIp);
+
+    httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString())
+        .whenCompleteAsync((res, err) -> {
+          AuthAttemptEvent.AuthResult result = processHttpResponse(res, err, username, playerIp);
+          event.setResult(result);
+          continuation.resume();
+        });
+  }
+
+  @Subscribe
+  public void onShutdown(ProxyShutdownEvent event) throws Exception {
+    if (httpClient instanceof AutoCloseable c) {
+      c.close();
+    }
+  }
+
+  private HttpRequest buildHttpRequest(byte[] sharedSecret, PublicKey serverKey, String username,
+                                       String playerIp) {
+    String serverId = generateServerId(sharedSecret, serverKey);
+    String url = String.format(MOJANG_HASJOINED_URL,
+        urlFormParameterEscaper().escape(username), serverId);
+
+    if (server.getConfiguration().shouldPreventClientProxyConnections()) {
+      url += "&ip=" + urlFormParameterEscaper().escape(playerIp);
+    }
+
+    String agent = server.getVersion().getName() + "/" + server.getVersion().getVersion();
+    return HttpRequest.newBuilder()
+        .setHeader("User-Agent", agent)
+        .uri(URI.create(url))
+        .build();
+  }
+
+  private AuthAttemptEvent.AuthResult processHttpResponse(HttpResponse<String> res, Throwable err,
+                                                          String username, String playerIp) {
+    if (err != null) {
+      logger.error("Failed to authenticate player", err);
+      return new AuthAttemptEvent.FailureResult(
+          Component.translatable("multiplayer.disconnect.authservers_down"));
+    }
+
+    if (res.statusCode() == 200) {
+      GameProfile profile;
+      try {
+        profile = GENERAL_GSON.fromJson(res.body(), GameProfile.class);
+      } catch (JsonParseException e) {
+        logger.warn("Failed to parse Mojang session server response for {} ({})",
+            username, playerIp, e);
+        return new AuthAttemptEvent.FailureResult(
+            Component.translatable("multiplayer.disconnect.authservers_down"));
+      }
+
+      return new AuthAttemptEvent.SuccessResult(profile);
+    } else if (res.statusCode() == 204) {
+      // apparently an offline-mode user logged onto this online-mode proxy
+      return new AuthAttemptEvent.FailureResult(
+          Component.translatable("velocity.error.online-mode-only", NamedTextColor.RED));
+    } else {
+      // Something else went wrong
+      logger.warn("Recieved an unexpected error code {} from Mojang session server for {} ({})",
+          res.statusCode(), username, playerIp);
+      return new AuthAttemptEvent.FailureResult(
+          Component.translatable("multiplayer.disconnect.authservers_down"));
+    }
+  }
+
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -17,14 +17,12 @@
 
 package com.velocitypowered.proxy.connection.client;
 
-import static com.google.common.net.UrlEscapers.urlFormParameterEscaper;
-import static com.velocitypowered.proxy.VelocityServer.GENERAL_GSON;
 import static com.velocitypowered.proxy.connection.VelocityConstants.EMPTY_BYTE_ARRAY;
 import static com.velocitypowered.proxy.crypto.EncryptionUtils.decryptRsa;
-import static com.velocitypowered.proxy.crypto.EncryptionUtils.generateServerId;
 
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Longs;
+import com.velocitypowered.api.event.connection.AuthAttemptEvent;
 import com.velocitypowered.api.event.connection.PreLoginEvent;
 import com.velocitypowered.api.event.connection.PreLoginEvent.PreLoginComponentResult;
 import com.velocitypowered.api.network.ProtocolVersion;
@@ -42,11 +40,7 @@ import com.velocitypowered.proxy.protocol.packet.LoginPluginResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.ServerLoginPacket;
 import com.velocitypowered.proxy.util.VelocityProperties;
 import io.netty.buffer.ByteBuf;
-import java.net.InetSocketAddress;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
+
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.MessageDigest;
@@ -54,7 +48,6 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -65,10 +58,6 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 public class InitialLoginSessionHandler implements MinecraftSessionHandler {
 
   private static final Logger logger = LogManager.getLogger(InitialLoginSessionHandler.class);
-  private static final String MOJANG_HASJOINED_URL =
-      System.getProperty("mojang.sessionserver",
-              "https://sessionserver.mojang.com/session/minecraft/hasJoined")
-          .concat("?username=%s&serverId=%s");
 
   private final VelocityServer server;
   private final MinecraftConnection mcConnection;
@@ -76,6 +65,8 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
   private @MonotonicNonNull ServerLoginPacket login;
   private byte[] verify = EMPTY_BYTE_ARRAY;
   private LoginState currentState = LoginState.LOGIN_PACKET_EXPECTED;
+  private boolean onlineMode;
+  private final boolean offlineEncryption;
   private final boolean forceKeyAuthentication;
 
   InitialLoginSessionHandler(VelocityServer server, MinecraftConnection mcConnection,
@@ -83,6 +74,8 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
     this.server = Preconditions.checkNotNull(server, "server");
     this.mcConnection = Preconditions.checkNotNull(mcConnection, "mcConnection");
     this.inbound = Preconditions.checkNotNull(inbound, "inbound");
+    this.onlineMode = server.getConfiguration().isOnlineMode();
+    this.offlineEncryption = server.getConfiguration().isOfflineEncryptionEnabled();
     this.forceKeyAuthentication = VelocityProperties.readBoolean(
             "auth.forceSecureProfiles", server.getConfiguration().isForceKeyAuthentication());
   }
@@ -120,7 +113,9 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
     inbound.setPlayerKey(playerKey);
     this.login = packet;
 
-    final PreLoginEvent event = new PreLoginEvent(inbound, login.getUsername(), login.getHolderUuid());
+    String username = login.getUsername();
+    PreLoginEvent event = new PreLoginEvent(inbound, username, login.getHolderUuid(), offlineEncryption);
+
     server.getEventManager().fire(event).thenRunAsync(() -> {
       if (mcConnection.isClosed()) {
         // The player was disconnected
@@ -142,17 +137,36 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
         }
 
         mcConnection.eventLoop().execute(() -> {
-          if (!result.isForceOfflineMode()
-              && (server.getConfiguration().isOnlineMode() || result.isOnlineModeAllowed())) {
-            // Request encryption.
+          if (result.isForceOfflineMode()) {
+            onlineMode = false;
+          } else if (result.isOnlineModeAllowed()) {
+            onlineMode = true;
+          }
+
+          // support for offline mode encryption was added in 1.20.5
+          if (onlineMode || (event.isAttemptEncryption() &&
+              mcConnection.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_20_5))) {
             EncryptionRequestPacket request = generateEncryptionRequest();
+            request.setShouldAuthenticate(onlineMode);
+
             this.verify = Arrays.copyOf(request.getVerifyToken(), 4);
             mcConnection.write(request);
             this.currentState = LoginState.ENCRYPTION_REQUEST_SENT;
           } else {
-            mcConnection.setActiveSessionHandler(StateRegistry.LOGIN,
-                new AuthSessionHandler(server, inbound,
-                    GameProfile.forOfflinePlayer(login.getUsername()), false));
+            // fire event and handle result on connection event loop
+            server.getEventManager().fire(new AuthAttemptEvent(
+                inbound, false, EMPTY_BYTE_ARRAY, username
+            )).thenAcceptAsync(e -> {
+              if (!mcConnection.isClosed()) {
+                AuthAttemptEvent.AuthResult res = e.getResult();
+                if (res == null) {
+                  // we allow offline mode connections if no auth result
+                  res = new AuthAttemptEvent.SuccessResult(GameProfile.forOfflinePlayer(username));
+                }
+
+                handlePlainAuthResult(res);
+              }
+            }, mcConnection.eventLoop());
           }
         });
       });
@@ -183,6 +197,7 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
       throw new IllegalStateException("No EncryptionRequest packet sent yet.");
     }
 
+    byte[] sharedSecret;
     try {
       KeyPair serverKeyPair = server.getServerKeyPair();
       if (inbound.getIdentifiedKey() != null) {
@@ -198,91 +213,78 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
         }
       }
 
-      byte[] decryptedSharedSecret = decryptRsa(serverKeyPair, packet.getSharedSecret());
-      String serverId = generateServerId(decryptedSharedSecret, serverKeyPair.getPublic());
-
-      String playerIp = ((InetSocketAddress) mcConnection.getRemoteAddress()).getHostString();
-      String url = String.format(MOJANG_HASJOINED_URL,
-          urlFormParameterEscaper().escape(login.getUsername()), serverId);
-
-      if (server.getConfiguration().shouldPreventClientProxyConnections()) {
-        url += "&ip=" + urlFormParameterEscaper().escape(playerIp);
-      }
-
-      final HttpRequest httpRequest = HttpRequest.newBuilder()
-              .setHeader("User-Agent",
-                      server.getVersion().getName() + "/" + server.getVersion().getVersion())
-              .uri(URI.create(url))
-              .build();
-      final HttpClient httpClient = server.createHttpClient();
-      httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString())
-          .whenCompleteAsync((response, throwable) -> {
-            if (mcConnection.isClosed()) {
-              // The player disconnected after we authenticated them.
-              return;
-            }
-
-            if (throwable != null) {
-              logger.error("Unable to authenticate player", throwable);
-              inbound.disconnect(Component.translatable("multiplayer.disconnect.authservers_down"));
-              return;
-            }
-
-            // Go ahead and enable encryption. Once the client sends EncryptionResponse, encryption
-            // is enabled.
-            try {
-              mcConnection.enableEncryption(decryptedSharedSecret);
-            } catch (GeneralSecurityException e) {
-              logger.error("Unable to enable encryption for connection", e);
-              // At this point, the connection is encrypted, but something's wrong on our side and
-              // we can't do anything about it.
-              mcConnection.close(true);
-              return;
-            }
-
-            if (response.statusCode() == 200) {
-              final GameProfile profile = GENERAL_GSON.fromJson(response.body(),
-                  GameProfile.class);
-              // Not so fast, now we verify the public key for 1.19.1+
-              if (inbound.getIdentifiedKey() != null
-                  && inbound.getIdentifiedKey().getKeyRevision() == IdentifiedKey.Revision.LINKED_V2
-                  && inbound.getIdentifiedKey() instanceof final IdentifiedKeyImpl key) {
-                if (!key.internalAddHolder(profile.getId())) {
-                  inbound.disconnect(
-                      Component.translatable("multiplayer.disconnect.invalid_public_key"));
-                }
-              }
-              // All went well, initialize the session.
-              mcConnection.setActiveSessionHandler(StateRegistry.LOGIN,
-                  new AuthSessionHandler(server, inbound, profile, true));
-            } else if (response.statusCode() == 204) {
-              // Apparently an offline-mode user logged onto this online-mode proxy.
-              inbound.disconnect(
-                  Component.translatable("velocity.error.online-mode-only", NamedTextColor.RED));
-            } else {
-              // Something else went wrong
-              logger.error(
-                  "Got an unexpected error code {} whilst contacting Mojang to log in {} ({})",
-                  response.statusCode(), login.getUsername(), playerIp);
-              inbound.disconnect(Component.translatable("multiplayer.disconnect.authservers_down"));
-            }
-          }, mcConnection.eventLoop())
-          .thenRun(() -> {
-            if (httpClient instanceof final AutoCloseable closeable) {
-              try {
-                closeable.close();
-              } catch (Exception e) {
-                // In Java 21, the HttpClient does not throw any Exception
-                // when trying to clean its resources, so this should not happen
-                logger.error("An unknown error occurred while trying to close an HttpClient", e);
-              }
-            }
-          });
+      sharedSecret = decryptRsa(serverKeyPair, packet.getSharedSecret());
     } catch (GeneralSecurityException e) {
       logger.error("Unable to enable encryption", e);
       mcConnection.close(true);
+      return true;
     }
+
+    // fire event and handle result on connection event loop
+    server.getEventManager().fire(new AuthAttemptEvent(
+        inbound, onlineMode, sharedSecret, login.getUsername()
+    )).thenAcceptAsync(event -> {
+      if (!mcConnection.isClosed()) {
+        AuthAttemptEvent.AuthResult res = event.getResult();
+        if (res == null) {
+          // if no auth result, we deny online mode connections but allow offline mode connections
+          res = onlineMode ? new AuthAttemptEvent.FailureResult(
+              Component.translatable("multiplayer.disconnect.authservers_down")) :
+              new AuthAttemptEvent.SuccessResult(
+                  GameProfile.forOfflinePlayer(login.getUsername())
+              );
+        }
+
+        handleEncryptedAuthResult(res, sharedSecret);
+      }
+    }, mcConnection.eventLoop()).exceptionally(ex -> {
+      logger.error("Exception in authentication attempt", ex);
+      return null;
+    });
+
     return true;
+  }
+
+  private void handlePlainAuthResult(AuthAttemptEvent.AuthResult result) {
+    if (result instanceof AuthAttemptEvent.SuccessResult res) {
+      mcConnection.setActiveSessionHandler(StateRegistry.LOGIN,
+          new AuthSessionHandler(server, inbound, res.profile(), false));
+    } else if (result instanceof AuthAttemptEvent.FailureResult failure) {
+      inbound.disconnect(failure.reason());
+    }
+  }
+
+  private void handleEncryptedAuthResult(AuthAttemptEvent.AuthResult res, byte[] sharedSecret) {
+    if (res instanceof AuthAttemptEvent.SuccessResult result) {
+      // verify public key for 1.19.1+
+      if (inbound.getIdentifiedKey() != null
+          && inbound.getIdentifiedKey().getKeyRevision() == IdentifiedKey.Revision.LINKED_V2
+          && inbound.getIdentifiedKey() instanceof final IdentifiedKeyImpl key) {
+        if (!key.internalAddHolder(result.profile().getId())) {
+          inbound.disconnect(
+              Component.translatable("multiplayer.disconnect.invalid_public_key"));
+          return;
+        }
+      }
+
+      // enable encryption for the connection
+      try {
+        mcConnection.enableEncryption(sharedSecret);
+      } catch (GeneralSecurityException e) {
+        logger.error("Unable to enable encryption for connection", e);
+        mcConnection.close(true);
+        return;
+      }
+
+      // initialize the session
+      mcConnection.setActiveSessionHandler(StateRegistry.LOGIN,
+          new AuthSessionHandler(server, inbound, result.profile(), true));
+    } else if (res instanceof AuthAttemptEvent.FailureResult failure) {
+      // disconnect the player with the provided reason
+      inbound.disconnect(failure.reason());
+    } else if (res == null) {
+      inbound.disconnect(Component.translatable("multiplayer.disconnect.authservers_down"));
+    }
   }
 
   private EncryptionRequestPacket generateEncryptionRequest() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -40,7 +40,6 @@ import com.velocitypowered.proxy.protocol.packet.LoginPluginResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.ServerLoginPacket;
 import com.velocitypowered.proxy.util.VelocityProperties;
 import io.netty.buffer.ByteBuf;
-
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.MessageDigest;
@@ -144,8 +143,8 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
           }
 
           // support for offline mode encryption was added in 1.20.5
-          if (onlineMode || (event.isOfflineEncryption() &&
-              mcConnection.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_20_5))) {
+          if (onlineMode || (event.isOfflineEncryption()
+              && mcConnection.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_20_5))) {
             EncryptionRequestPacket request = generateEncryptionRequest();
             request.setShouldAuthenticate(onlineMode);
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -144,7 +144,7 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
           }
 
           // support for offline mode encryption was added in 1.20.5
-          if (onlineMode || (event.isAttemptEncryption() &&
+          if (onlineMode || (event.isOfflineEncryption() &&
               mcConnection.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_20_5))) {
             EncryptionRequestPacket request = generateEncryptionRequest();
             request.setShouldAuthenticate(onlineMode);

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/EncryptionRequestPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/EncryptionRequestPacket.java
@@ -49,6 +49,22 @@ public class EncryptionRequestPacket implements MinecraftPacket {
     this.verifyToken = verifyToken.clone();
   }
 
+  public String getServerId() {
+    return serverId;
+  }
+
+  public void setServerId(String serverId) {
+    this.serverId = serverId;
+  }
+
+  public boolean getShouldAuthenticate() {
+    return shouldAuthenticate;
+  }
+
+  public void setShouldAuthenticate(boolean shouldAuthenticate) {
+    this.shouldAuthenticate = shouldAuthenticate;
+  }
+
   @Override
   public String toString() {
     return "EncryptionRequest{"

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -15,6 +15,10 @@ show-max-players = 500
 # Should we authenticate players with Mojang? By default, this is on.
 online-mode = true
 
+# Should we attempt to enable encryption for offline-mode connections? By default, this is off.
+# Note that this feature is only supported by version 1.20.5+.
+offline-encryption = false
+
 # Should the proxy enforce the new public key security standard? By default, this is on.
 force-key-authentication = true
 


### PR DESCRIPTION
This pull request adds additional flexibility to the login and authentication sequence.

There are two main changes in this PR:
- adds support for offline-mode encryption in 1.20.5+
- decouples the Mojang authentication logic from the login session handler using an event

I have added a flag offlineEncryption to the PreLoginEvent, which defines whether the proxy will attempt to encrypt the connection (if in offline mode) once the event has finished dispatching. However, it is clearly documented that setting this flag will not always force encryption to be enabled. In 1.20.5, a flag was added to the encryption start packet for whether the client should authenticate with Mojang, which gives us the ability to encrypt a connection without forcing the client to authenticate with the session server. In versions below 1.20.5, we must skip encryption even if this flag is set. The default value for this flag is the value of the offline-encryption proxy configuration value (default false).

I have added the AuthAttemptEvent, which is fired just after the PreLoginEvent, regardless of whether the connection is online or offline mode. This event allows plugins to override the authentication mechanism used by the proxy, which is particularly useful in server networks where authentication is handled on a single microservice, or if a custom session server were to be used. There is a default authentication mechanism which listens for this event with a low priority and skips official Mojang auth if the connection is offline-mode, or another plugin has already set the result.

In order to make these changes, I have had to refactor some of the login sequence code. Due to the sensitive nature of this secure process, it is vital that this PR receives careful review before approval. I have thought carefully about the changes, and no login features have been removed, but I would appreciate some care when verifying that the process remains robust.