### PR TITLE
Only log endpoint open & close once

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
@@ -129,7 +129,7 @@ public final class ConnectionManager {
               this.endpoints.put(address, new Endpoint(channel, ListenerType.MINECRAFT));
 
               if (finalBind == 0) {
-                LOGGER.info("Listening on {}", channel.localAddress());
+                LOGGER.info("Listening on {} with {} endpoint{}", channel.localAddress(), binds, binds == 1 ? "" : "s");
 
                 // Warn people with console access that HAProxy is in use, see PR: #1436
                 if (this.server.getConfiguration().isProxyProtocol()) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
@@ -128,9 +128,9 @@ public final class ConnectionManager {
             if (future.isSuccess()) {
               this.endpoints.put(address, new Endpoint(channel, ListenerType.MINECRAFT));
 
-              LOGGER.info("Listening on {}", channel.localAddress());
-
               if (finalBind == 0) {
+                LOGGER.info("Listening on {}", channel.localAddress());
+
                 // Warn people with console access that HAProxy is in use, see PR: #1436
                 if (this.server.getConfiguration().isProxyProtocol()) {
                   LOGGER.warn(
@@ -218,9 +218,14 @@ public final class ConnectionManager {
     // should have a chance to be notified before the server stops accepting connections.
     server.getEventManager().fire(new ListenerCloseEvent(oldBind, type)).join();
 
+    boolean loggedClosure = false;
+
     for (Endpoint endpoint : endpoints) {
       Channel serverChannel = endpoint.getChannel();
-      LOGGER.info("Closing endpoint {}", serverChannel.localAddress());
+      if (!loggedClosure) {
+        loggedClosure = true;
+        LOGGER.info("Closing endpoint {}", serverChannel.localAddress());
+      }
       serverChannel.close().syncUninterruptibly();
     }
   }
@@ -241,8 +246,9 @@ public final class ConnectionManager {
       // should have a chance to be notified before the server stops accepting connections.
       server.getEventManager().fire(new ListenerCloseEvent(address, type)).join();
 
+      LOGGER.info("Closing endpoint {}", address);
+
       for (Endpoint endpoint : endpoints) {
-        LOGGER.info("Closing endpoint {}", address);
         if (interrupt) {
           try {
             endpoint.getChannel().close().sync();

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
@@ -129,7 +129,11 @@ public final class ConnectionManager {
               this.endpoints.put(address, new Endpoint(channel, ListenerType.MINECRAFT));
 
               if (finalBind == 0) {
-                LOGGER.info("Listening on {} with {} endpoint{}", channel.localAddress(), binds, binds == 1 ? "" : "s");
+                if (binds == 1) {
+                  LOGGER.info("Listening on {}", channel.localAddress());
+                } else {
+                  LOGGER.info("Listening on {} with {} endpoints", channel.localAddress(), binds);
+                }
 
                 // Warn people with console access that HAProxy is in use, see PR: #1436
                 if (this.server.getConfiguration().isProxyProtocol()) {


### PR DESCRIPTION
When reuse-port is enabled in the config, the listening on and closing endpoint messages are logged for every endpoint that is opened/closed, even when as far as I can tell, the address being logged is always the same

Fixes #1755