### PR TITLE
Fix `TitleActionbarPacket`'s default action type by setting it to `SET_ACTION_BAR`

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleActionbarPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleActionbarPacket.java
@@ -28,7 +28,7 @@ public class TitleActionbarPacket extends GenericTitlePacket {
   private ComponentHolder component;
 
   public TitleActionbarPacket() {
-    setAction(ActionType.SET_TITLE);
+    setAction(ActionType.SET_ACTION_BAR);
   }
 
   @Override


### PR DESCRIPTION
Correct me if I'm wrong, but it seems like `SET_ACTION_BAR` is the right action for the `TitleActionbarPacket` packet.

This bug doesn't surface when creating this class from the factory:
```java
// in GenericTitlePacket
public static GenericTitlePacket constructTitlePacket(ActionType type, ProtocolVersion version) {
  GenericTitlePacket packet = null;
  if (version.noLessThan(ProtocolVersion.MINECRAFT_1_17)) {
    packet = switch (type) {
      case SET_ACTION_BAR -> new TitleActionbarPacket();
      case SET_SUBTITLE -> new TitleSubtitlePacket();
      case SET_TIMES -> new TitleTimesPacket();
      case SET_TITLE -> new TitleTextPacket();
      case HIDE, RESET -> new TitleClearPacket();
      default -> throw new IllegalArgumentException("Invalid ActionType");
    };
  } else {
    packet = new LegacyTitlePacket();
  }
  packet.setAction(type);
  return packet;
}
```

Namely through:
```java
case SET_ACTION_BAR -> new TitleActionbarPacket();
packet.setAction(type); // overrides the type as SET_ACTION_BAR (overrides wrong constructor value)
```

`StateRegistry` does use `TitleActionbarPacket`'s constructor directly, but it gets discarded and never stored/used because of all mappings being encode-only.

As far as I can see this has no implications in Velocity itself,the action type is only read by `TitleClearPacket` `LegacyTitlePacket` (the latter doesn't even distinguish between `SET_TITLE` and `SET_ACTION_BAR`)

For correctness sake, this should be fixed.