### PR TITLE
Add CLI options to load plugins from extra jars and directories

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/ProxyOptions.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/ProxyOptions.java
@@ -21,6 +21,7 @@ import com.velocitypowered.api.proxy.server.ServerInfo;
 import com.velocitypowered.proxy.util.AddressUtil;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import joptsimple.OptionParser;
@@ -28,6 +29,8 @@ import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import joptsimple.ValueConversionException;
 import joptsimple.ValueConverter;
+import joptsimple.util.PathConverter;
+import joptsimple.util.PathProperties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -43,6 +46,8 @@ public final class ProxyOptions {
   private final @Nullable Boolean haproxy;
   private final boolean ignoreConfigServers;
   private final List<ServerInfo> servers;
+  private final List<Path> extraPluginJars;
+  private final List<Path> extraPluginDirectories;
 
   ProxyOptions(final String[] args) {
     final OptionParser parser = new OptionParser();
@@ -64,6 +69,18 @@ public final class ProxyOptions {
     final OptionSpec<Void> ignoreConfigServers = parser.accepts("ignore-config-servers",
             "Skip registering servers from the config file. "
                     + "Useful in dynamic setups or with the --add-server flag.");
+    final OptionSpec<Path> pluginFiles = parser.acceptsAll(
+            Arrays.asList("add-plugin", "add-extra-plugin"),
+            "Load an additional plugin from the specified jar file.")
+        .withRequiredArg()
+        .withValuesConvertedBy(new PathConverter(PathProperties.FILE_EXISTING,
+            PathProperties.READABLE));
+    final OptionSpec<Path> pluginDirectories = parser.acceptsAll(
+            Arrays.asList("add-plugin-dir", "add-extra-plugin-dir"),
+            "Load plugins from an additional directory.")
+        .withRequiredArg()
+        .withValuesConvertedBy(new PathConverter(PathProperties.DIRECTORY_EXISTING,
+            PathProperties.READABLE));
     final OptionSet set = parser.parse(args);
 
     this.help = set.has(help);
@@ -71,6 +88,8 @@ public final class ProxyOptions {
     this.haproxy = haproxy.value(set);
     this.servers = servers.values(set);
     this.ignoreConfigServers = set.has(ignoreConfigServers);
+    this.extraPluginJars = pluginFiles.values(set);
+    this.extraPluginDirectories = pluginDirectories.values(set);
 
     if (this.help) {
       try {
@@ -99,6 +118,14 @@ public final class ProxyOptions {
 
   public List<ServerInfo> getServers() {
     return this.servers;
+  }
+
+  public List<Path> getExtraPluginJars() {
+    return this.extraPluginJars;
+  }
+
+  public List<Path> getExtraPluginDirectories() {
+    return this.extraPluginDirectories;
   }
 
   private static class ServerInfoConverter implements ValueConverter<ServerInfo> {

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -426,15 +426,14 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
 
       if (!pluginPath.toFile().exists()) {
         Files.createDirectory(pluginPath);
-      } else {
-        if (!pluginPath.toFile().isDirectory()) {
-          logger.warn("Plugin location {} is not a directory, continuing without loading plugins",
-              pluginPath);
-          return;
-        }
-
-        pluginManager.loadPlugins(pluginPath);
+      } else if (!pluginPath.toFile().isDirectory()) {
+        logger.warn("Plugin location {} is not a directory, continuing without loading plugins",
+            pluginPath);
+        return;
       }
+
+      pluginManager.loadPlugins(pluginPath, options.getExtraPluginDirectories(),
+          options.getExtraPluginJars());
     } catch (Exception e) {
       logger.error("Couldn't load plugins", e);
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/plugin/VelocityPluginManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/plugin/VelocityPluginManager.java
@@ -80,40 +80,43 @@ public class VelocityPluginManager implements PluginManager {
   }
 
   /**
-   * Loads all plugins from the specified {@code directory}.
+   * Loads all plugins found by scanning the given {@code directory} and
+   * {@code extraDirectories}, along with the individual plugin jars given in {@code extraJars}.
    *
-   * @param directory the directory to load from
-   * @throws IOException if we could not open the directory
+   * @param directory the main directory to scan for plugin jars
+   * @param extraDirectories additional directories to scan for plugin jars
+   * @param extraJars individual plugin jars to load
+   * @throws IOException if we could not open one of the directories
    */
-  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
-      justification = "I looked carefully and there's no way SpotBugs is right.")
-  public void loadPlugins(Path directory) throws IOException {
-    checkNotNull(directory, "directory");
-    checkArgument(directory.toFile().isDirectory(), "provided path isn't a directory");
-
+  public void loadPlugins(Path directory, List<Path> extraDirectories, List<Path> extraJars)
+      throws IOException {
     Map<String, PluginDescription> foundCandidates = new LinkedHashMap<>();
     JavaPluginLoader loader = new JavaPluginLoader(server, directory);
 
-    try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory,
-        p -> p.toFile().isFile() && p.toString().endsWith(".jar"))) {
-      for (Path path : stream) {
-        try {
-          PluginDescription candidate = loader.loadCandidate(path);
+    List<Path> candidates = new ArrayList<>();
+    collectPluginJars(directory, candidates);
+    for (Path extraDirectory : extraDirectories) {
+      collectPluginJars(extraDirectory, candidates);
+    }
+    candidates.addAll(extraJars);
 
-          // If we found a duplicate candidate (with the same ID), don't load it.
-          PluginDescription maybeExistingCandidate = foundCandidates.putIfAbsent(
-              candidate.getId(), candidate);
+    for (Path path : candidates) {
+      try {
+        PluginDescription candidate = loader.loadCandidate(path);
 
-          if (maybeExistingCandidate != null) {
-            logger.error("Refusing to load plugin at path {} since we already "
-                    + "loaded a plugin with the same ID {} from {}",
-                candidate.getSource().map(Objects::toString).orElse("<UNKNOWN>"),
-                candidate.getId(),
-                maybeExistingCandidate.getSource().map(Objects::toString).orElse("<UNKNOWN>"));
-          }
-        } catch (Throwable e) {
-          logger.error("Unable to load plugin {}", path, e);
+        // If we found a duplicate candidate (with the same ID), don't load it.
+        PluginDescription maybeExistingCandidate = foundCandidates.putIfAbsent(
+            candidate.getId(), candidate);
+
+        if (maybeExistingCandidate != null) {
+          logger.error("Refusing to load plugin at path {} since we already "
+                  + "loaded a plugin with the same ID {} from {}",
+              candidate.getSource().map(Objects::toString).orElse("<UNKNOWN>"),
+              candidate.getId(),
+              maybeExistingCandidate.getSource().map(Objects::toString).orElse("<UNKNOWN>"));
         }
+      } catch (Throwable e) {
+        logger.error("Unable to load plugin {}", path, e);
       }
     }
 
@@ -179,6 +182,17 @@ public class VelocityPluginManager implements PluginManager {
       logger.info("Loaded plugin {} {} by {}", description.getId(), description.getVersion()
           .orElse("<UNKNOWN>"), Joiner.on(", ").join(description.getAuthors()));
       registerPlugin(container);
+    }
+  }
+
+  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+      justification = "I looked carefully and there's no way SpotBugs is right.")
+  private static void collectPluginJars(Path directory, List<Path> candidates) throws IOException {
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory,
+        p -> p.toFile().isFile() && p.toString().endsWith(".jar"))) {
+      for (Path path : stream) {
+        candidates.add(path);
+      }
     }
   }
 


### PR DESCRIPTION
 Hi! This PR adds two cli options which allow loading additional plugin jars and directories in addition to the default plugins folder.
  
The data directory is intentionally kept fixed rather than tied to the plugin jar location. Paper takes the same approach, and since this option is likely to be used together with container volumes, which are often mounted readonly, keeping mutable data separate from the plugin binaries seems like the safer choice.
  
  https://github.com/PaperMC/Paper/blob/216388dfdf25b365e0d3ec24748def4dcaa30a76/paper-server/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java#L176
  
  For this reason, loadPlugins still keeps the directory argument so it can be used for the data directory.
  
  https://github.com/vjh0107/Velocity/blob/feat/cli-extra-plugins/proxy/src/main/java/com/velocitypowered/proxy/plugin/VelocityPluginManager.java#L91~L94