### PR TITLE
Gradle deprecation fixes & upgrades

### DIFF
--- a/build-logic/src/main/kotlin/velocity-init-manifest.gradle.kts
+++ b/build-logic/src/main/kotlin/velocity-init-manifest.gradle.kts
@@ -2,8 +2,15 @@ import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.withType
 import java.io.ByteArrayOutputStream
 
+// This interface is needed as a workaround to get an instance of ExecOperations
+interface Injected {
+    @get:Inject
+    val execOps: ExecOperations
+}
+
 val currentShortRevision = ByteArrayOutputStream().use {
-    exec {
+    val execOps = objects.newInstance<Injected>().execOps
+    execOps.exec {
         executable = "git"
         args = listOf("rev-parse", "HEAD")
         standardOutput = it

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,11 +20,11 @@ subprojects {
         testImplementation(rootProject.libs.junit)
     }
 
-    tasks {
-        test {
-            useJUnitPlatform()
-            reports {
-                junitXml.required.set(true)
+    testing.suites.named<JvmTestSuite>("test") {
+        useJUnitJupiter()
+        targets.all {
+            testTask.configure {
+                reports.junitXml.required = true
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ netty = "4.2.2.Final"
 
 [plugins]
 indra-publishing = "net.kyori.indra.publishing:2.0.6"
-shadow = "io.github.goooler.shadow:8.1.5"
+shadow = "com.gradleup.shadow:8.3.6"
 spotless = "com.diffplug.spotless:6.25.0"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR fixes all Gradle deprecations that I found when running `gradlew build`.

Additionally, it upgrades Gradle to the latest stable version.

I also switch to a maintained version of Shadow. This causes a coordinate change. 
As you can see in the [github repo](https://github.com/GradleUp/shadow), this version is also 
party maintained by Googler so I think this change is fine.
