### PR TITLE
Fix build-time GraalVmProcessor warning

### DIFF
--- a/proxy/build.gradle.kts
+++ b/proxy/build.gradle.kts
@@ -112,6 +112,15 @@ tasks {
         workingDir = file("run").also(File::mkdirs)
         standardInput = System.`in` // Doesn't work?
     }
+
+    withType<JavaCompile>().configureEach {
+        options.compilerArgs.addAll(
+            listOf(
+                "-Alog4j.graalvm.groupId=${project.group}",
+                "-Alog4j.graalvm.artifactId=${project.name}"
+            )
+        )
+    }
 }
 
 val projectVersion = version as String


### PR DESCRIPTION
Building the project shows the following warning:
```
> Task :velocity-proxy:compileJava
warning: The `GraalVmProcessor` annotation processor is missing the recommended `log4j.graalvm.groupId` and `log4j.graalvm.artifactId` options.
  To follow the GraalVM recommendations, please add the following options to your build tool:
    -Alog4j.graalvm.groupId=<groupId>
    -Alog4j.graalvm.artifactId=<artifactId>
```

This PR fixes this by adding the required options.