### PR TITLE
Implement SkinSource for Player and GameProfile

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -39,6 +39,7 @@ import net.kyori.adventure.sound.SoundStop;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
+import net.kyori.adventure.text.object.PlayerHeadObjectContents;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.NotNull;
 
@@ -49,7 +50,8 @@ public interface Player extends
     /* Fundamental Velocity interfaces */
     CommandSource, InboundConnection, ChannelMessageSource, ChannelMessageSink,
     /* Adventure-specific interfaces */
-    Identified, HoverEventSource<HoverEvent.ShowEntity>, Keyed, KeyIdentifiable, Sound.Emitter {
+    Identified, HoverEventSource<HoverEvent.ShowEntity>, Keyed, KeyIdentifiable, Sound.Emitter,
+    PlayerHeadObjectContents.SkinSource {
 
   /**
    * Returns the player's current username.
@@ -337,6 +339,16 @@ public interface Player extends
           @NotNull UnaryOperator<HoverEvent.ShowEntity> op) {
     return HoverEvent.showEntity(op.apply(HoverEvent.ShowEntity.showEntity(this, getUniqueId(),
             Component.text(getUsername()))));
+  }
+
+  @SuppressWarnings("UnstableApiUsage") // permitted implementation
+  @Override
+  default void applySkinToPlayerHeadContents(
+      final PlayerHeadObjectContents.@NotNull Builder builder) {
+    builder.skin(this.getGameProfile());
+    if (this.hasSentPlayerSettings()) {
+      builder.hat(this.getPlayerSettings().getSkinParts().hasHat());
+    }
   }
 
   /**

--- a/api/src/main/java/com/velocitypowered/api/util/GameProfile.java
+++ b/api/src/main/java/com/velocitypowered/api/util/GameProfile.java
@@ -11,11 +11,14 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import net.kyori.adventure.text.object.PlayerHeadObjectContents;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a Mojang game profile. This class is immutable.
  */
-public final class GameProfile {
+public final class GameProfile implements PlayerHeadObjectContents.SkinSource {
 
   private final UUID id;
   private final String undashedId;
@@ -167,6 +170,23 @@ public final class GameProfile {
     Preconditions.checkNotNull(username, "username");
     return new GameProfile(UuidUtils.generateOfflinePlayerUuid(username), username,
         ImmutableList.of());
+  }
+
+  @SuppressWarnings("UnstableApiUsage") // permitted implementation
+  @Override
+  public void applySkinToPlayerHeadContents(
+      final PlayerHeadObjectContents.@NotNull Builder builder) {
+    if (this.properties.isEmpty()) {
+      builder.id(this.id);
+      return;
+    }
+
+    builder.id(this.id)
+        .name(this.name)
+        .profileProperties(this.properties.stream()
+            .map(property -> PlayerHeadObjectContents.property(property.getName(),
+                property.getValue(), property.getSignature()))
+            .collect(Collectors.toList()));
   }
 
   @Override


### PR DESCRIPTION
Implement adventure's `SkinSource` for `Player` and `GameProfile` to allow passing instances to `ObjectContents.playerHead(SkinSource)`.

The `GameProfile` implementation creates a "static" player head if the profile has any properties. Otherwise, it creates a "dynamic" player head using the profile's UUID.

The `Player` implementation uses its current game profile and, if the player already sent its settings, includes whether the hat should be shown.