### PR TITLE
Corrected grammar in plugin annotation's javadocs

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/plugin/Plugin.java
+++ b/api/src/main/java/com/velocitypowered/api/plugin/Plugin.java
@@ -29,7 +29,7 @@ public @interface Plugin {
   String id();
 
   /**
-   * The human readable name of the plugin as to be used in descriptions and similar things.
+   * The human-readable name of the plugin as to be used in descriptions and similar things.
    *
    * @return The plugin name, or an empty string if unknown
    */


### PR DESCRIPTION
Changed “human readable” to the grammatically correct compound adjective “human-readable” in the plugin annotation to improve clarity and consistency across the documentation.