### PR TITLE
Fix exception message formatting in command invocation

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -256,7 +256,7 @@ public class VelocityCommandManager implements CommandManager {
       }
     } catch (final Throwable e) {
       // Ugly, ugly swallowing of everything Throwable, because plugins are naughty.
-      throw new RuntimeException("Unable to invoke command  " + parsed.getReader().getString() + "for " + source, e);
+      throw new RuntimeException("Unable to invoke command " + parsed.getReader().getString() + " for " + source, e);
     } finally {
       eventManager.fireAndForget(new PostCommandInvocationEvent(source, parsed.getReader().getString(), result));
     }


### PR DESCRIPTION
**Before:** java.lang.RuntimeException: Unable to invoke command  examplecmd exampleargfor [connected player] SzymON_OFF (/1.1.1.1/11111)
**After:** java.lang.RuntimeException: Unable to invoke command examplecmd examplearg for [connected player] SzymON_OFF (/1.1.1.1:11111)