### PR TITLE
Provide an IDE pattern hint for plugin IDs

### DIFF
--- a/api/src/ap/java/com/velocitypowered/api/plugin/ap/SerializedPluginDescription.java
+++ b/api/src/ap/java/com/velocitypowered/api/plugin/ap/SerializedPluginDescription.java
@@ -24,7 +24,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public final class SerializedPluginDescription {
 
-  public static final Pattern ID_PATTERN = Pattern.compile("[a-z][a-z0-9-_]{0,63}");
+  public static final String ID_PATTERN_STRING = "[a-z][a-z0-9-_]{0,63}";
+  public static final Pattern ID_PATTERN = Pattern.compile(ID_PATTERN_STRING);
 
   // @Nullable is used here to make GSON skip these in the serialized file
   private final String id;

--- a/api/src/main/java/com/velocitypowered/api/plugin/Dependency.java
+++ b/api/src/main/java/com/velocitypowered/api/plugin/Dependency.java
@@ -8,11 +8,10 @@
 package com.velocitypowered.api.plugin;
 
 import com.velocitypowered.api.plugin.ap.SerializedPluginDescription;
-import org.intellij.lang.annotations.Pattern;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.intellij.lang.annotations.Pattern;
 
 /**
  * Indicates that the {@link Plugin} depends on another plugin in order to enable.

--- a/api/src/main/java/com/velocitypowered/api/plugin/Dependency.java
+++ b/api/src/main/java/com/velocitypowered/api/plugin/Dependency.java
@@ -7,6 +7,9 @@
 
 package com.velocitypowered.api.plugin;
 
+import com.velocitypowered.api.plugin.ap.SerializedPluginDescription;
+import org.intellij.lang.annotations.Pattern;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -24,6 +27,7 @@ public @interface Dependency {
    * @return The dependency plugin ID
    * @see Plugin#id()
    */
+  @Pattern(SerializedPluginDescription.ID_PATTERN_STRING)
   String id();
 
   /**

--- a/api/src/main/java/com/velocitypowered/api/plugin/Plugin.java
+++ b/api/src/main/java/com/velocitypowered/api/plugin/Plugin.java
@@ -7,6 +7,9 @@
 
 package com.velocitypowered.api.plugin;
 
+import com.velocitypowered.api.plugin.ap.SerializedPluginDescription;
+import org.intellij.lang.annotations.Pattern;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -26,6 +29,7 @@ public @interface Plugin {
    *
    * @return the ID for this plugin
    */
+  @Pattern(SerializedPluginDescription.ID_PATTERN_STRING)
   String id();
 
   /**

--- a/api/src/main/java/com/velocitypowered/api/plugin/Plugin.java
+++ b/api/src/main/java/com/velocitypowered/api/plugin/Plugin.java
@@ -8,12 +8,11 @@
 package com.velocitypowered.api.plugin;
 
 import com.velocitypowered.api.plugin.ap.SerializedPluginDescription;
-import org.intellij.lang.annotations.Pattern;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.intellij.lang.annotations.Pattern;
 
 /**
  * Annotation used to describe a Velocity plugin.


### PR DESCRIPTION
This would allow IDEs to show a warning when a plugin id isn't valid while you're writing it instead of during compile.