### PR TITLE
fix(proxy): queue play packets when reentering configuration

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -33,7 +33,6 @@ import com.velocitypowered.natives.encryption.VelocityCipher;
 import com.velocitypowered.natives.encryption.VelocityCipherFactory;
 import com.velocitypowered.natives.util.Natives;
 import com.velocitypowered.proxy.VelocityServer;
-import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
 import com.velocitypowered.proxy.connection.client.HandshakeSessionHandler;
 import com.velocitypowered.proxy.connection.client.InitialLoginSessionHandler;
 import com.velocitypowered.proxy.connection.client.StatusSessionHandler;
@@ -369,7 +368,6 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
   public void setState(StateRegistry state) {
     ensureInEventLoop();
 
-    final StateRegistry previousState = this.state;
     this.state = state;
     final MinecraftVarintFrameDecoder frameDecoder = this.channel.pipeline()
         .get(MinecraftVarintFrameDecoder.class);
@@ -390,13 +388,7 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
 
     if (state == StateRegistry.CONFIG) {
       // Activate the play packet queue
-      if (previousState == StateRegistry.PLAY
-          && this.pendingConfigurationSwitch
-          && this.association instanceof ConnectedPlayer) {
-        addPlayPacketQueueOutboundHandler();
-      } else {
-        addPlayPacketQueueHandler();
-      }
+      addPlayPacketQueueHandler();
     } else {
       // Remove the queue
       if (this.channel.pipeline().get(Connections.PLAY_PACKET_QUEUE_OUTBOUND) != null) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1385,7 +1385,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
           connection.pendingConfigurationSwitch = true;
           connection.getChannel().pipeline().get(MinecraftEncoder.class).setState(StateRegistry.CONFIG);
           // Make sure we don't send any play packets to the player after update start
-          connection.addPlayPacketQueueOutboundHandler();
+          connection.addPlayPacketQueueHandler();
         }, connection.eventLoop()).exceptionally((ex) -> {
           logger.error("Error switching player connection to config state", ex);
           return null;


### PR DESCRIPTION
## Summary

Restore the full play-packet queue when a player connection reenters configuration state from play state.

This keeps the existing serverbound forwarding guards from the previous reconfiguration change, but avoids switching the client-side connection to outbound-only queueing during reconfiguration. Reentering configuration is a transitional protocol state, so both inbound and outbound play packets should be handled consistently until the configuration acknowledgement completes.

## Root cause

The current code installs only `PlayPacketQueueOutboundHandler` when a play-state client is moved back into configuration. That protects clientbound play packets, but leaves the inbound side without the normal configuration-state queueing used elsewhere. In nested or rapid server-switch flows, this can leave the switch stuck waiting for reconfiguration to complete.

## Reconfiguration flow

```mermaid
sequenceDiagram
    actor Player
    participant Velocity
    participant Server as Backend server

    Player->>Velocity: In PLAY on current backend
    Server-->>Velocity: New backend login succeeds
    Velocity->>Player: StartUpdatePacket
    Note over Player,Velocity: Client starts PLAY to CONFIG reconfiguration
    Velocity->>Velocity: pendingConfigurationSwitch = true

    alt Outbound-only queueing
        Velocity->>Velocity: Install PlayPacketQueueOutboundHandler only
        Note over Velocity: Clientbound PLAY packets are queued,<br/>but serverbound PLAY packets are not buffered
        Player-->>Velocity: Serverbound PLAY packet during transition
        Velocity--xVelocity: Packet reaches the transitional CONFIG path
        Server--xVelocity: Switch can stall before configuration completes
        Velocity--xPlayer: Client remains at reconfiguring until timeout
    else Full play-packet queueing
        Velocity->>Velocity: Install full play-packet queue
        Note over Velocity: PLAY packets in both directions are queued,<br/>while CONFIG packets continue through
        Player->>Velocity: FinishedUpdatePacket
        Velocity->>Server: Forward FinishedUpdatePacket
        Velocity->>Velocity: Backend enters CONFIG
        Server->>Velocity: JoinGame after config completes
        Velocity->>Player: JoinGame and switch packets
        Velocity->>Velocity: Remove play-packet queues
        Player->>Velocity: In PLAY on new backend
    end
```

## Validation

- `git diff --check`
- `JAVA_HOME=/home/alex/.gradle/jdks/eclipse_adoptium-21-amd64-linux.2 ./gradlew check --console=plain`

## Disclosure

This PR was made by codex to fix a bug I have when configuration transitions happen.

---

Regression was introduced as part of b1a1b8bd.
