### PR TITLE
feat: Make version clickable in velocity info command

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/VelocityCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/VelocityCommand.java
@@ -161,14 +161,17 @@ public final class VelocityCommand {
           .decoration(TextDecoration.BOLD, true)
           .color(VELOCITY_COLOR)
           .append(Component.text()
-                  .content(version.getVersion())
-                  .decoration(TextDecoration.BOLD, false))
+              .content(version.getVersion())
+              .decoration(TextDecoration.BOLD, false))
+          .hoverEvent(Component.translatable("velocity.command.version-offer-copy-version"))
+          .clickEvent(ClickEvent.copyToClipboard(version.getName() + " "
+              + version.getVersion()))
           .build();
       final Component copyright = Component
           .translatable("velocity.command.version-copyright",
               Argument.string("vendor", version.getVendor()),
-                  Argument.string("name", version.getName()),
-                  Argument.component("year", Component.text(LocalDate.now().getYear())));
+              Argument.string("name", version.getName()),
+              Argument.component("year", Component.text(LocalDate.now().getYear())));
       source.sendMessage(velocity);
       source.sendMessage(copyright);
 

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
@@ -49,6 +49,7 @@ velocity.command.glist-view-all=To view all players on servers, use /glist all.
 velocity.command.reload-success=Velocity configuration successfully reloaded.
 velocity.command.reload-failure=Unable to reload your Velocity configuration. Check the console for more details.
 velocity.command.version-copyright=Copyright 2018-<arg:2> <arg:0>. <arg:1> is licensed under the terms of the GNU General Public License v3.
+velocity.command.version-offer-copy-version=Click to copy version to clipboard
 velocity.command.no-plugins=There are no plugins currently installed.
 velocity.command.plugins-list=Plugins: <arg:0>
 velocity.command.plugin-tooltip-website=Website: <arg:0>


### PR DESCRIPTION
Make it easier for users to provide us the full version string when asked to in support channels, if they're running the command in game instead of in console.