### PR TITLE
Fix inverted PluginMessageEvent source/target in InitialConnectSessionHandler

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialConnectSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialConnectSessionHandler.java
@@ -65,8 +65,7 @@ public class InitialConnectSessionHandler implements MinecraftSessionHandler {
       }
 
       byte[] copy = ByteBufUtil.getBytes(packet.content());
-      PluginMessageEvent event = new PluginMessageEvent(serverConn, serverConn.getPlayer(), id,
-          copy);
+      PluginMessageEvent event = new PluginMessageEvent(player, serverConn, id, copy);
       server.getEventManager().fire(event)
           .thenAcceptAsync(pme -> {
             if (pme.getResult().isAllowed() && serverConn.isActive()) {


### PR DESCRIPTION
- Fix `PluginMessageEvent` in `InitialConnectSessionHandler` so client -> backend plugin messages use `source = player` and `target = serverConn`, matching `ClientPlaySessionHandler` and `ClientConfigSessionHandler`.
- The handler previously used the backend -> client argument order from `BackendPlaySessionHandler` (introduced in #774), so client messages were exposed to plugins with `ServerConnection` as the source and `Player` as the target.