### PR TITLE
Bump Netty to `4.2.13.Final`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ configurate3 = "3.7.3"
 configurate4 = "4.2.0"
 flare = "2.0.1"
 log4j = "2.25.3"
-netty = "4.2.10.Final"
+netty = "4.2.13.Final"
 
 [plugins]
 fill = "io.papermc.fill.gradle:1.0.10"


### PR DESCRIPTION
This bump is recommended, given: https://github.com/netty/netty/security/advisories/GHSA-rwm7-x88c-3g2p

Although Velocity doesn't explicitly enable `ALLOW_HALF_CLOSURE`, it's still worth tightening the gap.