### PR TITLE
Add system property for packet direction validation

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
@@ -22,6 +22,7 @@ import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.StateRegistry;
+import com.velocitypowered.proxy.util.VelocityProperties;
 import com.velocitypowered.proxy.util.except.QuietRuntimeException;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
@@ -37,7 +38,7 @@ public class MinecraftDecoder extends ChannelInboundHandlerAdapter {
   private static final QuietRuntimeException DECODE_FAILED =
       new QuietRuntimeException("A packet did not decode successfully (invalid data). For more "
           + "information, launch Velocity with -Dvelocity.packet-decode-logging=true to see more.");
-  private static final boolean DIRECTION_VALIDATION = Boolean.getBoolean("velocity.packet-direction-validation");
+  private static final boolean DIRECTION_VALIDATION = VelocityProperties.readBoolean("velocity.packet-direction-validation", true);
 
   private final ProtocolUtils.Direction direction;
   private StateRegistry state;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
@@ -37,6 +37,7 @@ public class MinecraftDecoder extends ChannelInboundHandlerAdapter {
   private static final QuietRuntimeException DECODE_FAILED =
       new QuietRuntimeException("A packet did not decode successfully (invalid data). For more "
           + "information, launch Velocity with -Dvelocity.packet-decode-logging=true to see more.");
+  private static final boolean DIRECTION_VALIDATION = Boolean.getBoolean("velocity.packet-direction-validation");
 
   private final ProtocolUtils.Direction direction;
   private StateRegistry state;
@@ -74,7 +75,7 @@ public class MinecraftDecoder extends ChannelInboundHandlerAdapter {
     MinecraftPacket packet = this.registry.createPacket(packetId);
     if (packet == null) {
       buf.readerIndex(originalReaderIndex);
-      if (this.direction == ProtocolUtils.Direction.SERVERBOUND && this.state != StateRegistry.PLAY) {
+      if (DIRECTION_VALIDATION && this.direction == ProtocolUtils.Direction.SERVERBOUND && this.state != StateRegistry.PLAY) {
         buf.release();
         throw this.handleInvalidPacketId(packetId);
       }


### PR DESCRIPTION
An unintentional side effect introduced as a byproduct of the additional validation added in #1743 (in particular, the check added for packet direction and connection state) is that it breaks servers running a proxy-in-proxy configuration. Granted of course this is a known grey area and this is not officially supported, however we have had numerous complaints from users claiming that after updating to Velocity for Minecraft 26.1, their server no longer works.

The aim is to keep this validation optional via an added system property, retaining support for proxy-in-proxy, as it currently works fine otherwise, without any other changes on the user-end.

If there was any specific reasoning or justification for the validation being added that I'm unaware of, please let me know, but for the most part my understanding is that it was added as a generic safeguard because this is an uncommon packet state which doesn't normally occur for a single proxy to server.