### PR TITLE
Bump to Netty 4.2.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ configurate3 = "3.7.3"
 configurate4 = "4.1.2"
 flare = "2.0.1"
 log4j = "2.24.3"
-netty = "4.2.5.Final"
+netty = "4.2.6.Final"
 
 [plugins]
 fill = "io.papermc.fill.gradle:1.0.3"


### PR DESCRIPTION
https://netty.io/news/2025/09/08/4-2-6.html

> We are happy to announce the release of netty 4.2.6.Final. This is a bug-fix release which fixes a regression introduced by 4.2.5.Final that might affect you if you use BouncyCastle. We decided to do a quick follow-up release here so people that depend on it can still get the fixes for [CVE-2025-58057](https://github.com/netty/netty/security/advisories/GHSA-3p8m-j85q-pgmj) and [CVE-2025-58056](https://github.com/netty/netty/security/advisories/GHSA-fghv-69vj-qj49) that were part of 4.2.5.Final.

> 
> The most important changes are:

> 
> BouncyCastleAlpnSslUtils needs to use the correct SSLEngine class as otherwise it will fail to init static fields. ([#15630](https://github.com/netty/netty/pull/15630))
> IoUring: Allow to create IoHandlerFactory that supports changing the Thread and so supports AutoScalingEventExecutorChooserFactory. ([#15608](https://github.com/netty/netty/pull/15608))
