### PR TITLE
Fix wrong logs in `exception(Throwable)` for `ClientPlaySessionHandler` and `ClientConfigSessionHandler`

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -270,7 +270,7 @@ public class ClientConfigSessionHandler implements MinecraftSessionHandler {
   public void exception(Throwable throwable) {
     player.disconnect(Component.translatable("velocity.error.player-connection-error", NamedTextColor.RED));
     if (MinecraftDecoder.DEBUG) {
-      logger.info("Exception while handling plugin message packet for {}", player, throwable);
+      logger.info("Exception while handling packet for {}", player, throwable);
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -508,10 +508,9 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
 
   @Override
   public void exception(Throwable throwable) {
-    player.disconnect(
-        Component.translatable("velocity.error.player-connection-error", NamedTextColor.RED));
+    player.disconnect(Component.translatable("velocity.error.player-connection-error", NamedTextColor.RED));
     if (MinecraftDecoder.DEBUG) {
-      logger.info("Exception while handling plugin message packet for {}", player, throwable);
+      logger.info("Exception while handling packet for {}", player, throwable);
     }
   }
 


### PR DESCRIPTION
Most likely a copy/pasta mistake; the `exception(Throwable)` method gets called in many more cases than just bad plugin messages.