### PR TITLE
feat: allow for custom ping default

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -92,6 +92,8 @@ public class VelocityConfiguration implements ProxyConfig {
   private net.kyori.adventure.text.@MonotonicNonNull Component motdAsComponent;
   private @Nullable Favicon favicon;
   @Expose
+  private long unknownPingDefault = -1;
+  @Expose
   private boolean forceKeyAuthentication = true; // Added in 1.19
 
   private VelocityConfiguration(Servers servers, ForcedHosts forcedHosts, Advanced advanced,
@@ -107,7 +109,7 @@ public class VelocityConfiguration implements ProxyConfig {
       boolean preventClientProxyConnections, boolean announceForge,
       PlayerInfoForwarding playerInfoForwardingMode, byte[] forwardingSecret,
       boolean onlineModeKickExistingPlayers, PingPassthroughMode pingPassthrough,
-      boolean samplePlayersInPing, boolean enablePlayerAddressLogging, Servers servers,
+      boolean samplePlayersInPing, boolean enablePlayerAddressLogging, long unknownPingDefault, Servers servers,
       ForcedHosts forcedHosts, Advanced advanced, Query query, Metrics metrics,
       boolean forceKeyAuthentication) {
     this.bind = bind;
@@ -122,6 +124,7 @@ public class VelocityConfiguration implements ProxyConfig {
     this.pingPassthrough = pingPassthrough;
     this.samplePlayersInPing = samplePlayersInPing;
     this.enablePlayerAddressLogging = enablePlayerAddressLogging;
+    this.unknownPingDefault = unknownPingDefault;
     this.servers = servers;
     this.forcedHosts = forcedHosts;
     this.advanced = advanced;
@@ -413,6 +416,10 @@ public class VelocityConfiguration implements ProxyConfig {
     return enablePlayerAddressLogging;
   }
 
+  public long getUnknownPingDefault() {
+    return unknownPingDefault;
+  }
+
   public boolean isBungeePluginChannelEnabled() {
     return advanced.isBungeePluginMessageChannel();
   }
@@ -465,6 +472,7 @@ public class VelocityConfiguration implements ProxyConfig {
         .add("query", query)
         .add("favicon", favicon)
         .add("enablePlayerAddressLogging", enablePlayerAddressLogging)
+        .add("unknownPingDefault", unknownPingDefault)
         .add("forceKeyAuthentication", forceKeyAuthentication)
         .toString();
   }
@@ -557,6 +565,7 @@ public class VelocityConfiguration implements ProxyConfig {
       final boolean kickExisting = config.getOrElse("kick-existing-players", false);
       final boolean enablePlayerAddressLogging = config.getOrElse(
               "enable-player-address-logging", true);
+      final int unknownPingDefault = config.getOrElse("unknown-ping-default", -1);
 
       // Throw an exception if the forwarding-secret file is empty and the proxy is using a
       // forwarding mode that requires it.
@@ -579,6 +588,7 @@ public class VelocityConfiguration implements ProxyConfig {
               pingPassthroughMode,
               samplePlayersInPing,
               enablePlayerAddressLogging,
+              unknownPingDefault,
               new Servers(serversConfig),
               new ForcedHosts(forcedHostsConfig),
               new Advanced(advancedConfig),

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -318,6 +318,10 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
 
   @Override
   public long getPing() {
+    final long defaultPing = server.getConfiguration().getUnknownPingDefault();
+    if (this.ping < 0) {
+      return defaultPing;
+    }
     return this.ping;
   }
 

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -74,6 +74,10 @@ sample-players-in-ping = false
 # If not enabled (default is true) player IP addresses will be replaced by <ip address withheld> in logs
 enable-player-address-logging = true
 
+# What ping should be used for a player if their ping is not yet known? By default, this is -1.
+# Changing this may cause issues with implementations that expect a negative ping to mean "unknown".
+unknown-ping-default = -1
+
 [servers]
 # Configure your servers here. Each key represents the server's name, and the value
 # represents the IP address of the server to connect to.


### PR DESCRIPTION
When Velocity has not yet determined the player's ping, and the Velocity API is called, `-1` is returned. This change allows that value to be set to any `long` value via `velocity.toml`.