### PR TITLE
Forward DisconnectPacket to client in ConfigSessionHandler and TransitionSessionHandler

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -255,13 +255,15 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(DisconnectPacket packet) {
+    final MinecraftConnection connection = serverConn.ensureConnected();
     serverConn.disconnect();
-    resultFuture.thenApply((result) -> {
-      MinecraftConnection connection = serverConn.getConnection();
-      if (connection == null) {
-        return result;
-      }
-      connection.closeWith(DisconnectPacket.create(packet.getReason().getComponent(), connection.getProtocolVersion(), connection.getState()));
+
+    resultFuture.thenApply(result -> {
+      DisconnectPacket disconnect = DisconnectPacket.create(
+          packet.getReason().getComponent(),
+          connection.getProtocolVersion(),
+          connection.getState());
+      connection.closeWith(disconnect);
       return result;
     }).complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -170,7 +170,7 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
           if (serverConn.getConnection() != null) {
             // We can technically skip these first 2 states, however, for conformity to normal state flow expectations...
             serverConn.getConnection().write(new ResourcePackResponsePacket(
-                    packet.getId(), packet.getHash(), PlayerResourcePackStatusEvent.Status.ACCEPTED));
+                packet.getId(), packet.getHash(), PlayerResourcePackStatusEvent.Status.ACCEPTED));
             serverConn.getConnection().write(new ResourcePackResponsePacket(
                 packet.getId(), packet.getHash(), PlayerResourcePackStatusEvent.Status.DOWNLOADED));
             serverConn.getConnection().write(new ResourcePackResponsePacket(
@@ -255,7 +255,8 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(DisconnectPacket packet) {
-    serverConn.disconnect();
+    MinecraftConnection connection = serverConn.getPlayer().getConnection();
+    connection.closeWith(DisconnectPacket.create(packet.getReason().getComponent(), connection.getProtocolVersion(), connection.getState()));
     resultFuture.complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
     return true;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -255,8 +255,6 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(DisconnectPacket packet) {
-    MinecraftConnection connection = serverConn.getPlayer().getConnection();
-    connection.closeWith(DisconnectPacket.create(packet.getReason().getComponent(), connection.getProtocolVersion(), connection.getState()));
     resultFuture.complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
     return true;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -255,18 +255,8 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(DisconnectPacket packet) {
-    final MinecraftConnection connection = serverConn.ensureConnected();
     serverConn.disconnect();
-
-    resultFuture.thenApply(result -> {
-      DisconnectPacket disconnect = DisconnectPacket.create(
-          packet.getReason().getComponent(),
-          connection.getProtocolVersion(),
-          connection.getState());
-      connection.closeWith(disconnect);
-      return result;
-    }).complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
-
+    resultFuture.complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
     return true;
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -255,7 +255,9 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(DisconnectPacket packet) {
+    serverConn.disconnect();
     resultFuture.complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
+    serverConn.getPlayer().handleConnectionException(serverConn.getServer(), packet, true);
     return true;
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -256,8 +256,15 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
   @Override
   public boolean handle(DisconnectPacket packet) {
     serverConn.disconnect();
-    resultFuture.complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
-    serverConn.getPlayer().handleConnectionException(serverConn.getServer(), packet, true);
+    resultFuture.thenApply((result) -> {
+      MinecraftConnection connection = serverConn.getConnection();
+      if (connection == null) {
+        return result;
+      }
+      connection.closeWith(DisconnectPacket.create(packet.getReason().getComponent(), connection.getProtocolVersion(), connection.getState()));
+      return result;
+    }).complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
+
     return true;
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -182,7 +182,6 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
       resultFuture.complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
     }
 
-    serverConn.getPlayer().handleConnectionException(serverConn.getServer(), packet, true);
     return true;
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -174,12 +174,16 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
 
     // If we were in the middle of the Forge handshake, it is not safe to proceed. We must kick
     // the client.
-    if (connection.getType() == ConnectionTypes.LEGACY_FORGE
-        && !serverConn.getPhase().consideredComplete()) {
-      resultFuture.complete(ConnectionRequestResults.forUnsafeDisconnect(packet,
-          serverConn.getServer()));
+    if (connection.getType() == ConnectionTypes.LEGACY_FORGE && !serverConn.getPhase().consideredComplete()) {
+      resultFuture.thenApply((result) -> {
+        connection.closeWith(DisconnectPacket.create(packet.getReason().getComponent(), connection.getProtocolVersion(), connection.getState()));
+        return result;
+      }).complete(ConnectionRequestResults.forUnsafeDisconnect(packet, serverConn.getServer()));
     } else {
-      resultFuture.complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
+      resultFuture.thenApply((result) -> {
+        connection.closeWith(DisconnectPacket.create(packet.getReason().getComponent(), connection.getProtocolVersion(), connection.getState()));
+        return result;
+      }).complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
     }
 
     return true;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -176,12 +176,18 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
     // the client.
     if (connection.getType() == ConnectionTypes.LEGACY_FORGE && !serverConn.getPhase().consideredComplete()) {
       resultFuture.thenApply((result) -> {
-        connection.closeWith(DisconnectPacket.create(packet.getReason().getComponent(), connection.getProtocolVersion(), connection.getState()));
+        connection.closeWith(DisconnectPacket.create(
+            packet.getReason().getComponent(),
+            connection.getProtocolVersion(),
+            connection.getState()));
         return result;
       }).complete(ConnectionRequestResults.forUnsafeDisconnect(packet, serverConn.getServer()));
     } else {
       resultFuture.thenApply((result) -> {
-        connection.closeWith(DisconnectPacket.create(packet.getReason().getComponent(), connection.getProtocolVersion(), connection.getState()));
+        connection.closeWith(DisconnectPacket.create(
+            packet.getReason().getComponent(),
+            connection.getProtocolVersion(),
+            connection.getState()));
         return result;
       }).complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -169,7 +169,8 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(DisconnectPacket packet) {
-    final MinecraftConnection connection = serverConn.getPlayer().getConnection();
+    final MinecraftConnection connection = serverConn.ensureConnected();
+    serverConn.disconnect();
 
     // If we were in the middle of the Forge handshake, it is not safe to proceed. We must kick
     // the client.
@@ -181,6 +182,7 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
       resultFuture.complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
     }
 
+    serverConn.getPlayer().handleConnectionException(serverConn.getServer(), packet, true);
     return true;
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -175,21 +175,9 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
     // If we were in the middle of the Forge handshake, it is not safe to proceed. We must kick
     // the client.
     if (connection.getType() == ConnectionTypes.LEGACY_FORGE && !serverConn.getPhase().consideredComplete()) {
-      resultFuture.thenApply((result) -> {
-        connection.closeWith(DisconnectPacket.create(
-            packet.getReason().getComponent(),
-            connection.getProtocolVersion(),
-            connection.getState()));
-        return result;
-      }).complete(ConnectionRequestResults.forUnsafeDisconnect(packet, serverConn.getServer()));
+      resultFuture.complete(ConnectionRequestResults.forUnsafeDisconnect(packet, serverConn.getServer()));
     } else {
-      resultFuture.thenApply((result) -> {
-        connection.closeWith(DisconnectPacket.create(
-            packet.getReason().getComponent(),
-            connection.getProtocolVersion(),
-            connection.getState()));
-        return result;
-      }).complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
+      resultFuture.complete(ConnectionRequestResults.forDisconnect(packet, serverConn.getServer()));
     }
 
     return true;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -170,7 +170,6 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
   @Override
   public boolean handle(DisconnectPacket packet) {
     final MinecraftConnection connection = serverConn.getPlayer().getConnection();
-    connection.closeWith(DisconnectPacket.create(packet.getReason().getComponent(), connection.getProtocolVersion(), connection.getState()));
 
     // If we were in the middle of the Forge handshake, it is not safe to proceed. We must kick
     // the client.

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -169,8 +169,8 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(DisconnectPacket packet) {
-    final MinecraftConnection connection = serverConn.ensureConnected();
-    serverConn.disconnect();
+    final MinecraftConnection connection = serverConn.getPlayer().getConnection();
+    connection.closeWith(DisconnectPacket.create(packet.getReason().getComponent(), connection.getProtocolVersion(), connection.getState()));
 
     // If we were in the middle of the Forge handshake, it is not safe to proceed. We must kick
     // the client.

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1487,12 +1487,12 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
             final Component reason = status.getReasonComponent()
                     .orElse(ConnectionMessages.INTERNAL_SERVER_CONNECTION_ERROR);
 
-              if (connectedServer == null && connection.getState() == StateRegistry.CONFIG) {
-                  connection.closeWith(DisconnectPacket.create(reason, getProtocolVersion(), connection.getState()));
-              } else {
-                  handleConnectionException(toConnect,
-                          DisconnectPacket.create(reason, getProtocolVersion(), connection.getState()), status.isSafe());
-              }
+            if (connectedServer == null && connection.getState() == StateRegistry.CONFIG) {
+              connection.closeWith(DisconnectPacket.create(reason, getProtocolVersion(), connection.getState()));
+            } else {
+              handleConnectionException(toConnect,
+                    DisconnectPacket.create(reason, getProtocolVersion(), connection.getState()), status.isSafe());
+            }
           }
           default -> {
             // The only remaining value is successful (no need to do anything!)

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1438,8 +1438,14 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
           VelocityServerConnection con =
               new VelocityServerConnection(vrs, previousServer, ConnectedPlayer.this, server);
           connectionInFlight = con;
-          return con.connect().whenCompleteAsync((result, exception) -> this.resetIfInFlightIs(con),
-              connection.eventLoop());
+          return con.connect().whenCompleteAsync((result, exception) -> {
+            if (result != null && !result.isSuccessful() && !result.isSafe()) {
+              result.getReasonComponent()
+                  .ifPresent(reason -> handleConnectionException(result.getAttemptedConnection(),
+                      DisconnectPacket.create(reason, getProtocolVersion(), connection.getState()), false));
+            }
+            this.resetIfInFlightIs(con);
+          }, connection.eventLoop());
         }, connection.eventLoop());
       });
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1486,8 +1486,13 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
           case SERVER_DISCONNECTED -> {
             final Component reason = status.getReasonComponent()
                     .orElse(ConnectionMessages.INTERNAL_SERVER_CONNECTION_ERROR);
-            handleConnectionException(toConnect,
-                    DisconnectPacket.create(reason, getProtocolVersion(), connection.getState()), status.isSafe());
+
+              if (connectedServer == null && connection.getState() == StateRegistry.CONFIG) {
+                  connection.closeWith(DisconnectPacket.create(reason, getProtocolVersion(), connection.getState()));
+              } else {
+                  handleConnectionException(toConnect,
+                          DisconnectPacket.create(reason, getProtocolVersion(), connection.getState()), status.isSafe());
+              }
           }
           default -> {
             // The only remaining value is successful (no need to do anything!)


### PR DESCRIPTION
This resolves #1603 by forwarding the DisconnectPacket correctly during both phases and was inspired by the precise code mentioned in the issue report.