### PR TITLE
Document command rate limiting on Command events (#1637)

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/command/CommandExecuteEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/command/CommandExecuteEvent.java
@@ -19,6 +19,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /**
  * This event is fired when someone executes a command. Velocity will wait for this event to finish
  * firing before trying to handle the command and/or forwarding it to the server.
+ *
+ * <p>Note that due to the proxy's command rate limiting, this event may not be fired for
+ * every command sent by the client in rapid succession. In such cases, the command is forwarded
+ * directly to the backend server.</p>
  */
 @AwaitingEvent
 public final class CommandExecuteEvent implements ResultedEvent<CommandResult> {

--- a/api/src/main/java/com/velocitypowered/api/event/command/PostCommandInvocationEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/command/PostCommandInvocationEvent.java
@@ -19,6 +19,10 @@ import org.jetbrains.annotations.NotNull;
  * <p>Commands can be cancelled or forwarded to backend servers in {@link CommandExecuteEvent}.
  * This will prevent firing this event.</p>
  *
+ * <p>Note that due to the proxy's command rate limiting, this event may not be fired for
+ * every command sent by the client in rapid succession. In such cases, the command is forwarded
+ * directly to the backend server and not handled by the proxy.</p>
+ *
  * @since 3.3.0
  */
 public final class PostCommandInvocationEvent {


### PR DESCRIPTION
This PR resolves issue #1637 by adding Javadocs to CommandExecuteEvent and PostCommandInvocationEvent.

As said in #1635, developers are not always aware that Velocity does command rate limiting. This can lead to confusion when not all rapidly executed commands (usually done with macros or mods) trigger the corresponding events, as they are forwarded directly to the backend server.

These small changes clarify the intended behavior directly within the event documentation, preventing further confusion.