### PR TITLE
Feat: HaProxyAddress

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/InboundConnection.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/InboundConnection.java
@@ -42,6 +42,14 @@ public interface InboundConnection {
   Optional<String> getRawVirtualHost();
 
   /**
+   * If the connection was made through a proxy using the HAProxy protocol, this will contain the
+   * real address of the proxy. Otherwise, this will be empty.
+   *
+   * @return the address of the HAProxy proxy, if applicable
+   */
+  Optional<InetSocketAddress> getHaProxyAddress();
+
+  /**
    * Determine whether or not the player remains online.
    *
    * @return whether or not the player active

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -87,6 +87,7 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
   private final Channel channel;
   public boolean pendingConfigurationSwitch = false;
   private SocketAddress remoteAddress;
+  private @Nullable SocketAddress haProxyAddress;
   private StateRegistry state;
   private Map<StateRegistry, MinecraftSessionHandler> sessionHandlers;
   private @Nullable MinecraftSessionHandler activeSessionHandler;
@@ -158,6 +159,10 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
       } else if (msg instanceof HAProxyMessage proxyMessage) {
         this.remoteAddress = new InetSocketAddress(proxyMessage.sourceAddress(),
             proxyMessage.sourcePort());
+
+        final var proxyTransportAddress = (InetSocketAddress) ctx.channel().remoteAddress();
+        this.haProxyAddress = new InetSocketAddress(proxyTransportAddress.getAddress().getHostAddress(),
+                proxyTransportAddress.getPort());
       } else if (msg instanceof ByteBuf) {
         activeSessionHandler.handleUnknown((ByteBuf) msg);
       }
@@ -325,6 +330,10 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
 
   public SocketAddress getRemoteAddress() {
     return remoteAddress;
+  }
+
+  public @Nullable SocketAddress getHaProxyAddress() {
+    return haProxyAddress;
   }
 
   public StateRegistry getState() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -383,6 +383,11 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     return Optional.ofNullable(rawVirtualHost);
   }
 
+  @Override
+  public Optional<InetSocketAddress> getHaProxyAddress() {
+    return Optional.ofNullable((InetSocketAddress) connection.getHaProxyAddress());
+  }
+
   void setPermissionFunction(PermissionFunction permissionFunction) {
     this.permissionFunction = permissionFunction;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -249,6 +249,11 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
     }
 
     @Override
+    public Optional<InetSocketAddress> getHaProxyAddress() {
+      return Optional.ofNullable((InetSocketAddress) connection.getHaProxyAddress());
+    }
+
+    @Override
     public boolean isActive() {
       return !connection.isClosed();
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialInboundConnection.java
@@ -70,6 +70,11 @@ public final class InitialInboundConnection implements VelocityInboundConnection
   }
 
   @Override
+  public Optional<InetSocketAddress> getHaProxyAddress() {
+    return Optional.ofNullable((InetSocketAddress) connection.getHaProxyAddress());
+  }
+
+  @Override
   public boolean isActive() {
     return connection.getChannel().isActive();
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginInboundConnection.java
@@ -78,6 +78,11 @@ public class LoginInboundConnection implements LoginPhaseConnection, KeyIdentifi
   }
 
   @Override
+  public Optional<InetSocketAddress> getHaProxyAddress() {
+    return delegate.getHaProxyAddress();
+  }
+
+  @Override
   public boolean isActive() {
     return delegate.isActive();
   }


### PR DESCRIPTION
- Exposes for the InboundConnection the SocketAddress related to the HaProxy Address which transports the player tcp connection. Mostly for debugging / diagnostic reasons.
- This can be useful to diagnose if players with high latency are sharing the same HaProxy Address.
- Given that the majority of networks run velocity behind services like TCPShield or similar, exposing the HaProxyAddress can give them some benefit for debugging.