### PR TITLE
fix: Enable EMIT_CLICK_URL_HTTPS on component serializers

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
@@ -62,6 +62,8 @@ public enum ProtocolUtils {
           .legacyHoverEventSerializer(NBTLegacyHoverEventSerializer.get())
           .options(
               OptionSchema.globalSchema().stateBuilder()
+              // general options
+              .value(JSONOptions.EMIT_CLICK_URL_HTTPS, Boolean.TRUE)
               // before 1.16
               .value(JSONOptions.EMIT_RGB, Boolean.FALSE)
               .value(JSONOptions.EMIT_HOVER_EVENT_TYPE, JSONOptions.HoverEventValueMode.VALUE_FIELD)
@@ -80,6 +82,8 @@ public enum ProtocolUtils {
           .legacyHoverEventSerializer(NBTLegacyHoverEventSerializer.get())
           .options(
               OptionSchema.globalSchema().stateBuilder()
+              // general options
+              .value(JSONOptions.EMIT_CLICK_URL_HTTPS, Boolean.TRUE)
               // after 1.16
               .value(JSONOptions.EMIT_RGB, Boolean.TRUE)
               .value(JSONOptions.EMIT_HOVER_EVENT_TYPE, JSONOptions.HoverEventValueMode.CAMEL_CASE)
@@ -99,6 +103,8 @@ public enum ProtocolUtils {
           .legacyHoverEventSerializer(NBTLegacyHoverEventSerializer.get())
           .options(
               OptionSchema.globalSchema().stateBuilder()
+              // general options
+              .value(JSONOptions.EMIT_CLICK_URL_HTTPS, Boolean.TRUE)
               // after 1.16
               .value(JSONOptions.EMIT_RGB, Boolean.TRUE)
               .value(JSONOptions.EMIT_HOVER_EVENT_TYPE, JSONOptions.HoverEventValueMode.CAMEL_CASE)
@@ -118,6 +124,8 @@ public enum ProtocolUtils {
           .legacyHoverEventSerializer(NBTLegacyHoverEventSerializer.get())
           .options(
               OptionSchema.globalSchema().stateBuilder()
+              // general options
+              .value(JSONOptions.EMIT_CLICK_URL_HTTPS, Boolean.TRUE)
               // after 1.16
               .value(JSONOptions.EMIT_RGB, Boolean.TRUE)
               .value(JSONOptions.EMIT_HOVER_EVENT_TYPE, JSONOptions.HoverEventValueMode.SNAKE_CASE)


### PR DESCRIPTION
Since 1.21.5 URIs without a `http://` or `https://` in a `open_url` click event are no longer silently ignored but fail parsing and disconnect. Paper mitigates this in their codec by prepending a `https://` to URIs with no protocol.

This PR enables [`JSONOptions.EMIT_CLICK_URL_HTTPS`](https://jd.advntr.dev/text-serializer-json/4.25.0/net/kyori/adventure/text/serializer/json/JSONOptions.html#EMIT_CLICK_URL_HTTPS) on our component serializers, to match papers behavior. To "fix" the disconnect the option would technically only be needed for >= 1.21.5, but I think it is best to just enable it for every version to stay consistent.

Related #1630