### PR TITLE
fix: Load default english translations as fallback

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -386,6 +386,14 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
             });
           }
 
+          try {
+            translationRegistry.registerAll(Locale.US, path.resolve("messages.properties"),
+                false);
+          } catch (IllegalArgumentException ignored) {
+            // Ignore duplicate translation key errors. We're loading these as fallback, so keys
+            // might already be present from the lang directory.
+          }
+
         } catch (IOException e) {
           logger.error("Encountered an I/O error whilst loading translations", e);
         }


### PR DESCRIPTION
As pointed out in https://github.com/PaperMC/Velocity/pull/1775#issuecomment-4273723975, when adding new translation strings to `messages.properties`, these strings are not populated into the translation files of existing setups. I think a full migration system, as suggested by the comment, for this would be overkill, we're rarely adding translations anyways, so I went with a different approach.

This pr loads the default `messages.properties` translations that are bundled with velocity as a "patch" on top of any existing translation files. This will prevent any missing translations from showing up as their key since the default english translations will always be available. 
