### PR TITLE
Improve documentation for priority parameter in EventManager

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/EventManager.java
+++ b/api/src/main/java/com/velocitypowered/api/event/EventManager.java
@@ -60,7 +60,8 @@ public interface EventManager {
    *
    * @param plugin the plugin to associate with the handler
    * @param eventClass the class for the event handler to register
-   * @param postOrder the relative order in which events should be posted to the handler
+   * @param postOrder the relative order in which events should be posted to the handler. The higher
+   *  the priority, the earlier the event handler will be called
    * @param handler the handler to register
    * @param <E> the event type to handle
    */

--- a/api/src/main/java/com/velocitypowered/api/event/EventManager.java
+++ b/api/src/main/java/com/velocitypowered/api/event/EventManager.java
@@ -61,7 +61,7 @@ public interface EventManager {
    * @param plugin the plugin to associate with the handler
    * @param eventClass the class for the event handler to register
    * @param postOrder the relative order in which events should be posted to the handler. The higher
-   *  the priority, the earlier the event handler will be called
+   *     the priority, the earlier the event handler will be called
    * @param handler the handler to register
    * @param <E> the event type to handle
    */


### PR DESCRIPTION
`PostOrder` was deprecated in commit
 (4f227badc20dc30b0f6d84b5349c8809481dcbb1) in favor of priorities.
`PostOrder` itself was very descriptive on which `PostOrder` is processed first. A number cannot be descriptive about that - it is never clear if higher or lower numbers are processed first.

The `Subscribe` event attribute does contain a description on how priorities are evaluated. The `EventManager` did not, which literally did confused developers (me) manually registering events.

This commit fixes this by describing the priority parameter in `EventManager` with the same description that `Subscribe` uses.

---

There are related concerns to the topic of priorities: https://github.com/PaperMC/Velocity/issues/1536
This commit merely makes priorities more accessible to developers.

---

CleckStyle did not complain about this change. However I am unsure if this way of describing the parameter is proper. As I did not find any example for wrapped parameter descriptions or documentation.

Please let me know, if you want anything changed and I will adjust it.