### PR TITLE
Always resolve hostnames. (Fix #1750)

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/ProxyOptions.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/ProxyOptions.java
@@ -111,7 +111,7 @@ public final class ProxyOptions {
       }
       InetSocketAddress address;
       try {
-        address = AddressUtil.parseAddress(split[1]);
+        address = AddressUtil.parseAndResolveAddress(split[1]);
       } catch (IllegalStateException e) {
         throw new ValueConversionException("Invalid hostname for server flag with name: " + split[0]);
       }

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -297,7 +297,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
 
     if (!options.isIgnoreConfigServers()) {
       for (Map.Entry<String, String> entry : configuration.getServers().entrySet()) {
-        servers.register(new ServerInfo(entry.getKey(), AddressUtil.parseAddress(entry.getValue())));
+        servers.register(new ServerInfo(entry.getKey(), AddressUtil.parseAndResolveAddress(entry.getValue())));
       }
     }
 
@@ -489,7 +489,7 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     // move back to a fallback server.
     Collection<ConnectedPlayer> evacuate = new ArrayList<>();
     for (Map.Entry<String, String> entry : newConfiguration.getServers().entrySet()) {
-      ServerInfo newInfo = new ServerInfo(entry.getKey(), AddressUtil.parseAddress(entry.getValue()));
+      ServerInfo newInfo = new ServerInfo(entry.getKey(), AddressUtil.parseAndResolveAddress(entry.getValue()));
       Optional<RegisteredServer> rs = servers.getServer(entry.getKey());
       if (rs.isEmpty()) {
         servers.register(newInfo);

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -144,7 +144,7 @@ public class VelocityConfiguration implements ProxyConfig {
       valid = false;
     } else {
       try {
-        AddressUtil.parseAddress(bind);
+        AddressUtil.parseAndResolveAddress(bind);
       } catch (IllegalArgumentException e) {
         logger.error("'bind' option does not specify a valid IP address.", e);
         valid = false;
@@ -175,7 +175,7 @@ public class VelocityConfiguration implements ProxyConfig {
 
     for (Map.Entry<String, String> entry : servers.getServers().entrySet()) {
       try {
-        AddressUtil.parseAddress(entry.getValue());
+        AddressUtil.parseAndResolveAddress(entry.getValue());
       } catch (IllegalArgumentException e) {
         logger.error("Server {} does not have a valid IP address.", entry.getKey(), e);
         valid = false;

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/AddressUtil.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/AddressUtil.java
@@ -34,7 +34,7 @@ public final class AddressUtil {
 
 
   /**
-   * Attempts to parse an IP address of the form {@code 127.0.0.1:25565}. The returned
+   * Attempts to parse an IPAddress/Hostname with an optional port of the form {@code 127.0.0.1:25565}. The returned
    * {@link InetSocketAddress} is resolved.
    *
    * @param ip the IP to parse

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/AddressUtil.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/AddressUtil.java
@@ -18,8 +18,6 @@
 package com.velocitypowered.proxy.util;
 
 import com.google.common.base.Preconditions;
-import com.google.common.net.InetAddresses;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 
@@ -34,28 +32,6 @@ public final class AddressUtil {
     throw new AssertionError();
   }
 
-  /**
-   * Attempts to parse an IP address of the form {@code 127.0.0.1:25565}. The returned
-   * {@link InetSocketAddress} is not resolved.
-   *
-   * @param ip the IP to parse
-   * @return the parsed address
-   */
-  public static InetSocketAddress parseAddress(String ip) {
-    Preconditions.checkNotNull(ip, "ip");
-    URI uri = URI.create("tcp://" + ip);
-    if (uri.getHost() == null) {
-      throw new IllegalStateException("Invalid hostname/IP " + ip);
-    }
-
-    int port = uri.getPort() == -1 ? DEFAULT_MINECRAFT_PORT : uri.getPort();
-    try {
-      InetAddress ia = InetAddresses.forUriString(uri.getHost());
-      return new InetSocketAddress(ia, port);
-    } catch (IllegalArgumentException e) {
-      return InetSocketAddress.createUnresolved(uri.getHost(), port);
-    }
-  }
 
   /**
    * Attempts to parse an IP address of the form {@code 127.0.0.1:25565}. The returned

--- a/proxy/src/test/java/com/velocitypowered/proxy/util/AddressUtilTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/util/AddressUtilTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AddressUtilTest {
+
+  @Test
+  public void testIpAndPort() {
+    var result = AddressUtil.parseAndResolveAddress("127.0.0.1:25565");
+    Assertions.assertEquals("127.0.0.1", result.getAddress().getHostAddress());
+    Assertions.assertEquals(25565, result.getPort());
+    Assertions.assertFalse(result.isUnresolved());
+  }
+
+  @Test
+  public void testV6IpAndPort() {
+    var result = AddressUtil.parseAndResolveAddress("[::1]:25565");
+    Assertions.assertEquals("0:0:0:0:0:0:0:1", result.getAddress().getHostAddress());
+    Assertions.assertEquals(25565, result.getPort());
+    Assertions.assertFalse(result.isUnresolved());
+  }
+
+  @Test
+  public void testResolveHostname() {
+    var result = AddressUtil.parseAndResolveAddress("localhost:25565");
+    Assertions.assertFalse(result.isUnresolved());
+  }
+}


### PR DESCRIPTION
This PR fixes #1750. It will resolve all the hostnames in the configuration.  

We're resolving in `bind` before, and `[servers]` are not. 