### PR TITLE
chore: bump adventure to 4.24.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,8 @@ shadow = "com.gradleup.shadow:8.3.6"
 spotless = "com.diffplug.spotless:6.25.0"
 
 [libraries]
-adventure-bom = "net.kyori:adventure-bom:4.23.0"
-adventure-text-serializer-json-legacy-impl = "net.kyori:adventure-text-serializer-json-legacy-impl:4.23.0"
+adventure-bom = "net.kyori:adventure-bom:4.24.0"
+adventure-text-serializer-json-legacy-impl = "net.kyori:adventure-text-serializer-json-legacy-impl:4.24.0"
 adventure-facet = "net.kyori:adventure-platform-facet:4.3.4"
 asm = "org.ow2.asm:asm:9.8"
 auto-service = "com.google.auto.service:auto-service:1.0.1"


### PR DESCRIPTION
no changes that require implementation from our side: https://github.com/KyoriPowered/adventure/releases/tag/v4.24.0
we could *technically* implement `Audience#closeDialog` (we have the packet, just need to map it during PLAY), but I think that's best saved for when an actual API comes around.