### PR TITLE
Setup encryption before possible disconnect

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -199,8 +199,12 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
       }
 
       byte[] decryptedSharedSecret = decryptRsa(serverKeyPair, packet.getSharedSecret());
-      String serverId = generateServerId(decryptedSharedSecret, serverKeyPair.getPublic());
 
+      // Go ahead and enable encryption. Once the client sends EncryptionResponse, encryption
+      // is enabled.
+      mcConnection.enableEncryption(decryptedSharedSecret);
+
+      String serverId = generateServerId(decryptedSharedSecret, serverKeyPair.getPublic());
       String playerIp = ((InetSocketAddress) mcConnection.getRemoteAddress()).getHostString();
       String url = String.format(MOJANG_HASJOINED_URL,
           urlFormParameterEscaper().escape(login.getUsername()), serverId);
@@ -226,18 +230,6 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
             if (throwable != null) {
               logger.error("Unable to authenticate player", throwable);
               inbound.disconnect(Component.translatable("multiplayer.disconnect.authservers_down"));
-              return;
-            }
-
-            // Go ahead and enable encryption. Once the client sends EncryptionResponse, encryption
-            // is enabled.
-            try {
-              mcConnection.enableEncryption(decryptedSharedSecret);
-            } catch (GeneralSecurityException e) {
-              logger.error("Unable to enable encryption for connection", e);
-              // At this point, the connection is encrypted, but something's wrong on our side and
-              // we can't do anything about it.
-              mcConnection.close(true);
               return;
             }
 


### PR DESCRIPTION
There's no reason to delay setting up encryption to after we have fetched the `GameProfile` from Mojang.

Before this PR, this could result in a `disconnect()` call _before we had set up encryption_ if Mojang's servers are down:
```java
if (throwable != null) {
  logger.error("Unable to authenticate player", throwable);
  inbound.disconnect(Component.translatable("multiplayer.disconnect.authservers_down"));
  return;
}

// Only here we were setting up encryption
```

Simulating this with `throwable != null || true`, we get disconnected on the client with a garbled exception message complaining about packets instead of the proper disconnect message. This is because as far as the client is concerned, encryption should already be in place.

This PR moves enabling encryption on the connection right when we receive the packet and after we're done with setting up the crypto stuff.

This whole code block is already in a giant try/catch block:
```java
try {
  // ...
} catch (GeneralSecurityException e) {
  logger.error("Unable to enable encryption", e);
  mcConnection.close(true);
}
```

which still results in the same behavior when `enableEncryption()` fails (error log & disconnect), just without sending an unneeded fetch to Mojang.