### PR TITLE
fix: outdated client message

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -45,7 +45,6 @@ import java.net.InetSocketAddress;
 import java.util.Optional;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.minimessage.translation.Argument;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -128,10 +127,10 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
     if (!handshake.getProtocolVersion().isSupported()) {
       // Bump connection into correct protocol state so that we can send the disconnect packet.
       connection.setState(StateRegistry.LOGIN);
-      ic.disconnectQuietly(Component.translatable()
-              .key("multiplayer.disconnect.outdated_client")
-              .arguments(Argument.string("versions", ProtocolVersion.SUPPORTED_VERSION_STRING))
-              .build());
+      ic.disconnectQuietly(Component.translatable(
+          "multiplayer.disconnect.outdated_client",
+          Component.text(ProtocolVersion.SUPPORTED_VERSION_STRING)
+      ));
       return;
     }
 


### PR DESCRIPTION
Got wrongly replaced in https://github.com/PaperMC/Velocity/pull/1108

<img width="794" height="299" alt="image" src="https://github.com/user-attachments/assets/53e9dab7-9eda-4265-90a4-29261cc6af86" />
