### PR TITLE
Clean up default permission resolver fields

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
@@ -113,19 +113,19 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
       }
 
       return server.getEventManager()
-          .fire(new PermissionsSetupEvent(player, ConnectedPlayer.DEFAULT_PERMISSIONS))
+          .fire(new PermissionsSetupEvent(player, ConnectedPlayer.DEFAULT_PERMISSION_PROVIDER))
           .thenAcceptAsync(event -> {
             if (!mcConnection.isClosed()) {
               // wait for permissions to load, then set the players permission function
-              final PermissionFunction function = event.createFunction(player);
+              PermissionFunction function = event.createFunction(player);
               if (function == null) {
                 logger.error("A plugin permission provider {} provided an invalid permission "
                         + "function for player {}. This is a bug in the plugin, not in "
                         + "Velocity. Falling back to the default permission function.",
                     event.getProvider().getClass().getName(), player.getUsername());
-              } else {
-                player.setPermissionFunction(function);
+                function = ConnectedPlayer.DEFAULT_PERMISSION_PROVIDER.createFunction(player);
               }
+              player.setPermissionFunction(function);
               startLoginCompletion(player);
             }
           }, mcConnection.eventLoop());

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -155,7 +155,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   public static final int MAX_CLIENTSIDE_PLUGIN_CHANNELS = Integer.getInteger("velocity.max-clientside-plugin-channels", 1024);
   private static final PlainTextComponentSerializer PASS_THRU_TRANSLATE =
       PlainTextComponentSerializer.builder().flattener(TranslatableMapper.FLATTENER).build();
-  static final PermissionProvider DEFAULT_PERMISSIONS = s -> PermissionFunction.ALWAYS_UNDEFINED;
+  static final PermissionProvider DEFAULT_PERMISSION_PROVIDER = s -> PermissionFunction.ALWAYS_UNDEFINED;
 
   private static final ComponentLogger logger = ComponentLogger.logger(ConnectedPlayer.class);
 
@@ -214,7 +214,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     this.virtualHost = virtualHost;
     this.rawVirtualHost = rawVirtualHost;
     this.handshakeIntent = handshakeIntent;
-    this.permissionFunction = PermissionFunction.ALWAYS_UNDEFINED;
+    this.permissionFunction = DEFAULT_PERMISSION_PROVIDER.createFunction(this);
     this.connectionPhase = connection.getType().getInitialClientPhase();
     this.onlineMode = onlineMode;
     this.clientsideChannels = CappedSet.create(MAX_CLIENTSIDE_PLUGIN_CHANNELS);

--- a/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
@@ -17,10 +17,9 @@
 
 package com.velocitypowered.proxy.console;
 
-import static com.velocitypowered.api.permission.PermissionFunction.ALWAYS_TRUE;
-
 import com.velocitypowered.api.event.permission.PermissionsSetupEvent;
 import com.velocitypowered.api.permission.PermissionFunction;
+import com.velocitypowered.api.permission.PermissionProvider;
 import com.velocitypowered.api.permission.Tristate;
 import com.velocitypowered.api.proxy.ConsoleCommandSource;
 import com.velocitypowered.proxy.VelocityServer;
@@ -54,12 +53,14 @@ import org.jline.reader.LineReaderBuilder;
  */
 public final class VelocityConsole extends SimpleTerminalConsole implements ConsoleCommandSource {
 
+  private static final PermissionProvider DEFAULT_PERMISSION_PROVIDER = s -> PermissionFunction.ALWAYS_TRUE;
+
   private static final Logger logger = LogManager.getLogger(VelocityConsole.class);
   private static final ComponentLogger componentLogger = ComponentLogger
           .logger(VelocityConsole.class);
 
   private final VelocityServer server;
-  private PermissionFunction permissionFunction = ALWAYS_TRUE;
+  private PermissionFunction permissionFunction;
   private static final @NotNull PointersSupplier<VelocityConsole> POINTERS = PointersSupplier.<VelocityConsole>builder()
       .resolving(PermissionChecker.POINTER, VelocityConsole::getPermissionChecker)
       .resolving(Identity.LOCALE, (console) -> ClosestLocaleMatcher.INSTANCE
@@ -69,6 +70,7 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
 
   public VelocityConsole(VelocityServer server) {
     this.server = server;
+    this.permissionFunction = DEFAULT_PERMISSION_PROVIDER.createFunction(this);
   }
 
   @Override
@@ -94,7 +96,7 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
    * Sets up permissions for the console.
    */
   public void setupPermissions() {
-    PermissionsSetupEvent event = new PermissionsSetupEvent(this, s -> ALWAYS_TRUE);
+    PermissionsSetupEvent event = new PermissionsSetupEvent(this, DEFAULT_PERMISSION_PROVIDER);
     // we can safely block here, this is before any listeners fire
     this.permissionFunction = this.server.getEventManager().fire(event).join().createFunction(this);
     if (this.permissionFunction == null) {
@@ -103,7 +105,7 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
               + " for the console. This is a bug in the plugin, not in Velocity. Falling"
               + " back to the default permission function.",
           event.getProvider().getClass().getName());
-      this.permissionFunction = ALWAYS_TRUE;
+      this.permissionFunction = DEFAULT_PERMISSION_PROVIDER.createFunction(this);
     }
   }
 


### PR DESCRIPTION
`ConnectedPlayer`s `DEFAULT_PERMISSIONS` has always bothered me, because the field does not contain the default permissions of a player, it contains the default permission _provider_.

This PR fixes that ambiguous naming, and it also aligns `VelocityConsole` to a similar pattern: a single field defining the default, instead of hard-coding it multiple times in the constructor and the setupPermissions() method.