### PR TITLE
Introduce PermissionFunction#getPermissionMap

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionFunction.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionFunction.java
@@ -7,6 +7,9 @@
 
 package com.velocitypowered.api.permission;
 
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Function that calculates the permission settings for a given {@link PermissionSubject}.
  */
@@ -35,4 +38,15 @@ public interface PermissionFunction {
    * @return the value the permission is set to
    */
   Tristate getPermissionValue(String permission);
+
+  /**
+   * Gets the subjects permission map for any set permission.
+   * There does not have to be a guarantee that when {@link #getPermissionValue} returns {@link Tristate#TRUE} or {@link Tristate#FALSE}
+   * for a given permission, that it should also be contained within this permission map.
+   *
+   * @return the permission map, or {@code null} if the implementing provider does not expose this information.
+   */
+  default @Nullable Map<String, Boolean> getPermissionMap() {
+    return null;
+  }
 }

--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionFunction.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionFunction.java
@@ -9,6 +9,7 @@ package com.velocitypowered.api.permission;
 
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * Function that calculates the permission settings for a given {@link PermissionSubject}.
@@ -43,10 +44,11 @@ public interface PermissionFunction {
    * Gets the subjects permission map for any set permission.
    * There does not have to be a guarantee that when {@link #getPermissionValue} returns {@link Tristate#TRUE} or {@link Tristate#FALSE}
    * for a given permission, that it should also be contained within this permission map.
+   * This method should return an unmodifiable map. Modifying the returned map may cause undefined behavior or throw.
    *
    * @return the permission map, or {@code null} if the implementing provider does not expose this information.
    */
-  default @Nullable Map<String, Boolean> getPermissionMap() {
+  default @Nullable @Unmodifiable Map<String, Boolean> getPermissionMap() {
     return null;
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionFunction.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionFunction.java
@@ -48,7 +48,9 @@ public interface PermissionFunction {
    *
    * @return the permission map, or {@code null} if the implementing provider does not expose this information.
    */
-  default @Nullable @Unmodifiable Map<String, Boolean> getPermissionMap() {
+  @Nullable
+  @Unmodifiable
+  default Map<String, Boolean> getPermissionMap() {
     return null;
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
@@ -43,7 +43,9 @@ public interface PermissionSubject {
    *
    * @return the permission map, or {@code null} if the implementing provider does not expose this information.
    */
-  @Nullable @Unmodifiable Map<String, Boolean> getPermissionMap();
+  @Nullable
+  @Unmodifiable
+  Map<String, Boolean> getPermissionMap();
 
   /**
    * Gets the permission checker for the subject.

--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
@@ -7,7 +7,9 @@
 
 package com.velocitypowered.api.permission;
 
+import java.util.Map;
 import net.kyori.adventure.permission.PermissionChecker;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Represents a object that has a set of queryable permissions.
@@ -31,6 +33,15 @@ public interface PermissionSubject {
    * @return the value the permission is set to
    */
   Tristate getPermissionValue(String permission);
+
+  /**
+   * Gets the subjects permission map for any set permission.
+   * There does not have to be a guarantee that when {@link #getPermissionValue} returns {@link Tristate#TRUE} or {@link Tristate#FALSE}
+   * for a given permission, that it should also be contained within this permission map.
+   *
+   * @return the permission map, or {@code null} if the implementing provider does not expose this information.
+   */
+  @Nullable Map<String, Boolean> getPermissionMap();
 
   /**
    * Gets the permission checker for the subject.

--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
@@ -10,6 +10,7 @@ package com.velocitypowered.api.permission;
 import java.util.Map;
 import net.kyori.adventure.permission.PermissionChecker;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * Represents a object that has a set of queryable permissions.
@@ -38,10 +39,11 @@ public interface PermissionSubject {
    * Gets the subjects permission map for any set permission.
    * There does not have to be a guarantee that when {@link #getPermissionValue} returns {@link Tristate#TRUE} or {@link Tristate#FALSE}
    * for a given permission, that it should also be contained within this permission map.
+   * This method should return an unmodifiable map. Modifying the returned map may cause undefined behavior or throw.
    *
    * @return the permission map, or {@code null} if the implementing provider does not expose this information.
    */
-  @Nullable Map<String, Boolean> getPermissionMap();
+  @Nullable @Unmodifiable Map<String, Boolean> getPermissionMap();
 
   /**
    * Gets the permission checker for the subject.

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -111,6 +111,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -1001,6 +1002,11 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   @Override
   public Tristate getPermissionValue(String permission) {
     return permissionFunction.getPermissionValue(permission);
+  }
+
+  @Override
+  public @Nullable Map<String, Boolean> getPermissionMap() {
+    return permissionFunction.getPermissionMap();
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -146,6 +146,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * Represents a player that is connected to the proxy.
@@ -1005,7 +1006,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   }
 
   @Override
-  public @Nullable Map<String, Boolean> getPermissionMap() {
+  public @Nullable @Unmodifiable Map<String, Boolean> getPermissionMap() {
     return permissionFunction.getPermissionMap();
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
@@ -46,6 +46,7 @@ import org.apache.logging.log4j.io.IoBuilder;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
 import org.jline.reader.Candidate;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -85,7 +86,7 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
   }
 
   @Override
-  public @Nullable Map<String, Boolean> getPermissionMap() {
+  public @Nullable @Unmodifiable Map<String, Boolean> getPermissionMap() {
     return permissionFunction.getPermissionMap();
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
@@ -27,6 +27,7 @@ import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.util.ClosestLocaleMatcher;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.permission.PermissionChecker;
@@ -43,6 +44,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.io.IoBuilder;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.NotNull;
 import org.jline.reader.Candidate;
 import org.jline.reader.LineReader;
@@ -79,7 +81,12 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
 
   @Override
   public @NonNull Tristate getPermissionValue(@NonNull String permission) {
-    return this.permissionFunction.getPermissionValue(permission);
+    return permissionFunction.getPermissionValue(permission);
+  }
+
+  @Override
+  public @Nullable Map<String, Boolean> getPermissionMap() {
+    return permissionFunction.getPermissionMap();
   }
 
   /**

--- a/proxy/src/test/java/com/velocitypowered/proxy/command/MockCommandSource.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/command/MockCommandSource.java
@@ -19,6 +19,8 @@ package com.velocitypowered.proxy.command;
 
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.permission.Tristate;
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A fake {@link CommandSource}.
@@ -30,5 +32,10 @@ public class MockCommandSource implements CommandSource {
   @Override
   public Tristate getPermissionValue(final String permission) {
     return Tristate.UNDEFINED;
+  }
+
+  @Override
+  public @Nullable Map<String, Boolean> getPermissionMap() {
+    return null;
   }
 }

--- a/proxy/src/test/java/com/velocitypowered/proxy/command/MockCommandSource.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/command/MockCommandSource.java
@@ -21,6 +21,7 @@ import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.permission.Tristate;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * A fake {@link CommandSource}.
@@ -35,7 +36,7 @@ public class MockCommandSource implements CommandSource {
   }
 
   @Override
-  public @Nullable Map<String, Boolean> getPermissionMap() {
+  public @Nullable @Unmodifiable Map<String, Boolean> getPermissionMap() {
     return null;
   }
 }


### PR DESCRIPTION
This PR introduces `PermissionFunction#getPermissionMap`, and delegates like `[Connected]Player#getPermissionMap`.

I would like to see this be a feature of Velocity, because I'm currently trying to optimize a bit of code that uses the Velocity permission API:
```java
private int getTimeoutInSeconds(Player player) {
  for (int i = 86400; i > 0; i--) {
    if (player.hasPermission("velocity.queue.timeout." + i)) {
      return i;
    }
  }
  return -1;
}
```

Of course having up to 86.400 permission checks is not good, even if it's just a one-off, and especially because we don't know how the permission provider implements this (each call might reach out to a redis/SQL db).

Unfortunately because lots of servers are already relying on being able to specify a permission like this, it's not trivial for me to fix this issue by reducing the amount of permission checks. Ideally I'd like to see Velocity and permission providers like LuckPerms expose the permission map, as I'm sure I'm not the first one with this kind of permission check as well.

After this PR, a better implementation of such a method in a plugin would be:
```java
private int getTimeoutInSeconds(final Player player) {
  return getPermissionMap().entrySet().stream()
          .filter(e -> e.getValue() == true)
          .map(Map.Entry::getKey)
          .filter(s -> s.startsWith("velocity.queue.timeout."))
          .map(this::parseOptionalInt)
          .flatMapToInt(OptionalInt::stream)
          .max()
          .orElse(-1);
}
```

Resulting in at most a couple hundred checks, and no possibility of spamming a DB or something.

It would be trivial for a permission provider like LuckPerms to implement this, as an example here is their `PermissionFunction` implementation: [PlayerPermissionProvider](https://github.com/LuckPerms/LuckPerms/blob/master/velocity/src/main/java/me/lucko/luckperms/velocity/service/PlayerPermissionProvider.java).
They reference their internal [CachedPermissionData](https://github.com/LuckPerms/LuckPerms/blob/master/api/src/main/java/net/luckperms/api/cacheddata/CachedPermissionData.java), which already exposes `@NonNull @Unmodifiable Map<String, Boolean> getPermissionMap()`.

Of course by leaving the API `@Nullable` on the Velocity side, with a default return of `null`, we don't break any existing code. Even though Velocity's `PermissionFunction` is a `@FunctionalInterface`, it's possible to have additional `default` methods and allow other APIs implement them.

Having this be a part of the Velocity permission API would avoid having a dependency on the underlying permission providers like LuckPerms, which I think is a good thing.

I'm also wondering if it might be better to introduce `Map<String, TriState> getPermissionMap()` instead of `Map<String, Boolean> getPermissionMap()` instead. Should we allow permission providers to force a permission to be "unset", and expose that via the `permissionMap` getter?