### PR TITLE
Feat/configurable command forwarding

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/CommandMeta.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandMeta.java
@@ -42,6 +42,13 @@ public interface CommandMeta {
   @Nullable Object getPlugin();
 
   /**
+   * Returns whether partial invocations of this command are forwarded to the backend.
+   *
+   * @return whether to forward partial invocations
+   */
+  boolean forwardPartial();
+
+  /**
    * Provides a fluent interface to create {@link CommandMeta}s.
    */
   interface Builder {
@@ -72,6 +79,18 @@ public interface CommandMeta {
      * @return this builder, for chaining
      */
     Builder plugin(Object plugin);
+
+    /**
+     * Specifies whether partial matches to this command are forwarded to the backend.
+     *
+     * <p>For example with the registered command "rootcommand -> subcommand" where only the subcommand is executable, this
+     * specifies whether invocations such as "/rootcommand" or "/rootcommand nonexistant" should be forwarded to the
+     * backend, or be handled on the proxy.
+     *
+     * @param fowardPartial whether to forward partial matches
+     * @return this builder, for chaining
+     */
+    Builder forwardPartial(boolean fowardPartial);
 
     /**
      * Returns a newly-created {@link CommandMeta} based on the specified parameters.

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -239,26 +239,43 @@ public class VelocityCommandManager implements CommandManager {
       return executed;
     } catch (final CommandSyntaxException e) {
       boolean isSyntaxError = !e.getType().equals(CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand())
-              && !e.getType().equals(CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownArgument());
+          && !e.getType().equals(CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownArgument());
+
       if (isSyntaxError) {
-        final Message message = e.getRawMessage();
-        if (message instanceof ComponentLike componentLike) {
-          source.sendMessage(componentLike.asComponent().applyFallbackStyle(NamedTextColor.RED));
-        } else {
-          source.sendMessage(Component.text(e.getMessage(), NamedTextColor.RED));
-        }
-        result = com.velocitypowered.api.command.CommandResult.SYNTAX_ERROR;
+        sendError(source, e);
+        result = CommandResult.SYNTAX_ERROR;
         // This is, of course, a lie, but the API will need to change...
         return true;
-      } else {
-        result = CommandResult.FORWARDED;
-        return false;
       }
+
+      boolean existsOnProxy = !parsed.getContext().getNodes().isEmpty();
+      if (existsOnProxy) {
+        String invokedAlias = parsed.getContext().getNodes().get(0).getRange().get(parsed.getReader());
+        CommandMeta meta = this.commandMetas.get(invokedAlias);
+        if (meta != null && !meta.forwardPartial()) {
+          // mark command handled and send error to source if command meta specifies partial matches should not be forwarded
+          sendError(source, e);
+          result = CommandResult.SYNTAX_ERROR;
+          return true;
+        }
+      }
+      // Command does not exist or was not handled on the proxy, let the backend server handle it
+      result = CommandResult.FORWARDED;
+      return false;
     } catch (final Throwable e) {
       // Ugly, ugly swallowing of everything Throwable, because plugins are naughty.
       throw new RuntimeException("Unable to invoke command " + parsed.getReader().getString() + " for " + source, e);
     } finally {
       eventManager.fireAndForget(new PostCommandInvocationEvent(source, parsed.getReader().getString(), result));
+    }
+  }
+
+  private void sendError(CommandSource source, CommandSyntaxException e) {
+    final Message message = e.getRawMessage();
+    if (message instanceof ComponentLike componentLike) {
+      source.sendMessage(componentLike.asComponent().applyFallbackStyle(NamedTextColor.RED));
+    } else {
+      source.sendMessage(Component.text(e.getMessage(), NamedTextColor.RED));
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -238,8 +238,8 @@ public class VelocityCommandManager implements CommandManager {
       result = executed ? CommandResult.EXECUTED : CommandResult.FORWARDED;
       return executed;
     } catch (final CommandSyntaxException e) {
-      boolean isSyntaxError = !e.getType().equals(
-          CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand());
+      boolean isSyntaxError = !e.getType().equals(CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownCommand())
+              && !e.getType().equals(CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownArgument());
       if (isSyntaxError) {
         final Message message = e.getRawMessage();
         if (message instanceof ComponentLike componentLike) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -59,7 +59,10 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.checkerframework.checker.lock.qual.GuardedBy;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -271,12 +274,33 @@ public class VelocityCommandManager implements CommandManager {
   }
 
   private void sendError(CommandSource source, CommandSyntaxException e) {
+    TextComponent.Builder error = Component.text();
     final Message message = e.getRawMessage();
     if (message instanceof ComponentLike componentLike) {
-      source.sendMessage(componentLike.asComponent().applyFallbackStyle(NamedTextColor.RED));
+      error.append(componentLike.asComponent().applyFallbackStyle(NamedTextColor.RED));
     } else {
-      source.sendMessage(Component.text(e.getMessage(), NamedTextColor.RED));
+      error.append(Component.text(message.toString(), NamedTextColor.RED));
     }
+
+    if (e.getInput() != null && e.getCursor() > 0) {
+      int min = Math.min(e.getInput().length(), e.getCursor());
+      TextComponent.Builder details = Component.text()
+          .color(NamedTextColor.GRAY)
+          .clickEvent(ClickEvent.suggestCommand("/" + e.getInput()));
+
+      if (min > 10) {
+        details.append(Component.text("..."));
+      }
+      details.append(Component.text(e.getInput().substring(Math.max(0, min - 10), min)));
+
+      if (e.getInput().length() > min) {
+        details.append(Component.text(e.getInput().substring(min), NamedTextColor.RED, TextDecoration.UNDERLINED));
+      }
+      details.append(Component.translatable("command.context.here", NamedTextColor.RED, TextDecoration.ITALIC));
+      error.append(Component.newline(), details);
+    }
+
+    source.sendMessage(error);
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandMeta.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandMeta.java
@@ -43,12 +43,14 @@ public final class VelocityCommandMeta implements CommandMeta {
     private final ImmutableSet.Builder<String> aliases;
     private final ImmutableList.Builder<CommandNode<CommandSource>> hints;
     private @MonotonicNonNull Object plugin;
+    private boolean forwardPartial;
 
     public Builder(final String alias) {
       Preconditions.checkNotNull(alias, "alias");
       this.aliases = ImmutableSet.<String>builder()
           .add(alias.toLowerCase(Locale.ENGLISH));
       this.hints = ImmutableList.builder();
+      this.forwardPartial = false;
       this.plugin = null;
     }
 
@@ -84,8 +86,14 @@ public final class VelocityCommandMeta implements CommandMeta {
     }
 
     @Override
+    public CommandMeta.Builder forwardPartial(boolean fowardPartial) {
+      this.forwardPartial = fowardPartial;
+      return this;
+    }
+
+    @Override
     public CommandMeta build() {
-      return new VelocityCommandMeta(this.aliases.build(), this.hints.build(), this.plugin);
+      return new VelocityCommandMeta(this.aliases.build(), this.hints.build(), this.plugin, this.forwardPartial);
     }
   }
 
@@ -126,15 +134,18 @@ public final class VelocityCommandMeta implements CommandMeta {
   private final Set<String> aliases;
   private final List<CommandNode<CommandSource>> hints;
   private final Object plugin;
+  private final boolean forwardPartial;
 
   private VelocityCommandMeta(
       final Set<String> aliases,
       final List<CommandNode<CommandSource>> hints,
-      final @Nullable Object plugin
+      final @Nullable Object plugin,
+      final boolean forwardPartial
   ) {
     this.aliases = aliases;
     this.hints = hints;
     this.plugin = plugin;
+    this.forwardPartial = forwardPartial;
   }
 
   @Override
@@ -150,6 +161,11 @@ public final class VelocityCommandMeta implements CommandMeta {
   @Override
   public @Nullable Object getPlugin() {
     return plugin;
+  }
+
+  @Override
+  public boolean forwardPartial() {
+    return forwardPartial;
   }
 
   @Override

--- a/proxy/src/test/java/com/velocitypowered/proxy/command/BrigadierCommandTests.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/command/BrigadierCommandTests.java
@@ -259,7 +259,7 @@ public class BrigadierCommandTests extends CommandTestSuite {
         .then(LiteralArgumentBuilder
             .<CommandSource>literal("world")
             .executes(context -> fail())
-            .requires(src -> true)
+            .requires(src -> false)
         )
         .build();
 

--- a/proxy/src/test/java/com/velocitypowered/proxy/command/BrigadierCommandTests.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/command/BrigadierCommandTests.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
@@ -231,6 +232,92 @@ public class BrigadierCommandTests extends CommandTestSuite {
         manager.executeAsync(source, "hello").join());
 
     assertSame(expected, wrapper.getCause());
+  }
+
+  @Test
+  void testForwardPartialMatch() {
+    final var node = LiteralArgumentBuilder
+        .<CommandSource>literal("hello")
+        .executes(context -> fail())
+        .then(LiteralArgumentBuilder
+            .<CommandSource>literal("world")
+            .executes(context -> fail())
+        )
+        .build();
+
+    var meta = manager.metaBuilder(new BrigadierCommand(node)).forwardPartial(true).build();
+    manager.register(meta, new BrigadierCommand(node));
+
+    assertForwarded("hello badargument");
+  }
+
+  @Test
+  void testForwardMissingRequirement() {
+    final var node = LiteralArgumentBuilder
+        .<CommandSource>literal("hello")
+        .executes(context -> fail())
+        .then(LiteralArgumentBuilder
+            .<CommandSource>literal("world")
+            .executes(context -> fail())
+            .requires(src -> true)
+        )
+        .build();
+
+    var meta = manager.metaBuilder(new BrigadierCommand(node)).forwardPartial(true).build();
+    manager.register(meta, new BrigadierCommand(node));
+
+    assertForwarded("hello world");
+  }
+
+  @Test
+  void testDontForwardHasRequirement() {
+    final var callCount = new AtomicInteger();
+
+    final var node = LiteralArgumentBuilder
+        .<CommandSource>literal("hello")
+        .executes(context -> fail())
+        .then(LiteralArgumentBuilder
+            .<CommandSource>literal("world")
+            .executes(context -> {
+              callCount.incrementAndGet();
+              return 1;
+            })
+            .requires(src -> true)
+        )
+        .build();
+
+    var meta = manager.metaBuilder(new BrigadierCommand(node)).forwardPartial(true).build();
+    manager.register(meta, new BrigadierCommand(node));
+
+    assertHandled("hello world");
+    assertEquals(1, callCount.get());
+  }
+
+  @Test
+  void testDontForwardArgumentParseException() {
+    final var callCount = new AtomicInteger();
+
+    final var node = LiteralArgumentBuilder
+        .<CommandSource>literal("number")
+        .executes(context -> fail())
+        .then(RequiredArgumentBuilder
+            .<CommandSource, Integer>argument("numberInRange", IntegerArgumentType.integer(1, 5))
+            .executes(context -> {
+              callCount.incrementAndGet();
+              return 1;
+            })
+            .requires(src -> true)
+        )
+        .build();
+
+    var meta = manager.metaBuilder(new BrigadierCommand(node)).forwardPartial(true).build();
+    manager.register(meta, new BrigadierCommand(node));
+
+    assertHandled("number 1");
+    assertHandled("number 235");
+    assertHandled("number -5");
+    assertHandled("number word"); // Is it desirable for this to be forwarded?
+    assertEquals(1, callCount.get());
   }
 
   // Suggestions


### PR DESCRIPTION
Currently if you have the following command
```java
var command = new BrigadierCommand(
        literalArgumentBuilder("vtestcommand")
                .then(literalArgumentBuilder("child")
                        .then(literalArgumentBuilder("grandchild")
                                .executes(ctx -> {
                                    ctx.getSource().sendMessage(text("grandchild response"));
                                    return 1;
                                })
                        )
                )
);
```
`/root` and `/root child` get forwarded to the backend and handled there, but `/root nonexistant` gets handled on the proxy. This is because the former cause "UnknownCommand" exceptions, and the later causes an "UnknownArgument" exception.

The first commit in this PR aligns that behaviour, however this causes breakages in Simple/Raw commands as those assume they get handled on the proxy even if the user doesn't have the requisite permission. Which isn't true anymore if we are forwarding invocations that cause a "UnknownArgument" exception. [this test](https://github.com/PaperMC/Velocity/blob/6cc1be7746ec49d2b600b1af1dcec99584750d38/proxy/src/test/java/com/velocitypowered/proxy/command/SimpleCommandTests.java#L143C8-L143C57) fails for example.

Currently I have resolved this by adding an toggle in the CommandMeta that decides whether partially-matching commands such as the ones above should be forwarded. The default is `false` to ensure all Simple- and RawCommands keep working as expected. I assume this will also cause the least amount of breakage in people's Brigadier commands, but there will still be some.