### PR TITLE
Legacy/BungeeGuard forwarding `FML`/`FORGE` hostname token fixes

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/legacy/LegacyForgeConnectionType.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/legacy/LegacyForgeConnectionType.java
@@ -38,11 +38,11 @@ public class LegacyForgeConnectionType extends ConnectionTypeImpl {
   @Override
   public GameProfile addGameProfileTokensIfRequired(GameProfile original,
       PlayerInfoForwarding forwardingType) {
-    // We can't forward the FML token to the server when we are running in legacy forwarding mode,
+    // We can't forward the FML token to the server when we are running in legacy (or bungeeguard) forwarding mode,
     // since both use the "hostname" field in the handshake. We add a special property to the
     // profile instead, which will be ignored by non-Forge servers and can be intercepted by a
     // Forge coremod, such as SpongeForge.
-    if (forwardingType == PlayerInfoForwarding.LEGACY) {
+    if (forwardingType == PlayerInfoForwarding.LEGACY || forwardingType == PlayerInfoForwarding.BUNGEEGUARD) {
       return original.addProperty(IS_FORGE_CLIENT_PROPERTY);
     }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
@@ -18,7 +18,7 @@
 package com.velocitypowered.proxy.connection.forge.modern;
 
 import static com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants.EXTRA_DATA_PROPERTY;
-import static com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants.IS_FORGE_CLIENT_PROPERTY;
+import static com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants.IS_MODERN_FORGE_CLIENT_PROPERTY;
 import static com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants.MODERN_FORGE_TOKEN;
 
 import com.velocitypowered.api.util.GameProfile;
@@ -75,13 +75,9 @@ public class ModernForgeConnectionType extends ConnectionTypeImpl {
     // profile instead, which will be ignored by non-Forge servers and can be intercepted by a
     // Forge coremod, such as SpongeForge, BungeeForge, or ProxyCompatibleForge.
     if (forwardingType == PlayerInfoForwarding.LEGACY || forwardingType == PlayerInfoForwarding.BUNGEEGUARD) {
-      final String[] split = hostName.split("\0", 2);
-      if (split.length < 2) { // This shouldn't occur; just a sanity check
-        return original.addProperty(IS_FORGE_CLIENT_PROPERTY);
-      }
-      final String extraData = "\1" + split[1].replaceAll("\0", "\1");
-      return original.addProperty(IS_FORGE_CLIENT_PROPERTY)
-              .addProperty(EXTRA_DATA_PROPERTY.apply(extraData));
+      return original.addProperty(IS_MODERN_FORGE_CLIENT_PROPERTY)
+              .addProperty(EXTRA_DATA_PROPERTY.apply(
+                      this.getModernToken().replaceAll("\0", "\1")));
     }
 
     return original;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
@@ -28,7 +28,7 @@ import com.velocitypowered.proxy.connection.client.ClientConnectionPhases;
 import com.velocitypowered.proxy.connection.util.ConnectionTypeImpl;
 
 /**
- * Contains extra logic.
+ * Contains extra logic to handle Forge 1.20.2+ clients.
  */
 public class ModernForgeConnectionType extends ConnectionTypeImpl {
 
@@ -48,7 +48,7 @@ public class ModernForgeConnectionType extends ConnectionTypeImpl {
   /**
    * Align the acquisition logic with the internal code of Forge.
    *
-   * @return returns the final correct hostname
+   * @return returns the modern Forge token with the Net Version.
    */
   public String getModernToken() {
     int netVersion = 0;
@@ -59,12 +59,12 @@ public class ModernForgeConnectionType extends ConnectionTypeImpl {
           if (pt.length() > MODERN_FORGE_TOKEN.length()) {
             netVersion = Integer.parseInt(
                     pt.substring(MODERN_FORGE_TOKEN.length()));
+            break;
           }
         }
       }
     }
-    return netVersion == 0 ? "\0" + MODERN_FORGE_TOKEN : "\0"
-            + MODERN_FORGE_TOKEN + netVersion;
+    return MODERN_FORGE_TOKEN + (netVersion == 0 ? "" : netVersion);
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
@@ -17,6 +17,8 @@
 
 package com.velocitypowered.proxy.connection.forge.modern;
 
+import static com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants.EXTRA_DATA_PROPERTY;
+import static com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants.IS_FORGE_CLIENT_PROPERTY;
 import static com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants.MODERN_FORGE_TOKEN;
 
 import com.velocitypowered.api.util.GameProfile;
@@ -71,9 +73,15 @@ public class ModernForgeConnectionType extends ConnectionTypeImpl {
     // We can't forward the FORGE token to the server when we are running in legacy (or bungeeguard) forwarding mode,
     // since both use the "hostname" field in the handshake. We add a special property to the
     // profile instead, which will be ignored by non-Forge servers and can be intercepted by a
-    // Forge coremod, such as ProxyCompatibleForge.
+    // Forge coremod, such as SpongeForge, BungeeForge, or ProxyCompatibleForge.
     if (forwardingType == PlayerInfoForwarding.LEGACY || forwardingType == PlayerInfoForwarding.BUNGEEGUARD) {
-      return original.addProperty(new GameProfile.Property("forgeClient", this.getModernToken(), ""));
+      final String[] split = hostName.split("\0", 2);
+      if (split.length < 2) { // This shouldn't occur; just a sanity check
+        return original.addProperty(IS_FORGE_CLIENT_PROPERTY);
+      }
+      final String extraData = "\1" + split[1].replaceAll("\0", "\1");
+      return original.addProperty(IS_FORGE_CLIENT_PROPERTY)
+              .addProperty(EXTRA_DATA_PROPERTY.apply(extraData));
     }
 
     return original;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConnectionType.java
@@ -19,6 +19,8 @@ package com.velocitypowered.proxy.connection.forge.modern;
 
 import static com.velocitypowered.proxy.connection.forge.modern.ModernForgeConstants.MODERN_FORGE_TOKEN;
 
+import com.velocitypowered.api.util.GameProfile;
+import com.velocitypowered.proxy.config.PlayerInfoForwarding;
 import com.velocitypowered.proxy.connection.backend.BackendConnectionPhases;
 import com.velocitypowered.proxy.connection.client.ClientConnectionPhases;
 import com.velocitypowered.proxy.connection.util.ConnectionTypeImpl;
@@ -47,19 +49,33 @@ public class ModernForgeConnectionType extends ConnectionTypeImpl {
    * @return returns the final correct hostname
    */
   public String getModernToken() {
-    int natVersion = 0;
+    int netVersion = 0;
     int idx = hostName.indexOf('\0');
     if (idx != -1) {
       for (var pt : hostName.split("\0")) {
         if (pt.startsWith(MODERN_FORGE_TOKEN)) {
           if (pt.length() > MODERN_FORGE_TOKEN.length()) {
-            natVersion = Integer.parseInt(
+            netVersion = Integer.parseInt(
                     pt.substring(MODERN_FORGE_TOKEN.length()));
           }
         }
       }
     }
-    return natVersion == 0 ? "\0" + MODERN_FORGE_TOKEN : "\0"
-            + MODERN_FORGE_TOKEN + natVersion;
+    return netVersion == 0 ? "\0" + MODERN_FORGE_TOKEN : "\0"
+            + MODERN_FORGE_TOKEN + netVersion;
+  }
+
+  @Override
+  public GameProfile addGameProfileTokensIfRequired(GameProfile original,
+      PlayerInfoForwarding forwardingType) {
+    // We can't forward the FORGE token to the server when we are running in legacy (or bungeeguard) forwarding mode,
+    // since both use the "hostname" field in the handshake. We add a special property to the
+    // profile instead, which will be ignored by non-Forge servers and can be intercepted by a
+    // Forge coremod, such as ProxyCompatibleForge.
+    if (forwardingType == PlayerInfoForwarding.LEGACY || forwardingType == PlayerInfoForwarding.BUNGEEGUARD) {
+      return original.addProperty(new GameProfile.Property("forgeClient", this.getModernToken(), ""));
+    }
+
+    return original;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
@@ -24,13 +24,23 @@ import java.util.function.Function;
  * Constants for use with Modern Forge systems.
  */
 public class ModernForgeConstants {
-  public static final String MODERN_FORGE_TOKEN = "FORGE";
-  public static final String MODERN_FORGE_CLIENT = "modernForgeClient";
-  public static final String EXTRA_DATA = "extraData";
+  /**
+   * Clients attempting to connect to 1.20.2+ Forge servers will have this token appended to the
+   * hostname in the initial handshake packet.
+   */
+  public static final String MODERN_FORGE_TOKEN = "\0FORGE";
 
+  /**
+   * Property used to identify a modern Forge client, used in tandem with "extraData".
+   */
+  public static final String MODERN_FORGE_CLIENT = "modernForgeClient";
   public static final GameProfile.Property IS_MODERN_FORGE_CLIENT_PROPERTY =
           new GameProfile.Property(MODERN_FORGE_CLIENT, "true", "");
 
+  /**
+   * Property used to forward the Forge marker with the Net Version to the backend server.
+   */
+  public static final String EXTRA_DATA = "extraData";
   public static final Function<String, GameProfile.Property> EXTRA_DATA_PROPERTY =
           (extraData) -> new GameProfile.Property(EXTRA_DATA, extraData, "");
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
@@ -25,12 +25,12 @@ import java.util.function.Function;
  */
 public class ModernForgeConstants {
   public static final String MODERN_FORGE_TOKEN = "FORGE";
-  public static final String FORGE_CLIENT = "forgeClient";
+  public static final String MODERN_FORGE_CLIENT = "modernForgeClient";
   public static final String EXTRA_DATA = "extraData";
 
-  public static final GameProfile.Property IS_FORGE_CLIENT_PROPERTY =
-          new GameProfile.Property(FORGE_CLIENT, "true", "");
+  public static final GameProfile.Property IS_MODERN_FORGE_CLIENT_PROPERTY =
+          new GameProfile.Property(MODERN_FORGE_CLIENT, "true", "");
 
   public static final Function<String, GameProfile.Property> EXTRA_DATA_PROPERTY =
-          (data) -> new GameProfile.Property(EXTRA_DATA, data, "");
+          (extraData) -> new GameProfile.Property(EXTRA_DATA, extraData, "");
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
@@ -17,9 +17,20 @@
 
 package com.velocitypowered.proxy.connection.forge.modern;
 
+import com.velocitypowered.api.util.GameProfile;
+import java.util.function.Function;
+
 /**
  * Constants for use with Modern Forge systems.
  */
 public class ModernForgeConstants {
   public static final String MODERN_FORGE_TOKEN = "FORGE";
+  public static final String FORGE_CLIENT = "forgeClient";
+  public static final String EXTRA_DATA = "extraData";
+
+  public static final GameProfile.Property IS_FORGE_CLIENT_PROPERTY =
+          new GameProfile.Property(FORGE_CLIENT, "true", "");
+
+  public static final Function<String, GameProfile.Property> EXTRA_DATA_PROPERTY =
+          (data) -> new GameProfile.Property(EXTRA_DATA, data, "");
 }


### PR DESCRIPTION
While working through implementing Legacy+BungeeGuard forwarding for [ProxyCompatibleForge](https://github.com/adde0109/Proxy-Compatible-Forge/pull/86), I realized that #1176 never implemented a way for Velocity to forward the modern `FORGE[#]` hostname token when legacy forwarding types were in use.
Additionally, while testing I found that the existing token forwarding for 1.8 - 1.12.2 didn't work with BungeeGuard forwarding.

The latter was a simple one-line fix, but I'd like some feedback regarding forwarding the modern `FORGE[#]` token, or if there are any other sections that need a tidy.

Somewhat in-line with [Waterfall's `"forgeClient"` and `"extraData"` properties](https://github.com/PaperMC/Waterfall/blob/master/BungeeCord-Patches/0011-Add-support-for-FML-with-IP-Forwarding-enabled.patch), I've added a new `"modernForgeClient"` property to account for backend implementations that always associate `"forgeClient"` with the older `FML` token, or backend implementations built with respect to Waterfall assuming the forwarded token is in the form of `FML[#]`. Any implementation that appends the `"extraData"` verbatim to the hostname (and replaces `\1` with `\0`) should continue to function as expected.

To note, I've explicitly strayed away from adding additional handling for `FML2` and `FML3` (Forge 1.13.2 - 1.20.1 and NeoForge 1.20.2), as in testing I found the resulting handshake errors from NeoForge 1.20.2 to be quite ambiguous, and would probably confuse users more than the current "vanilla <-> Neo/Forge" connection errors they would encounter.

Some notes regarding Neo/Forge markers:
- NeoForge 1.20.4-present: `N/A`
- [Forge 1.20.2-present](https://github.com/MinecraftForge/MinecraftForge/blob/26.1.2/src/main/java/net/minecraftforge/network/NetworkContext.java), Format: `\0FORGE + NET_VERSION`
- [NeoForge 1.20.2](https://github.com/neoforged/NeoForge/blob/1.20.2/src/main/java/net/neoforged/neoforge/network/NetworkConstants.java), Format: `\0FML + NET_VERSION`, where `NET_VERSION` is only ever `3`
- Forge [1.13.2](https://github.com/MinecraftForge/MinecraftForge/blob/1.13.x/src/main/java/net/minecraftforge/fml/network/FMLNetworkConstants.java)  - [1.20.1](https://github.com/MinecraftForge/MinecraftForge/blob/1.20.1/src/main/java/net/minecraftforge/network/NetworkConstants.java), Format:`\0FML + NET_VERSION`
  - Forge 1.13.2 - 1.18.1: `\0FML2`
  - Forge 1.18.2 - 1.20.1: `\0FML3`
- Forge [1.8](https://github.com/MinecraftForge/MinecraftForge/blob/1.8.9/patches/minecraft/net/minecraft/network/handshake/client/C00Handshake.java.patch) - [1.12.2](https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/patches/minecraft/net/minecraft/network/handshake/client/C00Handshake.java.patch), Format: `\0FML\0`
