### PR TITLE
Fix chat race conditions not addressed by #1042

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatQueue.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatQueue.java
@@ -111,14 +111,20 @@ public class ChatQueue implements AutoCloseable {
   }
 
   private <T extends MinecraftPacket> CompletableFuture<Void> writePacket(T packet, MinecraftConnection smc) {
-    return CompletableFuture.runAsync(() -> {
-      if (!closed && !smc.isClosed()) {
-        ChannelFuture future = smc.write(packet);
-        if (future != null) {
-          future.awaitUninterruptibly();
-        }
+    CompletableFuture<Void> result = new CompletableFuture<>();
+    smc.eventLoop().execute(() -> {
+      if (closed || smc.isClosed()) {
+        result.complete(null);
+        return;
       }
-    }, smc.eventLoop());
+      ChannelFuture future = smc.write(packet);
+      if (future != null) {
+        future.addListener(f -> result.complete(null));
+      } else {
+        result.complete(null);
+      }
+    });
+    return result;
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatQueue.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatQueue.java
@@ -110,18 +110,25 @@ public class ChatQueue implements AutoCloseable {
     });
   }
 
+  @SuppressWarnings("resource")
   private <T extends MinecraftPacket> CompletableFuture<Void> writePacket(T packet, MinecraftConnection smc) {
     CompletableFuture<Void> result = new CompletableFuture<>();
     smc.eventLoop().execute(() -> {
-      if (closed || smc.isClosed()) {
-        result.complete(null);
-        return;
-      }
-      ChannelFuture future = smc.write(packet);
-      if (future != null) {
-        future.addListener(f -> result.complete(null));
-      } else {
-        result.complete(null);
+      try {
+        if (closed || smc.isClosed()) {
+          result.complete(null);
+          return;
+        }
+        ChannelFuture future = smc.write(packet);
+        if (future != null) {
+          // Advance the queue once the write completes; a failed write means the
+          // connection is already dying, so draining the queue regardless is fine.
+          future.addListener(f -> result.complete(null));
+        } else {
+          result.complete(null);
+        }
+      } catch (Throwable t) {
+        result.completeExceptionally(t);
       }
     });
     return result;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatQueue.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatQueue.java
@@ -110,7 +110,6 @@ public class ChatQueue implements AutoCloseable {
     });
   }
 
-  @SuppressWarnings("resource")
   private <T extends MinecraftPacket> CompletableFuture<Void> writePacket(T packet, MinecraftConnection smc) {
     CompletableFuture<Void> result = new CompletableFuture<>();
     smc.eventLoop().execute(() -> {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
@@ -61,5 +61,7 @@ public abstract class RateLimitedCommandHandler<T extends MinecraftPacket> imple
         return false;
     }
 
+    // Implementations forward the packet through the chat queue WITHOUT firing
+    // CommandExecuteEvent - rate-limited commands are intentionally not seen by plugins.
     protected abstract void forwardRateLimited(T packet);
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
@@ -43,7 +43,12 @@ public abstract class RateLimitedCommandHandler<T extends MinecraftPacket> imple
                 }
 
                 if (velocityServer.getConfiguration().isForwardCommandsIfRateLimited()) {
-                    return false; // Send the packet to the server
+                    // Route through the chat queue rather than letting the dispatcher write the
+                    // packet directly: a direct write would race ahead of any queued earlier
+                    // commands whose plugin events are still pending, causing the backend to see
+                    // out-of-order timestamps and kick the player for "out-of-order chat".
+                    forwardRateLimited(packetClass().cast(packet));
+                    return true;
                 }
             } else {
                 failedAttempts = 0;
@@ -55,4 +60,6 @@ public abstract class RateLimitedCommandHandler<T extends MinecraftPacket> imple
 
         return false;
     }
+
+    protected abstract void forwardRateLimited(T packet);
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/RateLimitedCommandHandler.java
@@ -61,7 +61,10 @@ public abstract class RateLimitedCommandHandler<T extends MinecraftPacket> imple
         return false;
     }
 
-    // Implementations forward the packet through the chat queue WITHOUT firing
-    // CommandExecuteEvent - rate-limited commands are intentionally not seen by plugins.
+    /**
+     * Forwards a rate-limited command packet through the chat queue.
+     *
+     * @param packet the rate-limited command packet to forward
+     */
     protected abstract void forwardRateLimited(T packet);
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/keyed/KeyedCommandHandler.java
@@ -43,6 +43,15 @@ public class KeyedCommandHandler extends RateLimitedCommandHandler<KeyedPlayerCo
   }
 
   @Override
+  protected void forwardRateLimited(KeyedPlayerCommandPacket packet) {
+    player.getChatQueue().queuePacket(
+        newLastSeenMessages -> CompletableFuture.completedFuture(packet),
+        packet.getTimestamp(),
+        null
+    );
+  }
+
+  @Override
   public void handlePlayerCommandInternal(KeyedPlayerCommandPacket packet) {
     queueCommandResult(this.server, this.player, (event, newLastSeenMessages) -> {
       CommandExecuteEvent.CommandResult result = event.getResult();

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/legacy/LegacyCommandHandler.java
@@ -42,6 +42,12 @@ public class LegacyCommandHandler extends RateLimitedCommandHandler<LegacyChatPa
   }
 
   @Override
+  protected void forwardRateLimited(LegacyChatPacket packet) {
+    player.getChatQueue().queuePacket(
+        chatState -> packet);
+  }
+
+  @Override
   public void handlePlayerCommandInternal(LegacyChatPacket packet) {
     String command = packet.getMessage().substring(1);
     queueCommandResult(this.server, this.player, (event, newLastSeenMessages) -> {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
@@ -99,6 +99,16 @@ public class SessionCommandHandler extends RateLimitedCommandHandler<SessionPlay
   }
 
   @Override
+  protected void forwardRateLimited(SessionPlayerCommandPacket packet) {
+    player.getChatQueue().queuePacket(
+        newLastSeenMessages -> CompletableFuture.completedFuture(
+            packet.withLastSeenMessages(newLastSeenMessages)),
+        packet.timeStamp,
+        packet.lastSeenMessages
+    );
+  }
+
+  @Override
   public void handlePlayerCommandInternal(SessionPlayerCommandPacket packet) {
     queueCommandResult(this.server, this.player, (event, newLastSeenMessages) -> {
       SessionPlayerCommandPacket fixedPacket = packet.withLastSeenMessages(newLastSeenMessages);

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
@@ -100,6 +100,8 @@ public class SessionCommandHandler extends RateLimitedCommandHandler<SessionPlay
 
   @Override
   protected void forwardRateLimited(SessionPlayerCommandPacket packet) {
+    // Forwarded without firing CommandExecuteEvent: rate-limited commands are shed,
+    // so plugins do not see or get to cancel them - same as the prior direct-write path.
     player.getChatQueue().queuePacket(
         newLastSeenMessages -> CompletableFuture.completedFuture(
             packet.withLastSeenMessages(newLastSeenMessages)),

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/session/SessionCommandHandler.java
@@ -100,8 +100,6 @@ public class SessionCommandHandler extends RateLimitedCommandHandler<SessionPlay
 
   @Override
   protected void forwardRateLimited(SessionPlayerCommandPacket packet) {
-    // Forwarded without firing CommandExecuteEvent: rate-limited commands are shed,
-    // so plugins do not see or get to cancel them - same as the prior direct-write path.
     player.getChatQueue().queuePacket(
         newLastSeenMessages -> CompletableFuture.completedFuture(
             packet.withLastSeenMessages(newLastSeenMessages)),


### PR DESCRIPTION
Fix chat race conditions not addressed by #1042.

Despite #1042 serializing chat/command processing through `ChatQueue`, two issues allowed out-of-order packets to reach the backend:

1. Rate-limited commands bypassed `ChatQueue` entirely

`RateLimitedCommandHandler` returned false when a command was rate-limited and forward-commands-if-rate-limited was enabled (the default). This caused the Netty dispatch path to write the packet directly to the backend via `handleGeneric`, racing ahead of any earlier commands still waiting in the queue for their `CommandExecuteEvent` to complete. Under rapid command bursts (e.g. litematica's schematic paste), this produced the exact out_of_order_chat kick described in #1042.

Fix: route rate-limited commands through `ChatQueue` via a new `forwardRateLimited` path, skipping plugin event firing but preserving write order.

2. `ChatQueue.writePacket` blocked the Netty event loop

`writePacket` submitted a runnable to the event loop that called `awaitUninterruptibly()` on the resulting `ChannelFuture`. Under backpressure (socket buffer full), Netty's deadlock guard throws `BlockingOperationException` before actually blocking, which was silently swallowed by `.exceptionally(ignored -> null)`, making the "wait for send" step a no-op and allowing the queue to advance prematurely.

Fix: replace the blocking call with `addListener`, completing the `CompletableFuture` asynchronously when Netty confirms the write, with no event loop blocking.