### PR TITLE
Fix CallbackCommand permission

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/CallbackCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/CallbackCommand.java
@@ -35,8 +35,10 @@ public final class CallbackCommand implements Command<CommandSource> {
   public static BrigadierCommand create() {
     final LiteralCommandNode<CommandSource> node = BrigadierCommand
         .literalArgumentBuilder("velocity:callback")
+        .requires(source ->
+            source.getPermissionValue("velocity.command.callback") == Tristate.TRUE)
         .then(BrigadierCommand.requiredArgumentBuilder("id", StringArgumentType.word())
-                .executes(new CallbackCommand()))
+            .executes(new CallbackCommand()))
         .build();
 
     return new BrigadierCommand(node);


### PR DESCRIPTION
Should allow disabling `/velocity:callback` auto complete by disabling the `velocity.command.callback` permission to the desired players.