### PR TITLE
Clean up Title packets and enforce action types

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -135,6 +135,7 @@ import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import net.kyori.adventure.text.minimessage.translation.Argument;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import net.kyori.adventure.title.Title;
 import net.kyori.adventure.title.Title.Times;
 import net.kyori.adventure.title.TitlePart;
 import net.kyori.adventure.translation.GlobalTranslator;
@@ -486,11 +487,11 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   }
 
   @Override
-  public void showTitle(net.kyori.adventure.title.@NonNull Title title) {
+  public void showTitle(@NonNull Title title) {
     if (this.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_8)) {
       GenericTitlePacket timesPkt = GenericTitlePacket.constructTitlePacket(
           GenericTitlePacket.ActionType.SET_TIMES, this.getProtocolVersion());
-      net.kyori.adventure.title.Title.Times times = title.times();
+      Title.Times times = title.times();
       if (times != null) {
         timesPkt.setFadeIn((int) DurationUtils.toTicks(times.fadeIn()));
         timesPkt.setStay((int) DurationUtils.toTicks(times.stay()));

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/GenericTitlePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/GenericTitlePacket.java
@@ -22,10 +22,12 @@ import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import io.netty.buffer.ByteBuf;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class GenericTitlePacket implements MinecraftPacket {
 
   public enum ActionType {
+
     SET_TITLE(0),
     SET_SUBTITLE(1),
     SET_ACTION_BAR(2),
@@ -45,16 +47,7 @@ public abstract class GenericTitlePacket implements MinecraftPacket {
     }
   }
 
-
-  private ActionType action;
-
-  protected void setAction(ActionType action) {
-    this.action = action;
-  }
-
-  public final ActionType getAction() {
-    return action;
-  }
+  public abstract @NotNull ActionType getAction();
 
   public ComponentHolder getComponent() {
     throw new UnsupportedOperationException("Invalid function for this TitlePacket ActionType");
@@ -88,7 +81,6 @@ public abstract class GenericTitlePacket implements MinecraftPacket {
     throw new UnsupportedOperationException("Invalid function for this TitlePacket ActionType");
   }
 
-
   @Override
   public final void decode(ByteBuf buf, ProtocolUtils.Direction direction,
       ProtocolVersion version) {
@@ -103,21 +95,17 @@ public abstract class GenericTitlePacket implements MinecraftPacket {
    * @return GenericTitlePacket instance that follows the invoker type/version
    */
   public static GenericTitlePacket constructTitlePacket(ActionType type, ProtocolVersion version) {
-    GenericTitlePacket packet = null;
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_17)) {
-      packet = switch (type) {
+      return switch (type) {
         case SET_ACTION_BAR -> new TitleActionbarPacket();
         case SET_SUBTITLE -> new TitleSubtitlePacket();
         case SET_TIMES -> new TitleTimesPacket();
         case SET_TITLE -> new TitleTextPacket();
-        case HIDE, RESET -> new TitleClearPacket();
+        case HIDE, RESET -> new TitleClearPacket(type);
         default -> throw new IllegalArgumentException("Invalid ActionType");
       };
     } else {
-      packet = new LegacyTitlePacket();
+      return new LegacyTitlePacket(type);
     }
-    packet.setAction(type);
-    return packet;
   }
-
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/GenericTitlePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/GenericTitlePacket.java
@@ -82,9 +82,8 @@ public abstract class GenericTitlePacket implements MinecraftPacket {
   }
 
   @Override
-  public final void decode(ByteBuf buf, ProtocolUtils.Direction direction,
-      ProtocolVersion version) {
-    throw new UnsupportedOperationException(); // encode only
+  public final void decode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion version) {
+    throw new UnsupportedOperationException("Decode is not implemented");
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/LegacyTitlePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/LegacyTitlePacket.java
@@ -22,27 +22,40 @@ import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import io.netty.buffer.ByteBuf;
+import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 public class LegacyTitlePacket extends GenericTitlePacket {
+
+  private final ActionType action;
 
   private @Nullable ComponentHolder component;
   private int fadeIn;
   private int stay;
   private int fadeOut;
 
+  public LegacyTitlePacket() {
+    // This constructor only exists to keep StateRegistry happy (all mappings are encode-only, the constructor isn't stored or used).
+    throw new AssertionError("A bare LegacyTitlePacket should never be instantiated");
+  }
+
+  public LegacyTitlePacket(ActionType action) {
+    this.action = Objects.requireNonNull(action, "action");
+  }
+
   @Override
   public void encode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion version) {
     if (version.lessThan(ProtocolVersion.MINECRAFT_1_11)
-        && getAction() == ActionType.SET_ACTION_BAR) {
+        && this.action == ActionType.SET_ACTION_BAR) {
       throw new IllegalStateException("Action bars are only supported on 1.11 and newer");
     }
-    ProtocolUtils.writeVarInt(buf, getAction().getAction(version));
+    ProtocolUtils.writeVarInt(buf, this.action.getAction(version));
 
-    switch (getAction()) {
+    switch (this.action) {
       case SET_TITLE, SET_SUBTITLE, SET_ACTION_BAR -> {
         if (component == null) {
-          throw new IllegalStateException("No component found for " + getAction());
+          throw new IllegalStateException("No component found for " + this.action);
         }
         component.write(buf);
       }
@@ -52,14 +65,13 @@ public class LegacyTitlePacket extends GenericTitlePacket {
         buf.writeInt(fadeOut);
       }
       case HIDE, RESET -> {}
-      default -> throw new UnsupportedOperationException("Unknown action " + getAction());
+      default -> throw new UnsupportedOperationException("Unknown action " + this.action);
     }
-
   }
 
   @Override
-  public void setAction(ActionType action) {
-    super.setAction(action);
+  public @NotNull ActionType getAction() {
+    return action;
   }
 
   @Override
@@ -105,7 +117,7 @@ public class LegacyTitlePacket extends GenericTitlePacket {
   @Override
   public String toString() {
     return "GenericTitlePacket{"
-        + "action=" + getAction()
+        + "action=" + action
         + ", component='" + component + '\''
         + ", fadeIn=" + fadeIn
         + ", stay=" + stay

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/LegacyTitlePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/LegacyTitlePacket.java
@@ -36,8 +36,7 @@ public class LegacyTitlePacket extends GenericTitlePacket {
   private int fadeOut;
 
   public LegacyTitlePacket() {
-    // This constructor only exists to keep StateRegistry happy (all mappings are encode-only, the constructor isn't stored or used).
-    throw new AssertionError("A bare LegacyTitlePacket should never be instantiated");
+    throw new UnsupportedOperationException("Decode is not implemented");
   }
 
   public LegacyTitlePacket(ActionType action) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/LegacyTitlePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/LegacyTitlePacket.java
@@ -17,14 +17,14 @@
 
 package com.velocitypowered.proxy.protocol.packet.title;
 
+import com.google.common.base.Preconditions;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import io.netty.buffer.ByteBuf;
-import java.util.Objects;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class LegacyTitlePacket extends GenericTitlePacket {
 
@@ -40,7 +40,7 @@ public class LegacyTitlePacket extends GenericTitlePacket {
   }
 
   public LegacyTitlePacket(ActionType action) {
-    this.action = Objects.requireNonNull(action, "action");
+    this.action = Preconditions.checkNotNull(action, "action");
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleActionbarPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleActionbarPacket.java
@@ -28,7 +28,7 @@ public class TitleActionbarPacket extends GenericTitlePacket {
   private ComponentHolder component;
 
   public TitleActionbarPacket() {
-    setAction(ActionType.SET_TITLE);
+    setAction(ActionType.SET_ACTION_BAR);
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleActionbarPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleActionbarPacket.java
@@ -22,13 +22,15 @@ import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import io.netty.buffer.ByteBuf;
+import org.jetbrains.annotations.NotNull;
 
 public class TitleActionbarPacket extends GenericTitlePacket {
 
   private ComponentHolder component;
 
-  public TitleActionbarPacket() {
-    setAction(ActionType.SET_ACTION_BAR);
+  @Override
+  public @NotNull ActionType getAction() {
+    return ActionType.SET_ACTION_BAR;
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleClearPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleClearPacket.java
@@ -21,30 +21,37 @@ import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import io.netty.buffer.ByteBuf;
+import org.jetbrains.annotations.NotNull;
 
 public class TitleClearPacket extends GenericTitlePacket {
 
+  private final ActionType action;
+
   public TitleClearPacket() {
-    setAction(ActionType.HIDE);
+    this.action = ActionType.HIDE;
+  }
+
+  public TitleClearPacket(ActionType action) {
+    if (action != ActionType.HIDE && action != ActionType.RESET) {
+      throw new IllegalArgumentException("TitleClearPacket only accepts the CLEAR and RESET actions.");
+    }
+    this.action = action;
   }
 
   @Override
-  public void setAction(ActionType action) {
-    if (action != ActionType.HIDE && action != ActionType.RESET) {
-      throw new IllegalArgumentException("TitleClearPacket only accepts CLEAR and RESET actions");
-    }
-    super.setAction(action);
+  public @NotNull ActionType getAction() {
+    return action;
   }
 
   @Override
   public void encode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion version) {
-    buf.writeBoolean(getAction() == ActionType.RESET);
+    buf.writeBoolean(this.action == ActionType.RESET);
   }
 
   @Override
   public String toString() {
     return "TitleClearPacket{"
-        + ", resetTimes=" + (getAction() == ActionType.RESET)
+        + ", resetTimes=" + (this.action == ActionType.RESET)
         + '}';
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleClearPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleClearPacket.java
@@ -28,12 +28,12 @@ public class TitleClearPacket extends GenericTitlePacket {
   private final ActionType action;
 
   public TitleClearPacket() {
-    this.action = ActionType.HIDE;
+    this(ActionType.HIDE);
   }
 
   public TitleClearPacket(ActionType action) {
     if (action != ActionType.HIDE && action != ActionType.RESET) {
-      throw new IllegalArgumentException("TitleClearPacket only accepts the CLEAR and RESET actions.");
+      throw new IllegalArgumentException("TitleClearPacket only accepts the HIDE and RESET actions.");
     }
     this.action = action;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleSubtitlePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleSubtitlePacket.java
@@ -22,13 +22,15 @@ import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import io.netty.buffer.ByteBuf;
+import org.jetbrains.annotations.NotNull;
 
 public class TitleSubtitlePacket extends GenericTitlePacket {
 
   private ComponentHolder component;
 
-  public TitleSubtitlePacket() {
-    setAction(ActionType.SET_SUBTITLE);
+  @Override
+  public @NotNull ActionType getAction() {
+    return ActionType.SET_SUBTITLE;
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleTextPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleTextPacket.java
@@ -22,13 +22,15 @@ import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import io.netty.buffer.ByteBuf;
+import org.jetbrains.annotations.NotNull;
 
 public class TitleTextPacket extends GenericTitlePacket {
 
   private ComponentHolder component;
 
-  public TitleTextPacket() {
-    setAction(ActionType.SET_TITLE);
+  @Override
+  public @NotNull ActionType getAction() {
+    return ActionType.SET_TITLE;
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleTimesPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/TitleTimesPacket.java
@@ -21,6 +21,7 @@ import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import io.netty.buffer.ByteBuf;
+import org.jetbrains.annotations.NotNull;
 
 public class TitleTimesPacket extends GenericTitlePacket {
 
@@ -28,8 +29,9 @@ public class TitleTimesPacket extends GenericTitlePacket {
   private int stay;
   private int fadeOut;
 
-  public TitleTimesPacket() {
-    setAction(ActionType.SET_TIMES);
+  @Override
+  public @NotNull ActionType getAction() {
+    return ActionType.SET_TIMES;
   }
 
   @Override


### PR DESCRIPTION
~~Closes #1802, this PR builds on-top of the fix proposed and explained in that PR.~~

~This PR drops the method visibility, enforces the action types (similar pattern to the already-existing enforcement in `TitleClearPacket`) and cleans up some whitespace formatting.~

After the third commit, this PR now does away with the `setAction()` method completely, which was only used within this package. It does not make sense to set the action type at all here; they must be exactly one action for most modern packets, except for `TitleClearPacket` which supports two types (which is still enforced), and except for `LegacyTitlePacket` which can still hold any action type.