### PR TITLE
Require non-null `reason`

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -197,7 +197,7 @@ public interface Player extends
    *
    * @param reason component with the reason
    */
-  void disconnect(Component reason);
+  void disconnect(@NotNull Component reason);
 
   /**
    * Sends chat input onto the players current server as if they typed it into the client chat box.

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -111,6 +111,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -645,7 +646,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   }
 
   @Override
-  public void disconnect(Component reason) {
+  public void disconnect(@NotNull Component reason) {
+    Objects.requireNonNull(reason, "reason");
     if (connection.eventLoop().inEventLoop()) {
       disconnect0(reason, false);
     } else {


### PR DESCRIPTION
A plugin providing a `null` `reason` to `Player#disconnect` will get a vague `NullPointerException` pointing towards Velocity's/Adventure's internals, even though the problem is a proxy plugin providing a null reason.

This PR makes this non-null contract explicit and throws with a clear NPE.

Exception:
```
[07:17:53 INFO]: [connected player] xDevanger (/REDACTED): kicked from server lobby: ᴍᴄꜰᴜɴɴʏ.ᴘʟ » Serwer ʟᴏʙʙʏ jest w trakcie restartu...
[07:17:53 INFO]: [server connection] xDevanger -> lobby has disconnected
[07:17:53 WARN] [io.netty.util.concurrent.AbstractEventExecutor]: A task raised an exception. Task: com.velocitypowered.proxy.connection.client.ConnectedPlayer$$Lambda/0x0000000069e10a30@61031780
java.lang.NullPointerException: like
        at java.base/java.util.Objects.requireNonNull(Objects.java:246) ~[?:?]
        at net.kyori.adventure.text.Component.append(Component.java:2112) ~[velocity-ctd-fatjar-3.5.0-SNAPSHOT-301.jar:3.5.0-SNAPSHOT-git-2878e6c7-b301]
        at net.kyori.adventure.text.ScopedComponent.append(ScopedComponent.java:99) ~[velocity-ctd-fatjar-3.5.0-SNAPSHOT-301.jar:3.5.0-SNAPSHOT-git-2878e6c7-b301]
        at net.kyori.adventure.text.Component.append(Component.java:2101) ~[velocity-ctd-fatjar-3.5.0-SNAPSHOT-301.jar:3.5.0-SNAPSHOT-git-2878e6c7-b301]
        at net.kyori.adventure.text.ScopedComponent.append(ScopedComponent.java:93) ~[velocity-ctd-fatjar-3.5.0-SNAPSHOT-301.jar:3.5.0-SNAPSHOT-git-2878e6c7-b301]
        at com.velocitypowered.proxy.connection.client.ConnectedPlayer.disconnect0(ConnectedPlayer.java:890) ~[velocity-ctd-fatjar-3.5.0-SNAPSHOT-301.jar:3.5.0-SNAPSHOT-git-2878e6c7-b301]
        at com.velocitypowered.proxy.connection.client.ConnectedPlayer.lambda$disconnect$3(ConnectedPlayer.java:872) ~[velocity-ctd-fatjar-3.5.0-SNAPSHOT-301.jar:3.5.0-SNAPSHOT-git-2878e6c7-b301]
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:148) ~[velocity-ctd-fatjar-3.5.0-SNAPSHOT-301.jar:3.5.0-SNAPSHOT-git-2878e6c7-b301]
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:141) ~[velocity-ctd-fatjar-3.5.0-SNAPSHOT-301.jar:3.5.0-SNAPSHOT-git-2878e6c7-b301]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:535) ~[velocity-ctd-fatjar-3.5.0-SNAPSHOT-301.jar:3.5.0-SNAPSHOT-git-2878e6c7-b301]
        at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:201) ~[velocity-ctd-fatjar-3.5.0-SNAPSHOT-301.jar:3.5.0-SNAPSHOT-git-2878e6c7-b301]
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195) ~[velocity-ctd-fatjar-3.5.0-SNAPSHOT-301.jar:3.5.0-SNAPSHOT-git-2878e6c7-b301]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[velocity-ctd-fatjar-3.5.0-SNAPSHOT-301.jar:3.5.0-SNAPSHOT-git-2878e6c7-b301]
        at com.velocitypowered.proxy.util.concurrent.VelocityNettyThreadFactory$1.run(VelocityNettyThreadFactory.java:46) ~[velocity-ctd-fatjar-3.5.0-SNAPSHOT-301.jar:3.5.0-SNAPSHOT-git-2878e6c7-b301]
[07:17:53 INFO]: [server connection] xDevanger -> limbo has connected
```