### PR TITLE
feat(player-connection): add config option to disable errors from player while they cant connect to a backend server.

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -437,6 +437,10 @@ public class VelocityConfiguration implements ProxyConfig {
     return advanced.isLogPlayerConnections();
   }
 
+  public boolean isLogConnectionErrors() {
+    return advanced.isLogConnectionErrors();
+  }
+
   public boolean isAcceptTransfers() {
     return this.advanced.isAcceptTransfers();
   }
@@ -764,6 +768,8 @@ public class VelocityConfiguration implements ProxyConfig {
     @Expose
     private boolean logPlayerConnections = true;
     @Expose
+    private boolean logConnectionErrors = true;
+    @Expose
     private boolean acceptTransfers = false;
     @Expose
     private boolean enableReusePort = false;
@@ -801,6 +807,7 @@ public class VelocityConfiguration implements ProxyConfig {
         this.announceProxyCommands = config.getOrElse("announce-proxy-commands", true);
         this.logCommandExecutions = config.getOrElse("log-command-executions", false);
         this.logPlayerConnections = config.getOrElse("log-player-connections", true);
+        this.logConnectionErrors = config.getOrElse("log-connection-errors", true);
         this.acceptTransfers = config.getOrElse("accepts-transfers", false);
         this.enableReusePort = config.getOrElse("enable-reuse-port", false);
         this.commandRateLimit = config.getIntOrElse("command-rate-limit", 25);
@@ -867,6 +874,10 @@ public class VelocityConfiguration implements ProxyConfig {
       return logPlayerConnections;
     }
 
+    public boolean isLogConnectionErrors() {
+      return logConnectionErrors;
+    }
+
     public boolean isAcceptTransfers() {
       return this.acceptTransfers;
     }
@@ -911,6 +922,7 @@ public class VelocityConfiguration implements ProxyConfig {
           + ", announceProxyCommands=" + announceProxyCommands
           + ", logCommandExecutions=" + logCommandExecutions
           + ", logPlayerConnections=" + logPlayerConnections
+          + ", logConnectionErrors=" + logConnectionErrors
           + ", acceptTransfers=" + acceptTransfers
           + ", enableReusePort=" + enableReusePort
           + '}';

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -715,8 +715,10 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       friendlyError = Component.translatable("velocity.error.connected-server-error",
           Component.text(server.getServerInfo().getName()));
     } else {
-      logger.error("{}: unable to connect to server {}", this, server.getServerInfo().getName(),
-          wrapped);
+      if(this.server.getConfiguration().isLogConnectionErrors()) {
+        logger.error("{}: unable to connect to server {}", this, server.getServerInfo().getName(),
+            wrapped);
+      }
       friendlyError = Component.translatable("velocity.error.connecting-server-error",
           Component.text(server.getServerInfo().getName()));
     }

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -146,6 +146,9 @@ log-command-executions = false
 # and disconnecting from the proxy.
 log-player-connections = true
 
+# Enables logging of errors when players fail to connect to backend servers.
+logConnectionErrors = true
+
 # Allows players transferred from other hosts via the
 # Transfer packet (Minecraft 1.20.5) to be received.
 accepts-transfers = false


### PR DESCRIPTION
Fixes #1707 

This PR adds a new config option to the velocity config (refactoring the default toml) and using the configuration value to either prevent or allow sending the error message when a connected player fails to join the backend server.