### PR TITLE
fix: send callback command to >= 1.21.6 clients

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -359,7 +359,12 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
       // Inject commands from the proxy.
       final CommandGraphInjector<CommandSource> injector = server.getCommandManager().getInjector();
       injector.inject(rootNode, serverConn.getPlayer());
-      rootNode.removeChildByName("velocity:callback");
+
+      // In 1.21.6 a confirmation prompt was added when executing a command via `run_command` click
+      // action if the command is unknown. To prevent this prompt we have to send the command.
+      if (this.playerConnection.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_21_6)) {
+        rootNode.removeChildByName("velocity:callback");
+      }
     }
 
     server.getEventManager().fire(


### PR DESCRIPTION
In 1.21.6 a confirmation prompt was added when executing a command via `run_command` click action if the command is unknown. I couldn't find any gh issues about this, but I remember it being brought up in discord a few times. I see 2 options to fix this:

We could change the click callback implementation to use the new `custom` click action, which was also added in1.21.6. This is what was said will be done whenever this was brought up in discord. The issue I see with this is that there is no nice way to convert that action into something that is supported by <= 1.21.5 clients (the "old" `/velocity:callback` command). It would require us to reconstruct every component sent to older clients in order to replace the event on them and their children. That just doesn't seem ideal.

The other option is what this pr implements: just sending the `/velocity:callback` command to >= 1.21.6 clients. This basically has the same effect (to both players and developers) as the first option, but requires way less work. I don't think it's worth the effort to implement a click event replacement system just so that we're using "the mojang intended way" of doing this.

We should look into intercepting the packet and adding some sort of PlayerCustomClickEvent, to allow developers to add their own API for this if they want to.