### PR TITLE
Reduce default `read-timeout`

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -32,6 +32,7 @@ import com.velocitypowered.proxy.config.migration.KeyAuthenticationMigration;
 import com.velocitypowered.proxy.config.migration.MiniMessageTranslationsMigration;
 import com.velocitypowered.proxy.config.migration.MotdMigration;
 import com.velocitypowered.proxy.config.migration.PacketLimiterMigration;
+import com.velocitypowered.proxy.config.migration.ReadTimeoutMigration;
 import com.velocitypowered.proxy.config.migration.TransferIntegrationMigration;
 import com.velocitypowered.proxy.util.AddressUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -513,7 +514,8 @@ public class VelocityConfiguration implements ProxyConfig {
           new MotdMigration(),
           new MiniMessageTranslationsMigration(),
           new TransferIntegrationMigration(),
-          new PacketLimiterMigration()
+          new PacketLimiterMigration(),
+          new ReadTimeoutMigration()
       };
 
       for (final ConfigurationMigration migration : migrations) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -757,7 +757,7 @@ public class VelocityConfiguration implements ProxyConfig {
     @Expose
     private int connectionTimeout = 5000;
     @Expose
-    private int readTimeout = 30000;
+    private int readTimeout = 25000;
     @Expose
     private boolean proxyProtocol = false;
     @Expose
@@ -798,7 +798,7 @@ public class VelocityConfiguration implements ProxyConfig {
         this.compressionLevel = config.getIntOrElse("compression-level", -1);
         this.loginRatelimit = config.getIntOrElse("login-ratelimit", 3000);
         this.connectionTimeout = config.getIntOrElse("connection-timeout", 5000);
-        this.readTimeout = config.getIntOrElse("read-timeout", 30000);
+        this.readTimeout = config.getIntOrElse("read-timeout", 25000);
         if (config.contains("haproxy-protocol")) {
           this.proxyProtocol = config.getOrElse("haproxy-protocol", false);
         } else {

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/migration/ConfigurationMigration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/migration/ConfigurationMigration.java
@@ -30,7 +30,8 @@ public sealed interface ConfigurationMigration
                 MotdMigration,
                 MiniMessageTranslationsMigration,
                 TransferIntegrationMigration,
-                PacketLimiterMigration {
+                PacketLimiterMigration,
+                ReadTimeoutMigration {
   boolean shouldMigrate(CommentedFileConfig config);
 
   void migrate(CommentedFileConfig config, Logger logger) throws IOException;

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/migration/ReadTimeoutMigration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/migration/ReadTimeoutMigration.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018-2026 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.config.migration;
+
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * The old default value of 30 seconds was causing the client to time-out on itself,
+ * fully disconnecting itself from the proxy instead of Velocity handling a graceful
+ * transfer/disconnect.
+ *
+ * <p>See <a href="https://github.com/PaperMC/Velocity/issues/1819">PaperMC/Velocity#1819</a>.
+ */
+public final class ReadTimeoutMigration implements ConfigurationMigration {
+
+  private static final int PREVIOUS_DEFAULT_VALUE = 30_000;
+  private static final int NEW_DEFAULT_VALUE      = 25_000;
+
+  @Override
+  public boolean shouldMigrate(CommentedFileConfig config) {
+    return configVersion(config) < 2.9;
+  }
+
+  @Override
+  public void migrate(CommentedFileConfig config, Logger logger) {
+    Integer current = config.get("advanced.read-timeout");
+    if (current != null && current == PREVIOUS_DEFAULT_VALUE) {
+      // Only override value if it hasn't been changed.
+      config.set("advanced.read-timeout", NEW_DEFAULT_VALUE);
+    }
+
+    config.setComment("advanced.read-timeout",
+        " Specify a read timeout for connections here. The default is 25 seconds.");
+
+    config.set("config-version", "2.9");
+  }
+}

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -127,8 +127,8 @@ login-ratelimit = 3000
 # Specify a custom timeout for connection timeouts here. The default is five seconds.
 connection-timeout = 5000
 
-# Specify a read timeout for connections here. The default is 30 seconds.
-read-timeout = 30000
+# Specify a read timeout for connections here. The default is 25 seconds.
+read-timeout = 25000
 
 # Enables compatibility with HAProxy's PROXY protocol. If you don't know what this is for, then
 # don't enable it.

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -1,5 +1,5 @@
 # Config version. Do not change this
-config-version = "2.8"
+config-version = "2.9"
 
 # What port should the proxy be bound to? By default, we'll bind to all addresses on port 25565.
 bind = "0.0.0.0:25565"


### PR DESCRIPTION
Fixes #1819

Reduces the default `read-timeout` to 25 seconds, avoiding the client disconnecting itself (tested & verified), and adds a config migration for an unchanged old value.