### PR TITLE
Replace docs.advntr.dev to docs.papermc.io in jd

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
@@ -23,7 +23,7 @@ public interface CommandSource extends Audience, PermissionSubject {
    * Sends a message with the MiniMessage format to this source.
    *
    * @param message MiniMessage content
-   * @see <a href="https://docs.advntr.dev/minimessage/format.html">MiniMessage docs</a>
+   * @see <a href="https://docs.papermc.io/adventure/minimessage/format/">MiniMessage docs</a>
    *      for more information on the format.
    */
   default void sendRichMessage(final @NotNull String message) {
@@ -35,8 +35,8 @@ public interface CommandSource extends Audience, PermissionSubject {
    *
    * @param message MiniMessage content
    * @param resolvers resolvers to use
-   * @see <a href="https://docs.advntr.dev/minimessage/">MiniMessage docs</a>
-   *     and <a href="https://docs.advntr.dev/minimessage/dynamic-replacements">MiniMessage Placeholders docs</a>
+   * @see <a href="https://docs.papermc.io/adventure/minimessage/">MiniMessage docs</a>
+   *     and <a href="https://docs.papermc.io/adventure/minimessage/dynamic-replacements">MiniMessage Placeholders docs</a>
    *     for more information on the format.
    */
   default void sendRichMessage(


### PR DESCRIPTION
Noticed in https://github.com/PaperMC/Velocity/commit/7d0c002f89d1cc916fd7525bcb4f2a0f4bc31649 the javadocs still mention the old docs site, this PR just change that to the PaperMC docs.