### PR TITLE
Fix dimension reading in JoinGamePacket

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
@@ -246,7 +246,11 @@ public class JoinGamePacket implements MinecraftPacket {
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_9_1)) {
       this.dimension = buf.readInt();
     } else {
-      this.dimension = buf.readByte();
+      // Read as signed byte, then convert to unsigned for modded dimension IDs > 127
+      // (e.g. dimension 180 would be read as signed byte -76, but should be stored as 180).
+      // Preserve -1 (Nether) as-is since it is the only standard negative dimension ID.
+      int raw = buf.readByte();
+      this.dimension = (raw < -1) ? (raw & 0xFF) : raw;
     }
     if (version.noGreaterThan(ProtocolVersion.MINECRAFT_1_13_2)) {
       this.difficulty = buf.readUnsignedByte();


### PR DESCRIPTION
Velocity中`JoinGamePacket.java`对于1.7.10维度ID的传递只使用1字节，这导致部分模组维度的维度ID传递过程中发生数据截断，传递了非法数据给客户端，导致客户端崩溃。使用4字节处理维度ID可以解决该问题。我使用了Claude来分析和修改（因为我不会编程），图片为Claude修改完成的总结。

我是在游玩GTNH 2.8.0整合包时发现的此问题，当时我的服务器使用Velocity转发，通过Velocity实现玩家登录验证，我在游玩途中发现在私人维度（维度ID为180）中下线再加入客户端会崩溃，而跳过Velocity转发则不会，报错日志提示非法维度ID-76。

---

In Velocity, the `JoinGamePacket.java` uses only 1 byte to transmit the dimension ID for 1.7.10. This causes data truncation during the transmission of dimension IDs for some modded dimensions, sending illegal data to the client and causing the client to crash. Using 4 bytes to handle the dimension ID can resolve this issue. I used Claude to analyze and modify the code (since I don't know how to program), and the image shows the summary of the modifications completed by Claude.

I discovered this issue while playing the GTNH 2.8.0 modpack. At the time, my server used Velocity for forwarding and implemented player login authentication through Velocity. During gameplay, I found that logging out and re-joining in a private dimension (dimension ID 180) would cause the client to crash, whereas bypassing Velocity forwarding did not. The error log indicated an illegal dimension ID of -76.
<img width="1223" height="639" alt="Snipaste_2026-02-15_22-35-01" src="https://github.com/user-attachments/assets/e23b45ec-5626-459b-a4d7-5c89a1225c8c" />
