### PR TITLE
A API enhancement for getting the ip and port for current connected server. Closes #1750.

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/ServerConnection.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/ServerConnection.java
@@ -41,10 +41,12 @@ public interface ServerConnection extends ChannelMessageSource, ChannelMessageSi
   ServerInfo getServerInfo();
 
   /**
-   * Returns the server info that current connected to.
-   * Can be used for getting resolved ip and port.
+   * Returns the server info that this connection is currently connected to.
+   * Can be used for getting the resolved IP and port.
    *
-   * @return the server info that current connected to
+   * @return the server info that this connection is currently connected to, if available;
+   *         otherwise an empty {@link Optional} if the connection has not yet been established
+   *         or has been closed
    */
   Optional<ServerInfo> getConnectedServerInfo();
 

--- a/api/src/main/java/com/velocitypowered/api/proxy/ServerConnection.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/ServerConnection.java
@@ -41,6 +41,14 @@ public interface ServerConnection extends ChannelMessageSource, ChannelMessageSi
   ServerInfo getServerInfo();
 
   /**
+   * Returns the server info that current connected to.
+   * Can be used for getting resolved ip and port.
+   *
+   * @return the server info that current connected to
+   */
+  Optional<ServerInfo> getConnectedServerInfo();
+
+  /**
    * Returns the player that this connection is associated with.
    *
    * @return the player for this connection

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -49,6 +49,7 @@ import com.velocitypowered.proxy.server.VelocityRegisteredServer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
+import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -67,6 +68,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
   private final ConnectedPlayer proxyPlayer;
   private final VelocityServer server;
   private @Nullable MinecraftConnection connection;
+  private @Nullable ServerInfo connectedServerInfo;
   private boolean hasCompletedJoin = false;
   private boolean gracefulDisconnect = false;
   private BackendConnectionPhase connectionPhase = BackendConnectionPhases.UNKNOWN;
@@ -106,6 +108,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
         .addListener((ChannelFutureListener) future -> {
           if (future.isSuccess()) {
             connection = new MinecraftConnection(future.channel(), server);
+            connectedServerInfo = new ServerInfo(registeredServer.getServerInfo().getName(), (InetSocketAddress) future.channel().remoteAddress());
             connection.setAssociation(VelocityServerConnection.this);
             future.channel().pipeline().addLast(HANDLER, connection);
 
@@ -236,6 +239,11 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
   }
 
   @Override
+  public Optional<ServerInfo> getConnectedServerInfo() {
+    return Optional.ofNullable(connectedServerInfo);
+  }
+
+  @Override
   public ConnectedPlayer getPlayer() {
     return proxyPlayer;
   }
@@ -248,6 +256,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
       gracefulDisconnect = true;
       connection.close(false);
       connection = null;
+      connectedServerInfo = null;
     }
   }
 


### PR DESCRIPTION
This is an api enhancement of the use case mentioned in #1750. It adds a `getConnectedServerInfo` for getting the current connected IP and port.  

If I have a backend server with `some-dynamic-host-name:25565`, it will be resolved in `VelocityServerConnection#connect`, but the resolution result (as the server player really connects to) cannot be gotten by the API; I got an unsolved `InetSocketAddress` instead.  

It assumes `future.channel().remoteAddress()` will return an `InetSocketAddress` because it was up-cast from it in `Bootstrap#connect(SocketAddress)`.