### PR TITLE
update to netty 4.2.3.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ configurate3 = "3.7.3"
 configurate4 = "4.1.2"
 flare = "2.0.1"
 log4j = "2.24.3"
-netty = "4.2.1.Final"
+netty = "4.2.3.Final"
 
 [plugins]
 fill = "io.papermc.fill.gradle:1.0.3"

--- a/proxy/src/main/java/com/velocitypowered/proxy/Velocity.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/Velocity.java
@@ -47,6 +47,11 @@ public class Velocity {
       System.setProperty("io.netty.native.workdir", System.getProperty("velocity.natives-tmpdir"));
     }
 
+    // Restore allocator used before Netty 4.2 due to oom issues with the adaptive allocator
+    if (System.getProperty("io.netty.allocator.type") == null) {
+      System.setProperty("io.netty.allocator.type", "pooled");
+    }
+
     // Disable the resource leak detector by default as it reduces performance. Allow the user to
     // override this if desired.
     if (!VelocityProperties.hasProperty("io.netty.leakDetection.level")) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/Velocity.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/Velocity.java
@@ -47,11 +47,6 @@ public class Velocity {
       System.setProperty("io.netty.native.workdir", System.getProperty("velocity.natives-tmpdir"));
     }
 
-    // Restore allocator used before Netty 4.2 due to oom issues with the adaptive allocator
-    if (System.getProperty("io.netty.allocator.type") == null) {
-      System.setProperty("io.netty.allocator.type", "pooled");
-    }
-
     // Disable the resource leak detector by default as it reduces performance. Allow the user to
     // override this if desired.
     if (!VelocityProperties.hasProperty("io.netty.leakDetection.level")) {


### PR DESCRIPTION
Netty 4.2.3 fixes the issues introduced in 4.2.2 (#1591) and also includes a huge improvement to the adaptive allocator. Due to this I think it should be given another chance instead of using the pooled allocator by default.

The netty changelog can be found here: https://netty.io/news/2025/07/15/4-2-3.html
