### PR TITLE
Discard stale serverbound play packets when re-entering configuration

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -395,7 +395,7 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
       if (previousState == StateRegistry.PLAY
           && this.pendingConfigurationSwitch
           && this.association instanceof ConnectedPlayer) {
-        addPlayPacketQueueOutboundHandler();
+        addReconfigurationPlayPacketQueueHandler();
       } else {
         addPlayPacketQueueHandler();
       }
@@ -419,7 +419,20 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
     if (this.channel.pipeline().get(Connections.PLAY_PACKET_QUEUE_INBOUND) == null) {
       this.channel.pipeline().addAfter(Connections.MINECRAFT_DECODER, Connections.PLAY_PACKET_QUEUE_INBOUND,
            new PlayPacketQueueInboundHandler(this.protocolVersion,
-               channel.pipeline().get(MinecraftDecoder.class).getDirection()));
+               channel.pipeline().get(MinecraftDecoder.class).getDirection(), false));
+    }
+  }
+
+  /**
+   * Adds the play packet queue handlers for a re-entrant configuration switch.
+   */
+  public void addReconfigurationPlayPacketQueueHandler() {
+    addPlayPacketQueueOutboundHandler();
+
+    if (this.channel.pipeline().get(Connections.PLAY_PACKET_QUEUE_INBOUND) == null) {
+      this.channel.pipeline().addAfter(Connections.MINECRAFT_DECODER, Connections.PLAY_PACKET_QUEUE_INBOUND,
+           new PlayPacketQueueInboundHandler(this.protocolVersion,
+               channel.pipeline().get(MinecraftDecoder.class).getDirection(), true));
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -1384,8 +1384,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
           connection.write(StartUpdatePacket.INSTANCE);
           connection.pendingConfigurationSwitch = true;
           connection.getChannel().pipeline().get(MinecraftEncoder.class).setState(StateRegistry.CONFIG);
-          // Make sure we don't send any play packets to the player after update start
-          connection.addPlayPacketQueueOutboundHandler();
+          // Queue clientbound play packets, and drop stale serverbound ones, during reconfiguration
+          connection.addReconfigurationPlayPacketQueueHandler();
         }, connection.eventLoop()).exceptionally((ex) -> {
           logger.error("Error switching player connection to config state", ex);
           return null;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/PlayPacketQueueInboundHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/PlayPacketQueueInboundHandler.java
@@ -49,6 +49,8 @@ public class PlayPacketQueueInboundHandler extends ChannelDuplexHandler {
       "Queue too big (greater than " + MAXIMUM_SIZE + " bytes)");
 
   private final StateRegistry.PacketRegistry.ProtocolRegistry registry;
+  private final boolean discardStaleInbound;
+
   private final Queue<Object> queue = new ArrayDeque<>();
   private int queueSize = 0;
 
@@ -57,8 +59,10 @@ public class PlayPacketQueueInboundHandler extends ChannelDuplexHandler {
    *
    * @param version the protocol version
    */
-  public PlayPacketQueueInboundHandler(ProtocolVersion version, ProtocolUtils.Direction direction) {
+  public PlayPacketQueueInboundHandler(ProtocolVersion version, ProtocolUtils.Direction direction,
+                                       boolean discardStaleInbound) {
     this.registry = StateRegistry.CONFIG.getProtocolRegistry(direction, version);
+    this.discardStaleInbound = discardStaleInbound;
   }
 
   @Override
@@ -70,6 +74,13 @@ public class PlayPacketQueueInboundHandler extends ChannelDuplexHandler {
         ctx.fireChannelRead(msg);
         return;
       }
+    }
+
+    if (this.discardStaleInbound) {
+      // Re-entering configuration: this play packet belongs to the previous play session and
+      // must not be replayed into the next one, so drop it rather than queueing it.
+      ReferenceCountUtil.release(msg);
+      return;
     }
 
     int length = 0;


### PR DESCRIPTION
This targets https://github.com/PaperMC/Velocity/pull/1791 but with fewer side effects.