### PR TITLE
feat: map show_dialog & clear_dialog in CONFIG state

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftSessionHandler.java
@@ -24,6 +24,8 @@ import com.velocitypowered.proxy.protocol.packet.BundleDelimiterPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientSettingsPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientboundCookieRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientboundStoreCookiePacket;
+import com.velocitypowered.proxy.protocol.packet.DialogClearPacket;
+import com.velocitypowered.proxy.protocol.packet.DialogShowPacket;
 import com.velocitypowered.proxy.protocol.packet.DisconnectPacket;
 import com.velocitypowered.proxy.protocol.packet.EncryptionRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.EncryptionResponsePacket;
@@ -362,6 +364,14 @@ public interface MinecraftSessionHandler {
   }
 
   default boolean handle(ClientboundServerLinksPacket packet) {
+    return false;
+  }
+
+  default boolean handle(DialogClearPacket packet) {
+    return false;
+  }
+
+  default boolean handle(DialogShowPacket packet) {
     return false;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
@@ -59,6 +59,8 @@ import com.velocitypowered.proxy.protocol.packet.BundleDelimiterPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientSettingsPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientboundCookieRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientboundStoreCookiePacket;
+import com.velocitypowered.proxy.protocol.packet.DialogClearPacket;
+import com.velocitypowered.proxy.protocol.packet.DialogShowPacket;
 import com.velocitypowered.proxy.protocol.packet.DisconnectPacket;
 import com.velocitypowered.proxy.protocol.packet.EncryptionRequestPacket;
 import com.velocitypowered.proxy.protocol.packet.EncryptionResponsePacket;
@@ -237,6 +239,10 @@ public enum StateRegistry {
           map(0x0F, MINECRAFT_1_21, false));
       clientbound.register(ClientboundServerLinksPacket.class, ClientboundServerLinksPacket::new,
           map(0x10, MINECRAFT_1_21, false));
+      clientbound.register(DialogClearPacket.class, () -> DialogClearPacket.INSTANCE,
+          map(0x11, MINECRAFT_1_21_6, false));
+      clientbound.register(DialogShowPacket.class, () -> new DialogShowPacket(this),
+          map(0x12, MINECRAFT_1_21_6, false));
     }
   },
   PLAY {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/DialogClearPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/DialogClearPacket.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018-2025 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.protocol.packet;
+
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils.Direction;
+import io.netty.buffer.ByteBuf;
+
+public class DialogClearPacket implements MinecraftPacket {
+
+  public static final DialogClearPacket INSTANCE = new DialogClearPacket();
+
+  private DialogClearPacket() {
+  }
+
+  @Override
+  public void decode(ByteBuf buf, Direction direction, ProtocolVersion protocolVersion) {
+  }
+
+  @Override
+  public void encode(ByteBuf buf, Direction direction, ProtocolVersion protocolVersion) {
+  }
+
+  @Override
+  public boolean handle(MinecraftSessionHandler handler) {
+    return handler.handle(this);
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/DialogShowPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/DialogShowPacket.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018-2025 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.protocol.packet;
+
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import com.velocitypowered.proxy.protocol.ProtocolUtils.Direction;
+import com.velocitypowered.proxy.protocol.StateRegistry;
+import io.netty.buffer.ByteBuf;
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.nbt.BinaryTagIO;
+
+public class DialogShowPacket implements MinecraftPacket {
+
+  private final StateRegistry state;
+  private int id;
+  private BinaryTag nbt;
+
+  public DialogShowPacket(final StateRegistry state) {
+    this.state = state;
+  }
+
+  @Override
+  public void decode(ByteBuf buf, Direction direction, ProtocolVersion protocolVersion) {
+    this.id = this.state == StateRegistry.CONFIG ? 0 : ProtocolUtils.readVarInt(buf);
+    if (this.id == 0) {
+      this.nbt = ProtocolUtils.readBinaryTag(buf, protocolVersion, BinaryTagIO.reader());
+    }
+  }
+
+  @Override
+  public void encode(ByteBuf buf, Direction direction, ProtocolVersion protocolVersion) {
+    if (this.state == StateRegistry.CONFIG) {
+      ProtocolUtils.writeBinaryTag(buf, protocolVersion, this.nbt);
+    } else {
+      ProtocolUtils.writeVarInt(buf, this.id);
+      if (this.id == 0) {
+        ProtocolUtils.writeBinaryTag(buf, protocolVersion, this.nbt);
+      }
+    }
+  }
+
+  @Override
+  public boolean handle(MinecraftSessionHandler handler) {
+    return handler.handle(this);
+  }
+}


### PR DESCRIPTION
Maps `show_dialog` & `clear_dialog` during CONFIG state, so that they don't get caught in PlayPacketQueueInboundHandler.

I also included en- & decoding of the PLAY version of `show_dialog`, but decided against mapping it in StateRegistry since it is not needed right now. Maybe in the future when a dialog api is added it will be though, so then it's there (it will probably be changed then anyways, but whatever).

Fixes #1618 

Using the code provided in the linked issue (with the change of sending a clear if i == 3) now results in the expected behavior:

https://github.com/user-attachments/assets/9471bd85-f2ac-4894-b478-69587a3c217f
