### PR TITLE
fix: TranslatableMapper not using fallback translation

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/util/TranslatableMapper.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/TranslatableMapper.java
@@ -43,6 +43,12 @@ public enum TranslatableMapper implements BiConsumer<TranslatableComponent, Cons
     final Locale locale = ClosestLocaleMatcher.INSTANCE.lookupClosest(Locale.getDefault());
     if (GlobalTranslator.translator().canTranslate(translatableComponent.key(), locale)) {
       componentConsumer.accept(GlobalTranslator.render(translatableComponent, locale));
+    } else {
+      String fallback = translatableComponent.fallback();
+      if (fallback == null) {
+        fallback = translatableComponent.key();
+      }
+      componentConsumer.accept(Component.text(fallback));
     }
   }
 }


### PR DESCRIPTION
Fixes an issue where a TranslatableComponent that cannot be translated by the GlobalTranslator renders as an empty Component in the console.
Fixes #1710