### PR TITLE
feat: add ProxyPreShutdownEvent before players are disconnected

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/proxy/ProxyPreShutdownEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/ProxyPreShutdownEvent.java
@@ -16,9 +16,11 @@ import com.velocitypowered.api.event.annotation.AwaitingEvent;
  * This is the last point at which you can interact with currently connected players,
  * for example to transfer them to another proxy or perform other cleanup tasks.
  *
- * <p><b>Note:</b> Velocity will wait for all event listeners to complete before disconnecting players,
- * but note that the event will time out after 10 seconds
- * to prevent shutdown from hanging indefinitely.</p>
+ * @implNote Velocity will wait for all event listeners to complete before disconnecting players,
+ *     but note that the event will time out after the configured value of the
+ *     <code>velocity.pre-shutdown-timeout</code> system property, default 10 seconds,
+ *     in seconds to prevent shutdown from hanging indefinitely
+ * @since 3.4.0
  */
 @Beta
 @AwaitingEvent

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/ProxyPreShutdownEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/ProxyPreShutdownEvent.java
@@ -1,8 +1,18 @@
 /*
- * Copyright (C) 2018-2021 Velocity Contributors
+ * Copyright (C) 2018-2025 Velocity Contributors
  *
- * The Velocity API is licensed under the terms of the MIT License. For more details,
- * reference the LICENSE file in the api top-level directory.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package com.velocitypowered.api.event.proxy;
@@ -12,9 +22,13 @@ import com.velocitypowered.api.event.annotation.AwaitingEvent;
 /**
  * This event is fired by the proxy after it has stopped accepting new connections,
  * but before players are disconnected.
+ * <p>
  * This is the last point at which you can interact with currently connected players,
  * for example to transfer them to another proxy or perform other cleanup tasks.
- * Velocity will wait for all event listeners to complete before disconnecting players.
+ * <p>
+ * Velocity will wait for all event listeners to complete before disconnecting players,
+ * but note that the event will time out after a certain period (currently 10 seconds)
+ * to prevent shutdown from hanging indefinitely.
  */
 @AwaitingEvent
 public final class ProxyPreShutdownEvent {

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/ProxyPreShutdownEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/ProxyPreShutdownEvent.java
@@ -1,35 +1,26 @@
 /*
  * Copyright (C) 2018-2025 Velocity Contributors
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
  */
 
 package com.velocitypowered.api.event.proxy;
 
+import com.google.common.annotations.Beta;
 import com.velocitypowered.api.event.annotation.AwaitingEvent;
 
 /**
  * This event is fired by the proxy after it has stopped accepting new connections,
  * but before players are disconnected.
- * <p>
  * This is the last point at which you can interact with currently connected players,
  * for example to transfer them to another proxy or perform other cleanup tasks.
- * <p>
- * Velocity will wait for all event listeners to complete before disconnecting players,
+ *
+ * <p><b>Note:</b> Velocity will wait for all event listeners to complete before disconnecting players,
  * but note that the event will time out after a certain period (currently 10 seconds)
- * to prevent shutdown from hanging indefinitely.
+ * to prevent shutdown from hanging indefinitely.</p>
  */
+@Beta
 @AwaitingEvent
 public final class ProxyPreShutdownEvent {
 

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/ProxyPreShutdownEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/ProxyPreShutdownEvent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2018-2021 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package com.velocitypowered.api.event.proxy;
+
+import com.velocitypowered.api.event.annotation.AwaitingEvent;
+
+/**
+ * This event is fired by the proxy after it has stopped accepting new connections,
+ * but before players are disconnected.
+ * This is the last point at which you can interact with currently connected players,
+ * for example to transfer them to another proxy or perform other cleanup tasks.
+ * Velocity will wait for all event listeners to complete before disconnecting players.
+ */
+@AwaitingEvent
+public final class ProxyPreShutdownEvent {
+
+  @Override
+  public String toString() {
+    return "ProxyPreShutdownEvent";
+  }
+}

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/ProxyPreShutdownEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/ProxyPreShutdownEvent.java
@@ -17,7 +17,7 @@ import com.velocitypowered.api.event.annotation.AwaitingEvent;
  * for example to transfer them to another proxy or perform other cleanup tasks.
  *
  * <p><b>Note:</b> Velocity will wait for all event listeners to complete before disconnecting players,
- * but note that the event will time out after a certain period (currently 10 seconds)
+ * but note that the event will time out after 10 seconds
  * to prevent shutdown from hanging indefinitely.</p>
  */
 @Beta

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -578,6 +578,27 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
       // done first to refuse new connections
       cm.shutdown();
 
+      int shutdownTimeout = 10;
+
+      try {
+        logger.info("Firing ProxyShutdownEvent (waiting up to {}s for plugins)...",
+                10);
+
+        eventManager.fire(new ProxyShutdownEvent())
+                .toCompletableFuture()
+                .get(shutdownTimeout, TimeUnit.SECONDS);
+
+        logger.info("ProxyShutdownEvent handlers finished.");
+      } catch (TimeoutException te) {
+        logger.warn("ProxyShutdownEvent timed out after {}s; continuing shutdown.",
+                shutdownTimeout);
+      } catch (ExecutionException ee) {
+        logger.error("Exception in ProxyShutdownEvent handler; continuing shutdown.", ee);
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        logger.warn("Interrupted while waiting for ProxyShutdownEvent; continuing shutdown.");
+      }
+
       ImmutableList<ConnectedPlayer> players = ImmutableList.copyOf(connectionsByUuid.values());
       for (ConnectedPlayer player : players) {
         player.disconnect(reason);
@@ -589,7 +610,6 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
         try {
           // Wait for the connections finish tearing down, this
           // makes sure that all the disconnect events are being fired
-
           CompletableFuture<Void> playersTeardownFuture = CompletableFuture.allOf(players.stream()
                   .map(ConnectedPlayer::getTeardownFuture)
                   .toArray((IntFunction<CompletableFuture<Void>[]>) CompletableFuture[]::new));
@@ -601,8 +621,6 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
           timedOut = true;
           logger.error("Exception while tearing down player connections", e);
         }
-
-        eventManager.fire(new ProxyShutdownEvent()).join();
 
         timedOut = !scheduler.shutdown() || timedOut;
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -24,6 +24,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.velocitypowered.api.command.BrigadierCommand;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.proxy.ProxyPreShutdownEvent;
 import com.velocitypowered.api.event.proxy.ProxyReloadEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
@@ -581,22 +582,22 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
       int shutdownTimeout = 10;
 
       try {
-        logger.info("Firing ProxyShutdownEvent (waiting up to {}s for plugins)...",
+        logger.info("Firing ProxyPreShutdownEvent (waiting up to {}s for plugins)...",
                 10);
 
-        eventManager.fire(new ProxyShutdownEvent())
+        eventManager.fire(new ProxyPreShutdownEvent())
                 .toCompletableFuture()
                 .get(shutdownTimeout, TimeUnit.SECONDS);
 
-        logger.info("ProxyShutdownEvent handlers finished.");
+        logger.info("ProxyPreShutdownEvent handlers finished.");
       } catch (TimeoutException te) {
-        logger.warn("ProxyShutdownEvent timed out after {}s; continuing shutdown.",
+        logger.warn("ProxyPreShutdownEvent timed out after {}s; continuing shutdown.",
                 shutdownTimeout);
       } catch (ExecutionException ee) {
-        logger.error("Exception in ProxyShutdownEvent handler; continuing shutdown.", ee);
+        logger.error("Exception in ProxyPreShutdownEvent handler; continuing shutdown.", ee);
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
-        logger.warn("Interrupted while waiting for ProxyShutdownEvent; continuing shutdown.");
+        logger.warn("Interrupted while waiting for ProxyPreShutdownEvent; continuing shutdown.");
       }
 
       ImmutableList<ConnectedPlayer> players = ImmutableList.copyOf(connectionsByUuid.values());
@@ -622,6 +623,8 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
           timedOut = true;
           logger.error("Exception while tearing down player connections", e);
         }
+
+        eventManager.fire(new ProxyShutdownEvent()).join();
 
         timedOut = !scheduler.shutdown() || timedOut;
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -582,14 +582,9 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
       int shutdownTimeout = 10;
 
       try {
-        logger.info("Firing ProxyPreShutdownEvent (waiting up to {}s for plugins)...",
-                10);
-
         eventManager.fire(new ProxyPreShutdownEvent())
                 .toCompletableFuture()
                 .get(shutdownTimeout, TimeUnit.SECONDS);
-
-        logger.info("ProxyPreShutdownEvent handlers finished.");
       } catch (TimeoutException te) {
         logger.warn("ProxyPreShutdownEvent timed out after {}s; continuing shutdown.",
                 shutdownTimeout);

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -590,7 +590,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
                 shutdownTimeout);
       } catch (ExecutionException ee) {
         logger.error("Exception in ProxyPreShutdownEvent handler; continuing shutdown.", ee);
-      } catch (InterruptedException ie) {
+      } catch (InterruptedException ignored) {
         Thread.currentThread().interrupt();
         logger.warn("Interrupted while waiting for ProxyPreShutdownEvent; continuing shutdown.");
       }

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -151,7 +151,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
       )
       .registerTypeHierarchyAdapter(Favicon.class, FaviconSerializer.INSTANCE)
       .create();
-    private static final int PRE_SHUTDOWN_TIMEOUT =
+  private static final int PRE_SHUTDOWN_TIMEOUT =
             Integer.getInteger("velocity.pre-shutdown-timeout", 10);
 
   private final ConnectionManager cm;

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -586,7 +586,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
                 .toCompletableFuture()
                 .get(shutdownTimeout, TimeUnit.SECONDS);
       } catch (TimeoutException ignored) {
-        logger.warn("ProxyPreShutdownEvent timed out after {}s; continuing shutdown.",
+        logger.warn("Your plugins took over {} seconds to shut down while disconnecting players.",
                 shutdownTimeout);
       } catch (ExecutionException ee) {
         logger.error("Exception in ProxyPreShutdownEvent handler; continuing shutdown.", ee);

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -586,7 +586,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
                 .toCompletableFuture()
                 .get(shutdownTimeout, TimeUnit.SECONDS);
       } catch (TimeoutException ignored) {
-        logger.warn("Your plugins took over {} seconds to shut down while disconnecting players.",
+        logger.warn("Your plugins took over {} seconds during pre shut down.",
                 shutdownTimeout);
       } catch (ExecutionException ee) {
         logger.error("Exception in ProxyPreShutdownEvent handler; continuing shutdown.", ee);

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -586,7 +586,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
                 .toCompletableFuture()
                 .get(shutdownTimeout, TimeUnit.SECONDS);
       } catch (TimeoutException ignored) {
-        logger.warn("Your plugins took over {} seconds during pre shut down.",
+        logger.warn("Your plugins took over {} seconds during pre shutdown.",
                 shutdownTimeout);
       } catch (ExecutionException ee) {
         logger.error("Exception in ProxyPreShutdownEvent handler; continuing shutdown.", ee);

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -151,6 +151,8 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
       )
       .registerTypeHierarchyAdapter(Favicon.class, FaviconSerializer.INSTANCE)
       .create();
+    private static final int PRE_SHUTDOWN_TIMEOUT =
+            Integer.getInteger("velocity.pre-shutdown-timeout", 10);
 
   private final ConnectionManager cm;
   private final ProxyOptions options;
@@ -579,15 +581,13 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
       // done first to refuse new connections
       cm.shutdown();
 
-      int shutdownTimeout = 10;
-
       try {
         eventManager.fire(new ProxyPreShutdownEvent())
                 .toCompletableFuture()
-                .get(shutdownTimeout, TimeUnit.SECONDS);
+                .get(PRE_SHUTDOWN_TIMEOUT, TimeUnit.SECONDS);
       } catch (TimeoutException ignored) {
         logger.warn("Your plugins took over {} seconds during pre shutdown.",
-                shutdownTimeout);
+                PRE_SHUTDOWN_TIMEOUT);
       } catch (ExecutionException ee) {
         logger.error("Exception in ProxyPreShutdownEvent handler; continuing shutdown.", ee);
       } catch (InterruptedException ignored) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -585,7 +585,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
         eventManager.fire(new ProxyPreShutdownEvent())
                 .toCompletableFuture()
                 .get(shutdownTimeout, TimeUnit.SECONDS);
-      } catch (TimeoutException te) {
+      } catch (TimeoutException ignored) {
         logger.warn("ProxyPreShutdownEvent timed out after {}s; continuing shutdown.",
                 shutdownTimeout);
       } catch (ExecutionException ee) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -610,6 +610,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
         try {
           // Wait for the connections finish tearing down, this
           // makes sure that all the disconnect events are being fired
+
           CompletableFuture<Void> playersTeardownFuture = CompletableFuture.allOf(players.stream()
                   .map(ConnectedPlayer::getTeardownFuture)
                   .toArray((IntFunction<CompletableFuture<Void>[]>) CompletableFuture[]::new));


### PR DESCRIPTION
This change modifies the proxy shutdown sequence so that all connected players are not immediately disconnected.
Instead, the shutdown process now:

1. Stops accepting new connections (cm.shutdown()).
2. Fires ProxyPreShutdownEvent and waits (up to 10 seconds) for all event handlers to complete.

- This allows plugins to transfer players to another proxy or perform other shutdown logic before disconnection.