### PR TITLE
feat: add server field to ServerPostConnectEvent

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/player/ServerPostConnectEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/ServerPostConnectEvent.java
@@ -19,11 +19,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class ServerPostConnectEvent {
   private final Player player;
+  private final RegisteredServer server;
   private final RegisteredServer previousServer;
 
   public ServerPostConnectEvent(Player player,
-      @Nullable RegisteredServer previousServer) {
+                                RegisteredServer server,
+                                @Nullable RegisteredServer previousServer) {
     this.player = Preconditions.checkNotNull(player, "player");
+    this.server = server;
     this.previousServer = previousServer;
   }
 
@@ -34,6 +37,10 @@ public class ServerPostConnectEvent {
    */
   public Player getPlayer() {
     return player;
+  }
+
+  public RegisteredServer getServer() {
+    return server;
   }
 
   /**
@@ -50,6 +57,7 @@ public class ServerPostConnectEvent {
   public String toString() {
     return "ServerPostConnectEvent{"
         + "player=" + player
+        + ", server=" + server
         + ", previousServer=" + previousServer
         + '}';
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -63,8 +63,8 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
    * @param resultFuture the result future
    */
   TransitionSessionHandler(VelocityServer server,
-      VelocityServerConnection serverConn,
-      CompletableFuture<Impl> resultFuture) {
+                           VelocityServerConnection serverConn,
+                           CompletableFuture<Impl> resultFuture) {
     this.server = server;
     this.serverConn = serverConn;
     this.resultFuture = resultFuture;
@@ -153,6 +153,7 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
 
           // We're done! :)
           server.getEventManager().fireAndForget(new ServerPostConnectEvent(player,
+              serverConn.getServer(),
               previousServer));
           resultFuture.complete(ConnectionRequestResults.successful(serverConn.getServer()));
         }, smc.eventLoop()).exceptionally(exc -> {


### PR DESCRIPTION
Since the [ServerConnectedEvent](https://jd.papermc.io/velocity/3.4.0/com/velocitypowered/api/event/player/ServerConnectedEvent.html) doesn't seem to support sending plugin messages to the newly connected server, it would be helpful to be able to access the new server in ServerPostConnectEvent, where plugin messaging works.

Sorry for the weird formatting changes, I couldn't get my formatter to stop indenting the constructor arguments... the checkstyle seems to pass though...