### PR TITLE
Bump netty from 4.2.10.Final to 4.2.15.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ configurate3 = "3.7.3"
 configurate4 = "4.2.0"
 flare = "2.0.1"
 log4j = "2.25.3"
-netty = "4.2.10.Final"
+netty = "4.2.14.Final"
 
 [plugins]
 fill = "io.papermc.fill.gradle:1.0.10"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ configurate3 = "3.7.3"
 configurate4 = "4.2.0"
 flare = "2.0.1"
 log4j = "2.25.3"
-netty = "4.2.14.Final"
+netty = "4.2.15.Final"
 
 [plugins]
 fill = "io.papermc.fill.gradle:1.0.10"


### PR DESCRIPTION
4.2.15.Final fixes 22 CVEs, one of which [affects haproxy](https://github.com/netty/netty/security/advisories/GHSA-h2qv-fj59-j46j).

4.2.13.Final fixes 13 CVEs, one of which [affects epoll](https://github.com/netty/netty/security/advisories/GHSA-rwm7-x88c-3g2p).

4.2.11.Final, 4.2.12.Final, and 4.2.14.Final are bug-fix releases. There are no major/breaking changes.

I have tested this change in production and did not encounter any issues.