### PR TITLE
Fix fallback chain skipped when initial server stalls after accepting connection

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -69,6 +69,7 @@ import com.velocitypowered.proxy.connection.player.resourcepack.handler.Resource
 import com.velocitypowered.proxy.connection.util.ConnectionMessages;
 import com.velocitypowered.proxy.connection.util.ConnectionRequestResults.Impl;
 import com.velocitypowered.proxy.connection.util.VelocityInboundConnection;
+import com.velocitypowered.proxy.network.Connections;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.netty.MinecraftEncoder;
 import com.velocitypowered.proxy.protocol.packet.BundleDelimiterPacket;
@@ -105,6 +106,7 @@ import com.velocitypowered.proxy.util.TranslatableMapper;
 import com.velocitypowered.proxy.util.collect.CappedSet;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.handler.timeout.ReadTimeoutHandler;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
@@ -931,6 +933,12 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     if (serverConnection == connectionInFlight) {
       connectionInFlight = null;
     }
+
+    if (serverConnection != null) {
+      // The player has reached a server; restore the read-timeout that was suspended while we
+      // were establishing their initial connection (see pauseReadTimeout / issue GemstoneGG#938).
+      resumeReadTimeout();
+    }
   }
 
   public void sendLegacyForgeHandshakeResetPacket() {
@@ -1439,6 +1447,33 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     return bossBarManager;
   }
 
+  /**
+   * Suspends the read-timeout on the player's own (client-facing) connection while we establish
+   * their initial connection. The client legitimately idles on the loading screen during that
+   * window, so its read-timeout must not fire -- otherwise a backend that stalls after accepting
+   * the TCP connection times the idle client out before the backend connection's own timeout can
+   * drive the fallback chain, dropping the player instead of moving them on. Restored by
+   * {@link #resumeReadTimeout()} once a server is reached (issue GemstoneGG#938).
+   */
+  private void pauseReadTimeout() {
+    final var pipeline = connection.getChannel().pipeline();
+    if (pipeline.context(Connections.READ_TIMEOUT) != null) {
+      pipeline.remove(Connections.READ_TIMEOUT);
+    }
+  }
+
+  /**
+   * Restores the read-timeout on the player's own connection after it was suspended by
+   * {@link #pauseReadTimeout()}. Idempotent: does nothing if the handler is already present.
+   */
+  private void resumeReadTimeout() {
+    final var pipeline = connection.getChannel().pipeline();
+    if (pipeline.context(Connections.READ_TIMEOUT) == null && pipeline.context(Connections.FRAME_DECODER) != null) {
+      pipeline.addAfter(Connections.FRAME_DECODER, Connections.READ_TIMEOUT, new ReadTimeoutHandler(
+          server.getConfiguration().getReadTimeout(), TimeUnit.MILLISECONDS));
+    }
+  }
+
   private final class ConnectionRequestBuilderImpl implements ConnectionRequestBuilder {
 
     private final RegisteredServer toConnect;
@@ -1498,6 +1533,14 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
           VelocityServerConnection con =
               new VelocityServerConnection(vrs, previousServer, ConnectedPlayer.this, server);
           connectionInFlight = con;
+
+          if (connectedServer == null) {
+            // Establishing the player's initial connection (or working through the fallback chain
+            // for it): they have no backend yet and are idling on a loading screen. Suspend their
+            // connection's read-timeout so a stalled backend can't time the idle client out before
+            // the backend timeout drives the fallback. Restored in setConnectedServer (issue GemstoneGG#938).
+            pauseReadTimeout();
+          }
 
           return con.connect().whenCompleteAsync((result, exception) -> {
             if (result != null && !result.isSuccessful() && !result.isSafe()) {


### PR DESCRIPTION
When a player joins via a forced host whose first backend **accepts the TCP connection but then never completes login** (e.g. a firewall/anti-DDoS front that answers pings but black-holes logins), they get disconnected with "An internal error occurred in your connection" instead of being moved to the next server in the fallback chain. This issue surfaced on an issue on Velocity-CTD: GemstoneGG#938. I was able to recreate this failure state (simulating a "firewall" that answers pings but black-holes logins) with a Python script that does precisely this.

While the player idles in config waiting for the backend, two `ReadTimeoutHandler`s with the same duration race:

- **backend** connection timeout -> drives the fallback chain (correct)
- **player** connection timeout -> hard-disconnects (wrong)

The player-side handler is created first, so it fires first and wins -> disconnect instead of failover.

This is also why just lowering `read-timeout` didn't help (see referenced issue's chain): it shortens both equally, keeping the race tied (though this is an actual issue, see #1819 and #1820). Both this PR and reducing `read-timeout` is needed to fix this problem properly; without reducing the read timeout, the client would just disconnect itself after 30 seconds, still not allowing Velocity to properly handle the exception (by, after this PR, failing over to the next server in the fallback chain).

**Fix**

Suspend the player connection's read-timeout while establishing the initial connection (and through the fallback chain), restore it once a server is reached. The client can no longer time itself out during limbo, so the backend timeout fires and drives the existing fallback chain. As a bonus, `read-timeout` tuning now actually controls failover speed.