### PR TITLE
Store backend command tree per server connection to allow on-demand resending of command set

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.dialog.DialogLike;
 import net.kyori.adventure.identity.Identified;
@@ -532,4 +533,19 @@ public interface Player extends
    * @sinceMinecraft 1.21
    */
   void setServerLinks(@NotNull List<ServerLink> links);
+
+  /**
+   * Rebuilds and resends this player's command list, combining the commands offered by the
+   * player's current server with the proxy's own commands.
+   *
+   * <p>This is useful when the set of available commands has changed and the client's command
+   * list needs to be refreshed, for example after a command is registered or unregistered at
+   * runtime. The {@link com.velocitypowered.api.event.command.PlayerAvailableCommandsEvent} is
+   * fired before the updated list is sent, giving listeners a final chance to modify it.
+   *
+   * <p>This method is non-blocking; the command list is sent asynchronously.
+   *
+   * @return a future that completes once the command list has been sent
+   */
+  CompletableFuture<Void> sendAvailableCommands();
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -21,9 +21,6 @@ import static com.velocitypowered.proxy.connection.backend.BungeeCordMessageResp
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.mojang.brigadier.tree.RootCommandNode;
-import com.velocitypowered.api.command.CommandSource;
-import com.velocitypowered.api.event.command.PlayerAvailableCommandsEvent;
 import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.event.connection.PreTransferEvent;
 import com.velocitypowered.api.event.player.CookieRequestEvent;
@@ -36,7 +33,6 @@ import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.player.ResourcePackInfo;
 import com.velocitypowered.proxy.VelocityServer;
-import com.velocitypowered.proxy.command.CommandGraphInjector;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.connection.client.ClientPlaySessionHandler;
@@ -358,26 +354,8 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(AvailableCommandsPacket commands) {
-    RootCommandNode<CommandSource> rootNode = commands.getRootNode();
-    if (server.getConfiguration().isAnnounceProxyCommands()) {
-      // Inject commands from the proxy.
-      final CommandGraphInjector<CommandSource> injector = server.getCommandManager().getInjector();
-      injector.inject(rootNode, serverConn.getPlayer());
-
-      // In 1.21.6 a confirmation prompt was added when executing a command via `run_command` click
-      // action if the command is unknown. To prevent this prompt we have to send the command.
-      if (this.playerConnection.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_21_6)) {
-        rootNode.removeChildByName("velocity:callback");
-      }
-    }
-
-    server.getEventManager().fire(
-            new PlayerAvailableCommandsEvent(serverConn.getPlayer(), rootNode))
-        .thenAcceptAsync(event -> playerConnection.write(commands), playerConnection.eventLoop())
-        .exceptionally((ex) -> {
-          logger.error("Exception while handling available commands for {}", playerConnection, ex);
-          return null;
-        });
+    serverConn.setBackendCommandsNode(commands.getRootNode());
+    serverConn.getPlayer().sendAvailableCommands(serverConn);
     return true;
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -22,6 +22,8 @@ import static com.velocitypowered.proxy.network.Connections.HANDLER;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;
+import com.mojang.brigadier.tree.RootCommandNode;
+import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.network.HandshakeIntent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.ServerConnection;
@@ -72,6 +74,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
   private BackendConnectionPhase connectionPhase = BackendConnectionPhases.UNKNOWN;
   private final Map<Long, Long> pendingPings = new HashMap<>();
   private @MonotonicNonNull Integer entityId;
+  private volatile @Nullable RootCommandNode<CommandSource> backendCommandsNode;
 
   /**
    * Initializes a new server connection.
@@ -371,5 +374,13 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
    */
   public boolean hasCompletedJoin() {
     return hasCompletedJoin;
+  }
+
+  public @Nullable RootCommandNode<CommandSource> getBackendCommandsNode() {
+    return backendCommandsNode;
+  }
+
+  public void setBackendCommandsNode(@Nullable RootCommandNode<CommandSource> backendCommandsNode) {
+    this.backendCommandsNode = backendCommandsNode;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -24,6 +24,10 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
+import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.tree.RootCommandNode;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.event.command.PlayerAvailableCommandsEvent;
 import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.connection.DisconnectEvent.LoginStatus;
 import com.velocitypowered.api.event.connection.PreTransferEvent;
@@ -59,6 +63,7 @@ import com.velocitypowered.api.util.ModInfo;
 import com.velocitypowered.api.util.ServerLink;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.adventure.VelocityBossBarImplementation;
+import com.velocitypowered.proxy.command.CommandGraphInjector;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftConnectionAssociation;
 import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
@@ -71,6 +76,7 @@ import com.velocitypowered.proxy.connection.util.ConnectionRequestResults.Impl;
 import com.velocitypowered.proxy.connection.util.VelocityInboundConnection;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.netty.MinecraftEncoder;
+import com.velocitypowered.proxy.protocol.packet.AvailableCommandsPacket;
 import com.velocitypowered.proxy.protocol.packet.BundleDelimiterPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientSettingsPacket;
 import com.velocitypowered.proxy.protocol.packet.ClientboundCookieRequestPacket;
@@ -683,6 +689,52 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
 
   public void resetInFlightConnection() {
     connectionInFlight = null;
+  }
+
+  @Override
+  public CompletableFuture<Void> sendAvailableCommands() {
+    return sendAvailableCommands(this.connectedServer);
+  }
+
+  /**
+   * Rebuilds and resends this player's command list, combining the commands offered by the given
+   * {@link VelocityServerConnection}. This may be {@code null}, to not inject any backend server commands.
+   *
+   * @param conn the server connection to grab the {@link VelocityServerConnection#getBackendCommandsNode()} from,
+   *             or {@code null} to not inject any backend server commands
+   * @return a future that completes after the {@link AvailableCommandsPacket} packet has been sent to the player
+   */
+  public CompletableFuture<Void> sendAvailableCommands(@Nullable VelocityServerConnection conn) {
+    RootCommandNode<CommandSource> workingNode = new RootCommandNode<>();
+    if (conn != null) {
+      RootCommandNode<CommandSource> backendNode = conn.getBackendCommandsNode();
+      if (backendNode != null) {
+        for (CommandNode<CommandSource> child : backendNode.getChildren()) {
+          workingNode.addChild(child);
+        }
+      }
+    }
+
+    if (server.getConfiguration().isAnnounceProxyCommands()) {
+      // Inject commands from the proxy.
+      CommandGraphInjector<CommandSource> injector = server.getCommandManager().getInjector();
+      injector.inject(workingNode, this);
+
+      // In 1.21.6 a confirmation prompt was added when executing a command via `run_command` click
+      // action if the command is unknown. To prevent this prompt we have to send the command.
+      if (this.connection.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_21_6)) {
+        workingNode.removeChildByName("velocity:callback");
+      }
+    }
+
+    AvailableCommandsPacket packet = new AvailableCommandsPacket(workingNode);
+    return server.getEventManager()
+        .fire(new PlayerAvailableCommandsEvent(this, workingNode))
+        .thenAcceptAsync(event -> connection.write(packet), connection.eventLoop())
+        .exceptionally(ex -> {
+          logger.error("Exception while sending available commands to {}", this, ex);
+          return null;
+        });
   }
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/AvailableCommandsPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/AvailableCommandsPacket.java
@@ -70,6 +70,13 @@ public class AvailableCommandsPacket implements MinecraftPacket {
 
   private @MonotonicNonNull RootCommandNode<CommandSource> rootNode;
 
+  public AvailableCommandsPacket() {
+  }
+
+  public AvailableCommandsPacket(RootCommandNode<CommandSource> rootNode) {
+    this.rootNode = rootNode;
+  }
+
   /**
    * Returns the root node.
    *


### PR DESCRIPTION
Inspired by:
- https://github.com/GemstoneGG/Velocity-CTD/commit/137e6da1d218accdc6812f4900208c1494ed9459
- https://github.com/GemstoneGG/Velocity-CTD/commit/6b6345406ba90f3e32d12712a8271080d95c1142

With this PR, plugins may dynamically decide to add commands to the client's command tree by triggering `Player#sendAvailableCommands` and listening for the `PlayerAvailableCommandsEvent` that gets fired as a result of it.

#### How much memory does this PR consume per player?
Let's assume 1.000 commands per player. A conservative lower bound, and a complete but educated-ish guess, would be about ~64 bytes per command, giving 64kb per player (for 500 players, this is 32MB)

Take this with a _giant_ grain of salt, but I had Claude Opus 4.7 have a go at estimating the memory footprint this PR brings with it.
Prompt: `Investigate exactly how much memory 'RootCommandNode<CommandSource> backendCommandsNode' in 'BackendPlaySessionHandler' consumes per player for 1000 commands with typical string lengths.`
After 7 minutes of "brewing", it estimated 274-331 bytes per command, giving ~300kb per player. This would be a more substantial 150MB at 500 players.

If this does become a feature of Velocity, we may consider hiding the `velocity:callback` command from the command tree unless a plugin registers a click-callback through Adventure (vanilla Velocity never uses this feature; this command only really needs to be sent to the client if a plugin does actually make use of this feature). See: https://github.com/GemstoneGG/Velocity-CTD/pull/866