### PR TITLE
Increase TabComplete max char limit to respect command block character limit

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/TabCompleteRequestPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/TabCompleteRequestPacket.java
@@ -31,7 +31,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class TabCompleteRequestPacket implements MinecraftPacket {
 
-  private static final int VANILLA_MAX_TAB_COMPLETE_LEN = 2048;
+  private static final int VANILLA_MAX_TAB_COMPLETE_LEN = 32767;
 
   private @Nullable String command;
   private int transactionId;


### PR DESCRIPTION
This change increases the TabComplete limit in order to fix the now broken pasting of larger commands into command blocks after Mojang's change to the way Tab Complete works. It has been increased to 32767 from 2048, and this increase has no negative impact on performance, stability, or protocol compliance.

Mojang clients and servers already allow command strings up to 32767 characters, and this update brings Velocity in line with the vanilla protocol. This prevents unnecessary disconnections when pasting valid command block contents while retaining full protection against malformed packets.