### PR TITLE
Pass register plugin messages through the serverbound configuration plugin message packet event

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -24,6 +24,7 @@ import com.velocitypowered.api.event.player.configuration.PlayerConfigurationEve
 import com.velocitypowered.api.event.player.configuration.PlayerFinishConfigurationEvent;
 import com.velocitypowered.api.event.player.configuration.PlayerFinishedConfigurationEvent;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
@@ -135,9 +136,16 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
       byte[] bytes = ByteBufUtil.getBytes(packet.content());
       ChannelIdentifier id = this.server.getChannelRegistrar().getFromId(packet.getChannel());
 
+      // Cancel unregistered plugin messages unless they are register/unregister packets
       if (id == null) {
-        serverConn.ensureConnected().write(packet.retain());
-        return true;
+        if (PluginMessageUtil.isRegister(packet)) {
+          id = MinecraftChannelIdentifier.from("register");
+        } else if (PluginMessageUtil.isUnregister(packet)) {
+          id = MinecraftChannelIdentifier.from("unregister");
+        } else {
+          serverConn.ensureConnected().write(packet.retain());
+          return true;
+        }
       }
 
       // Handling this stuff async means that we should probably pause

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -136,12 +136,12 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
       byte[] bytes = ByteBufUtil.getBytes(packet.content());
       ChannelIdentifier id = this.server.getChannelRegistrar().getFromId(packet.getChannel());
 
-      // Cancel unregistered plugin messages unless they are register/unregister packets
+      // Cancel unregistered plugin messages unless they are register/unregister messages
       if (id == null) {
         if (PluginMessageUtil.isRegister(packet)) {
-          id = MinecraftChannelIdentifier.from("register");
+          id = MinecraftChannelIdentifier.from(PluginMessageUtil.REGISTER_CHANNEL);
         } else if (PluginMessageUtil.isUnregister(packet)) {
-          id = MinecraftChannelIdentifier.from("unregister");
+          id = MinecraftChannelIdentifier.from(PluginMessageUtil.UNREGISTER_CHANNEL);
         } else {
           serverConn.ensureConnected().write(packet.retain());
           return true;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/util/PluginMessageUtil.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/util/PluginMessageUtil.java
@@ -48,9 +48,9 @@ public final class PluginMessageUtil {
   private static final String BRAND_CHANNEL_LEGACY = "MC|Brand";
   private static final String BRAND_CHANNEL = "minecraft:brand";
   private static final String REGISTER_CHANNEL_LEGACY = "REGISTER";
-  private static final String REGISTER_CHANNEL = "minecraft:register";
+  public static final String REGISTER_CHANNEL = "minecraft:register";
   private static final String UNREGISTER_CHANNEL_LEGACY = "UNREGISTER";
-  private static final String UNREGISTER_CHANNEL = "minecraft:unregister";
+  public static final String UNREGISTER_CHANNEL = "minecraft:unregister";
 
   private PluginMessageUtil() {
     throw new AssertionError();


### PR DESCRIPTION
In our plugin, I need to cancel a channel sent by Fabric's Particle API in order to prevent a confliction between Fabric API and our packet transformers. This patch allows me to intercept the register/unregister payloads and remove the channel.

I'm not familiar with the internals, so I wasn't sure where to put this best (as putting it into the registrar directly would probably introduce destructive API changes)

This patch is required for the top header commit on this tree: https://github.com/ViaVersion/ViaVersion/tree/next/fabric-particle-workaround