### PR TITLE
1.21.7 Support

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -92,7 +92,7 @@ public enum ProtocolVersion implements Ordered<ProtocolVersion> {
   MINECRAFT_1_21_4(769, "1.21.4"),
   MINECRAFT_1_21_5(770, "1.21.5"),
   MINECRAFT_1_21_6(771, "1.21.6"),
-  MINECRAFT_1_21_7(772, 258, "1.21.7");
+  MINECRAFT_1_21_7(772, "1.21.7");
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -91,7 +91,8 @@ public enum ProtocolVersion implements Ordered<ProtocolVersion> {
   MINECRAFT_1_21_2(768, "1.21.2", "1.21.3"),
   MINECRAFT_1_21_4(769, "1.21.4"),
   MINECRAFT_1_21_5(770, "1.21.5"),
-  MINECRAFT_1_21_6(771, "1.21.6");
+  MINECRAFT_1_21_6(771, "1.21.6"),
+  MINECRAFT_1_21_7(1073742081 /* 772 */, "1.21.7");
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -92,7 +92,7 @@ public enum ProtocolVersion implements Ordered<ProtocolVersion> {
   MINECRAFT_1_21_4(769, "1.21.4"),
   MINECRAFT_1_21_5(770, "1.21.5"),
   MINECRAFT_1_21_6(771, "1.21.6"),
-  MINECRAFT_1_21_7(1073742081 /* 772 */, "1.21.7");
+  MINECRAFT_1_21_7(-1, 257, "1.21.7");
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -92,7 +92,7 @@ public enum ProtocolVersion implements Ordered<ProtocolVersion> {
   MINECRAFT_1_21_4(769, "1.21.4"),
   MINECRAFT_1_21_5(770, "1.21.5"),
   MINECRAFT_1_21_6(771, "1.21.6"),
-  MINECRAFT_1_21_7(-1, 257, "1.21.7");
+  MINECRAFT_1_21_7(-1, 258, "1.21.7");
 
   private static final int SNAPSHOT_BIT = 30;
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -92,7 +92,7 @@ public enum ProtocolVersion implements Ordered<ProtocolVersion> {
   MINECRAFT_1_21_4(769, "1.21.4"),
   MINECRAFT_1_21_5(770, "1.21.5"),
   MINECRAFT_1_21_6(771, "1.21.6"),
-  MINECRAFT_1_21_7(-1, 258, "1.21.7");
+  MINECRAFT_1_21_7(772, 258, "1.21.7");
 
   private static final int SNAPSHOT_BIT = 30;
 


### PR DESCRIPTION
https://minecraft.wiki/w/Java_Edition_1.21.7

There don't seem to be any changes in the protocol except for the protocol version ID.