### PR TITLE
Bump to Netty 4.2.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ configurate3 = "3.7.3"
 configurate4 = "4.1.2"
 flare = "2.0.1"
 log4j = "2.24.3"
-netty = "4.2.4.Final"
+netty = "4.2.5.Final"
 
 [plugins]
 fill = "io.papermc.fill.gradle:1.0.3"


### PR DESCRIPTION
https://netty.io/news/2025/09/03/4-2-5.html
Security fixes and IoUring performance issues have been fixed.

```
We are happy to announce the release of netty 4.2.5.Final. This is a bug-fix release which also contains a 2 security fixes, [CVE-2025-58057](https://github.com/netty/netty/security/advisories/GHSA-3p8m-j85q-pgmj) and [CVE-2025-58056](https://github.com/netty/netty/security/advisories/GHSA-fghv-69vj-qj49).

The most important changes are:

Decompression codecs vulnerable to DoS via zip bomb style attack ([CVE-2025-58057](https://github.com/netty/netty/security/advisories/GHSA-3p8m-j85q-pgmj))
Request smuggling due to incorrect parsing of chunk extensions ([CVE-2025-58056](https://github.com/netty/netty/security/advisories/GHSA-fghv-69vj-qj49))
Only register chunk sizes in adaptive allocator ([#15575](https://github.com/netty/netty/pull/15575))
Always load BouncyCastle classes with the Netty classloader ([#15569](https://github.com/netty/netty/pull/15569))
Update to quiche 0.24.5 ([#15556](https://github.com/netty/netty/pull/15556))
Clean up netty-buffer Import-Package ([#15562](https://github.com/netty/netty/pull/15562))
Don't try to handle incomplete upgrade request ([#15581](https://github.com/netty/netty/pull/15581))
SubmissionQueue::toString should iterate from the head ([#15586](https://github.com/netty/netty/pull/15586))
Implement automatic scaling for EventLoopGroup threads ([#15524](https://github.com/netty/netty/pull/15524))
Drop unknown frame on missing stream ([#15592](https://github.com/netty/netty/pull/15592))
IoUring: Reduce redundant system calls ([#15591](https://github.com/netty/netty/pull/15591))
IoUring: Always correctly handle result for zero copy ([#15600](https://github.com/netty/netty/pull/15600))
Fix IllegalReferenceCountException on invalid upgrade response ([#15602](https://github.com/netty/netty/pull/15602))
```