### PR TITLE
Add missing `package-info.java`s for event packages

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/command/package-info.java
+++ b/api/src/main/java/com/velocitypowered/api/event/command/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+/**
+ * Provides events for handling command execution.
+ */
+package com.velocitypowered.api.event.command;

--- a/api/src/main/java/com/velocitypowered/api/event/player/configuration/package-info.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/configuration/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+/**
+ * Provides events for handling the player configuration phase.
+ */
+package com.velocitypowered.api.event.player.configuration;

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/package-info.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2018 Velocity Contributors
+ *
+ * The Velocity API is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+/**
+ * Provides events for handling registration of servers on the proxy.
+ */
+package com.velocitypowered.api.event.proxy.server;


### PR DESCRIPTION
All 5 other subpackages of `com.velocitypowered.api.event` have the `package-info.java` file with very similar wording. This PR cleans this up by adding this to the remaining 3 subpackages.

(I'd recommend to merge with `[ci skip]`)