### PR TITLE
Delay instantiating ConnectedPlayer to after Velocity#canRegisterConnection returns true

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -692,16 +692,16 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
   /**
    * Checks if the {@code connection} can be registered with the proxy.
    *
-   * @param connection the connection to check
+   * @param gameProfile the {@link GameProfile} of the incoming connection
    * @return {@code true} if we can register the connection, {@code false} if not
    */
-  public boolean canRegisterConnection(ConnectedPlayer connection) {
+  public boolean canRegisterConnection(GameProfile gameProfile) {
     if (configuration.isOnlineMode() && configuration.isOnlineModeKickExistingPlayers()) {
       return true;
     }
-    String lowerName = connection.getUsername().toLowerCase(Locale.US);
+    String lowerName = gameProfile.getName().toLowerCase(Locale.US);
     return !(connectionsByName.containsKey(lowerName)
-        || connectionsByUuid.containsKey(connection.getUniqueId()));
+        || connectionsByUuid.containsKey(gameProfile.getId()));
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
@@ -100,7 +100,7 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
         return CompletableFuture.completedFuture(null);
       }
 
-      // Initiate a regular connection and move over to it.
+      // Check if we can register the connection before instantiating ConnectedPlayer
       if (!server.canRegisterConnection(profileEvent.getGameProfile())) {
         // ConnectedPlayer#disconnect0 uses its own translateMessage(), which uses the players' PlayerSettings
         // to translate the message, but at this stage this wouldn't have been set yet, resulting in
@@ -116,6 +116,7 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
         return CompletableFuture.completedFuture(null);
       }
 
+      // Initiate a regular connection and move over to it.
       ConnectedPlayer player = new ConnectedPlayer(server, profileEvent.getGameProfile(),
           mcConnection, inbound.getVirtualHost().orElse(null), inbound.getRawVirtualHost().orElse(null), onlineMode,
           inbound.getHandshakeIntent(), inbound.getIdentifiedKey());

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
@@ -40,17 +40,21 @@ import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.crypto.IdentifiedKeyImpl;
 import com.velocitypowered.proxy.protocol.StateRegistry;
+import com.velocitypowered.proxy.protocol.packet.DisconnectPacket;
 import com.velocitypowered.proxy.protocol.packet.LoginAcknowledgedPacket;
 import com.velocitypowered.proxy.protocol.packet.ServerLoginSuccessPacket;
 import com.velocitypowered.proxy.protocol.packet.ServerboundCookieResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.SetCompressionPacket;
+import com.velocitypowered.proxy.util.ClosestLocaleMatcher;
 import io.netty.buffer.ByteBuf;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.translation.GlobalTranslator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -97,16 +101,25 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
       }
 
       // Initiate a regular connection and move over to it.
+      if (!server.canRegisterConnection(profileEvent.getGameProfile())) {
+        // ConnectedPlayer#disconnect0 uses its own translateMessage(), which uses the players' PlayerSettings
+        // to translate the message, but at this stage this wouldn't have been set yet, resulting in
+        // Locale.getDefault() being used anyway.
+        mcConnection.closeWith(DisconnectPacket.create(
+            GlobalTranslator.render(
+                Component.translatable("velocity.error.already-connected-proxy", NamedTextColor.RED),
+                ClosestLocaleMatcher.INSTANCE.lookupClosest(Locale.getDefault())
+            ),
+            mcConnection.getProtocolVersion(),
+            mcConnection.getState()
+        ));
+        return CompletableFuture.completedFuture(null);
+      }
+
       ConnectedPlayer player = new ConnectedPlayer(server, profileEvent.getGameProfile(),
           mcConnection, inbound.getVirtualHost().orElse(null), inbound.getRawVirtualHost().orElse(null), onlineMode,
           inbound.getHandshakeIntent(), inbound.getIdentifiedKey());
       this.connectedPlayer = player;
-      if (!server.canRegisterConnection(player)) {
-        player.disconnect0(
-            Component.translatable("velocity.error.already-connected-proxy", NamedTextColor.RED),
-            true);
-        return CompletableFuture.completedFuture(null);
-      }
 
       if (server.getConfiguration().isLogPlayerConnections()) {
         logger.info("{} has connected", player);


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Velocity/issues/1740.
Inspired by https://github.com/PaperMC/Velocity/pull/1744, see https://github.com/PaperMC/Velocity/pull/1744#issuecomment-4105976714.
