### PR TITLE
Enforce blank line after type declaration

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/Command.java
+++ b/api/src/main/java/com/velocitypowered/api/command/Command.java
@@ -30,4 +30,5 @@ import com.velocitypowered.api.proxy.Player;
  * </ul>
  */
 public sealed interface Command permits BrigadierCommand, InvocableCommand {
+
 }

--- a/api/src/main/java/com/velocitypowered/api/command/CommandResult.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandResult.java
@@ -11,6 +11,7 @@ package com.velocitypowered.api.command;
  * The result of a command invocation attempt.
  */
 public enum CommandResult {
+
   /**
    * The command was successfully executed by the proxy.
    */

--- a/api/src/main/java/com/velocitypowered/api/event/command/CommandExecuteEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/command/CommandExecuteEvent.java
@@ -109,6 +109,7 @@ public final class CommandExecuteEvent implements ResultedEvent<CommandResult> {
    * @since 3.4.0
    */
   public record InvocationInfo(SignedState signedState, Source source) {
+
   }
 
   /**
@@ -117,6 +118,7 @@ public final class CommandExecuteEvent implements ResultedEvent<CommandResult> {
    * @since 3.4.0
    */
   public enum SignedState {
+
     /**
      * Indicates that the command was executed from a signed source with signed message arguments,
      * This is currently only possible by typing a command in chat with signed arguments.
@@ -158,6 +160,7 @@ public final class CommandExecuteEvent implements ResultedEvent<CommandResult> {
    * @since 3.4.0
    */
   public enum Source {
+
     /**
      * Indicates that the command was invoked by a player.
      *

--- a/api/src/main/java/com/velocitypowered/api/event/connection/PreLoginEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/connection/PreLoginEvent.java
@@ -193,6 +193,7 @@ public final class PreLoginEvent implements ResultedEvent<PreLoginEvent.PreLogin
     }
 
     private enum Result {
+
       ALLOWED,
       FORCE_ONLINE,
       FORCE_OFFLINE,

--- a/api/src/main/java/com/velocitypowered/api/event/connection/PreTransferEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/connection/PreTransferEvent.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 @AwaitingEvent
 @ApiStatus.Experimental
 public final class PreTransferEvent implements ResultedEvent<PreTransferEvent.TransferResult> {
+
   private final InetSocketAddress originalAddress;
   private final Player player;
   private TransferResult result = TransferResult.ALLOWED;
@@ -56,6 +57,7 @@ public final class PreTransferEvent implements ResultedEvent<PreTransferEvent.Tr
    * Transfer Result of a player to another host.
    */
   public static class TransferResult implements ResultedEvent.Result {
+
     private static final TransferResult ALLOWED = new TransferResult(true, null);
     private static final TransferResult DENIED = new TransferResult(false, null);
 

--- a/api/src/main/java/com/velocitypowered/api/event/player/PlayerClientBrandEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/PlayerClientBrandEvent.java
@@ -15,6 +15,7 @@ import com.velocitypowered.api.proxy.Player;
  * not wait on the result of this event.
  */
 public final class PlayerClientBrandEvent {
+
   private final Player player;
   private final String brand;
 

--- a/api/src/main/java/com/velocitypowered/api/event/player/PlayerResourcePackStatusEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/PlayerResourcePackStatusEvent.java
@@ -141,6 +141,7 @@ public class PlayerResourcePackStatusEvent {
    * Represents the possible statuses for the resource pack.
    */
   public enum Status {
+
     /**
      * The resource pack was applied successfully.
      */

--- a/api/src/main/java/com/velocitypowered/api/event/player/ServerLoginPluginMessageEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/ServerLoginPluginMessageEvent.java
@@ -29,6 +29,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 @AwaitingEvent
 public class ServerLoginPluginMessageEvent implements ResultedEvent<ResponseResult> {
+
   private final ServerConnection connection;
   private final ChannelIdentifier identifier;
   private final byte[] contents;

--- a/api/src/main/java/com/velocitypowered/api/event/player/ServerPostConnectEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/ServerPostConnectEvent.java
@@ -18,6 +18,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * firing.
  */
 public class ServerPostConnectEvent {
+
   private final Player player;
   private final RegisteredServer previousServer;
 

--- a/api/src/main/java/com/velocitypowered/api/event/player/ServerResourcePackSendEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/ServerResourcePackSendEvent.java
@@ -21,6 +21,7 @@ import com.velocitypowered.api.proxy.player.ResourcePackInfo;
  */
 @AwaitingEvent
 public class ServerResourcePackSendEvent implements ResultedEvent<ResultedEvent.GenericResult> {
+
   private GenericResult result;
   private final ResourcePackInfo receivedResourcePack;
   private ResourcePackInfo providedResourcePack;

--- a/api/src/main/java/com/velocitypowered/api/event/player/TabCompleteEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/TabCompleteEvent.java
@@ -23,6 +23,7 @@ import java.util.List;
  */
 @AwaitingEvent
 public class TabCompleteEvent {
+
   private final Player player;
   private final String partialMessage;
   private final List<String> suggestions;

--- a/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerConfigurationEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerConfigurationEvent.java
@@ -23,4 +23,5 @@ import org.jetbrains.annotations.NotNull;
  */
 @AwaitingEvent
 public record PlayerConfigurationEvent(@NotNull Player player, ServerConnection server) {
+
 }

--- a/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerEnterConfigurationEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerEnterConfigurationEvent.java
@@ -26,4 +26,5 @@ import org.jetbrains.annotations.NotNull;
  */
 @AwaitingEvent
 public record PlayerEnterConfigurationEvent(@NotNull Player player, ServerConnection server) {
+
 }

--- a/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerEnteredConfigurationEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerEnteredConfigurationEvent.java
@@ -24,4 +24,5 @@ import org.jetbrains.annotations.NotNull;
  * @sinceMinecraft 1.20.2
  */
 public record PlayerEnteredConfigurationEvent(@NotNull Player player, ServerConnection server) {
+
 }

--- a/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerFinishConfigurationEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerFinishConfigurationEvent.java
@@ -26,4 +26,5 @@ import org.jetbrains.annotations.NotNull;
  */
 @AwaitingEvent
 public record PlayerFinishConfigurationEvent(@NotNull Player player, @NotNull ServerConnection server) {
+
 }

--- a/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerFinishedConfigurationEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/player/configuration/PlayerFinishedConfigurationEvent.java
@@ -23,4 +23,5 @@ import org.jetbrains.annotations.NotNull;
  * @sinceMinecraft 1.20.2
  */
 public record PlayerFinishedConfigurationEvent(@NotNull Player player, @NotNull ServerConnection server) {
+
 }

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerRegisteredEvent.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
  * @since 3.3.0
  */
 public record ServerRegisteredEvent(@NotNull RegisteredServer registeredServer) {
+
   public ServerRegisteredEvent {
     Preconditions.checkNotNull(registeredServer, "registeredServer");
   }

--- a/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/proxy/server/ServerUnregisteredEvent.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
  * @since 3.3.0
  */
 public record ServerUnregisteredEvent(@NotNull RegisteredServer unregisteredServer) {
+
   public ServerUnregisteredEvent {
     Preconditions.checkNotNull(unregisteredServer, "unregisteredServer");
   }

--- a/api/src/main/java/com/velocitypowered/api/event/query/ProxyQueryEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/query/ProxyQueryEvent.java
@@ -85,6 +85,7 @@ public final class ProxyQueryEvent {
    * Represents the type of query the client is asking for.
    */
   public enum QueryType {
+
     /**
      * Basic query asks only a subset of information, such as hostname, game type (hardcoded to
      * <pre>MINECRAFT</pre>), map, current players, max players, proxy port and proxy hostname.

--- a/api/src/main/java/com/velocitypowered/api/network/HandshakeIntent.java
+++ b/api/src/main/java/com/velocitypowered/api/network/HandshakeIntent.java
@@ -11,6 +11,7 @@ package com.velocitypowered.api.network;
  * Represents the ClientIntent of a client in the Handshake state.
  */
 public enum HandshakeIntent {
+
   STATUS(1),
   LOGIN(2),
   TRANSFER(3);

--- a/api/src/main/java/com/velocitypowered/api/network/ListenerType.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ListenerType.java
@@ -11,6 +11,7 @@ package com.velocitypowered.api.network;
  * Represents each listener type.
  */
 public enum ListenerType {
+
   MINECRAFT("Minecraft"),
   QUERY("Query");
 

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolState.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolState.java
@@ -14,6 +14,7 @@ package com.velocitypowered.api.network;
  * @since 3.3.0
  */
 public enum ProtocolState {
+
   /**
    * Initial connection State.
    * <p>This status can be caused by a {@link HandshakeIntent#STATUS},

--- a/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
+++ b/api/src/main/java/com/velocitypowered/api/network/ProtocolVersion.java
@@ -21,6 +21,7 @@ import java.util.Set;
  * Represents each Minecraft protocol version.
  */
 public enum ProtocolVersion implements Ordered<ProtocolVersion> {
+
   UNKNOWN(-1, "Unknown") {
     @Override
     public boolean isUnknown() {

--- a/api/src/main/java/com/velocitypowered/api/proxy/ConnectionRequestBuilder.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/ConnectionRequestBuilder.java
@@ -88,6 +88,7 @@ public interface ConnectionRequestBuilder {
    * Represents the status of a connection request initiated by a {@link ConnectionRequestBuilder}.
    */
   enum Status {
+
     /**
      * The player was successfully connected to the server.
      */

--- a/api/src/main/java/com/velocitypowered/api/proxy/ConsoleCommandSource.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/ConsoleCommandSource.java
@@ -13,4 +13,5 @@ import com.velocitypowered.api.command.CommandSource;
  * Indicates that the executor of the command is the console.
  */
 public interface ConsoleCommandSource extends CommandSource {
+
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/crypto/IdentifiedKey.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/crypto/IdentifiedKey.java
@@ -59,6 +59,7 @@ public interface IdentifiedKey extends KeySigned {
    * The different versions of player keys, per Minecraft version.
    */
   enum Revision implements Ordered<Revision> {
+
     GENERIC_V1(ImmutableSet.of(), ImmutableSet.of(ProtocolVersion.MINECRAFT_1_19)),
     LINKED_V2(ImmutableSet.of(), ImmutableSet.of(ProtocolVersion.MINECRAFT_1_19_1));
 

--- a/api/src/main/java/com/velocitypowered/api/proxy/player/ChatSession.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/ChatSession.java
@@ -14,6 +14,7 @@ import java.util.UUID;
  * Represents a chat session held by a player.
  */
 public interface ChatSession extends KeyIdentifiable {
+
   /**
    * Returns the {@link UUID} of the session.
    *

--- a/api/src/main/java/com/velocitypowered/api/proxy/player/PlayerSettings.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/PlayerSettings.java
@@ -86,6 +86,7 @@ public interface PlayerSettings {
    * The client's current chat display mode.
    */
   enum ChatMode {
+
     SHOWN,
     COMMANDS_ONLY,
     HIDDEN
@@ -95,6 +96,7 @@ public interface PlayerSettings {
    * The player's selected dominant hand.
    */
   enum MainHand {
+
     LEFT,
     RIGHT
   }
@@ -103,6 +105,7 @@ public interface PlayerSettings {
    * The client's current "Particles" option state.
    */
   enum ParticleStatus {
+
     ALL,
     DECREASED,
     MINIMAL

--- a/api/src/main/java/com/velocitypowered/api/proxy/player/ResourcePackInfo.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/ResourcePackInfo.java
@@ -165,6 +165,7 @@ public interface ResourcePackInfo extends ResourcePackRequestLike {
    * Represents the origin of the resource-pack.
    */
   enum Origin {
+
     /**
      * Resource-pack originated from the downstream server.
      */

--- a/api/src/main/java/com/velocitypowered/api/proxy/player/TabListEntry.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/TabListEntry.java
@@ -18,6 +18,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Represents a single entry in a {@link TabList}.
  */
 public interface TabListEntry extends KeyIdentifiable {
+
   /**
    * Returns the {@link ChatSession} associated with this entry.
    *

--- a/api/src/main/java/com/velocitypowered/api/proxy/server/PingOptions.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/server/PingOptions.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
  * @see RegisteredServer#ping(PingOptions)
  */
 public final class PingOptions {
+
   /**
    * Default PingOptions.
    */
@@ -107,6 +108,7 @@ public final class PingOptions {
    * @since 3.2.0
    */
   public static final class Builder implements AbstractBuilder<PingOptions> {
+
     private ProtocolVersion protocolVersion = ProtocolVersion.UNKNOWN;
     private long timeout = 0;
     private String virtualHost = null;

--- a/api/src/main/java/com/velocitypowered/api/proxy/server/QueryResponse.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/server/QueryResponse.java
@@ -227,6 +227,7 @@ public final class QueryResponse {
    * A builder for {@link QueryResponse} objects.
    */
   public static final class Builder {
+
     private @MonotonicNonNull String hostname;
     private @MonotonicNonNull String gameVersion;
     private @MonotonicNonNull String map;

--- a/api/src/main/java/com/velocitypowered/api/scheduler/TaskStatus.java
+++ b/api/src/main/java/com/velocitypowered/api/scheduler/TaskStatus.java
@@ -11,6 +11,7 @@ package com.velocitypowered.api.scheduler;
  * Enumerates all possible task statuses.
  */
 public enum TaskStatus {
+
   /**
    * The task is scheduled and is currently running.
    */

--- a/api/src/main/java/com/velocitypowered/api/util/MessagePosition.java
+++ b/api/src/main/java/com/velocitypowered/api/util/MessagePosition.java
@@ -11,6 +11,7 @@ package com.velocitypowered.api.util;
  * Represents where a chat message is going to be sent.
  */
 public enum MessagePosition {
+
   /**
    * The chat message will appear in the client's HUD. These messages can be filtered out by the
    * client.

--- a/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
+++ b/api/src/main/java/com/velocitypowered/api/util/ServerLink.java
@@ -86,6 +86,7 @@ public final class ServerLink {
    * @apiNote {@link Type#BUG_REPORT} links are shown on the connection error screen
    */
   public enum Type {
+
     BUG_REPORT,
     COMMUNITY_GUIDELINES,
     SUPPORT,

--- a/build-logic/src/main/kotlin/BlankLineAfterTypeHeaderStep.kt
+++ b/build-logic/src/main/kotlin/BlankLineAfterTypeHeaderStep.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import com.diffplug.spotless.FormatterFunc
+import java.io.Serializable
+
+/**
+ * Spotless step that forces a single blank line after every type declaration's opening brace,
+ * e.g. after `class Foo {`, `interface Bar {`, `enum Baz {` or `record Qux(...) {`.
+ *
+ * Implemented as a named class (rather than a `custom { ... }` lambda) because [FormatterFunc]
+ * extends [Serializable], and Kotlin SAM-conversion lambdas are not serializable — which breaks
+ * Gradle's configuration cache when Spotless fingerprints its step list.
+ */
+class BlankLineAfterTypeHeaderStep : FormatterFunc, Serializable {
+
+    override fun apply(input: String): String =
+        REGEX.replace(input) { match -> match.groupValues[1] + "\n\n" }
+
+    companion object {
+
+        private const val serialVersionUID = 1L
+
+        // Anchors on a line starting with optional modifiers + a type keyword, lets the header
+        // span multiple lines up to its opening brace, then matches only when the following line
+        // is not already blank.
+        private val REGEX = Regex(
+            """(?m)^([ \t]*(?:(?:public|protected|private|abstract|final|sealed|non-sealed|static|strictfp)[ \t]+)*""" +
+                """(?:class|interface|enum|record|@interface)\b[^{]*\{)[ \t]*\r?\n(?![ \t]*\r?\n)""",
+        )
+    }
+}

--- a/build-logic/src/main/kotlin/velocity-spotless.gradle.kts
+++ b/build-logic/src/main/kotlin/velocity-spotless.gradle.kts
@@ -12,5 +12,9 @@ extensions.configure<SpotlessExtension> {
             licenseHeaderFile(rootProject.file("HEADER.txt"))
         }
         removeUnusedImports()
+
+        // Force a single blank line after every type declaration's opening brace,
+        // e.g. after `class Foo {`, `interface Bar {`, `enum Baz {`, `record Qux(...) {`.
+        custom("blankLineAfterTypeHeader", BlankLineAfterTypeHeaderStep())
     }
 }

--- a/native/src/main/java/com/velocitypowered/natives/Native.java
+++ b/native/src/main/java/com/velocitypowered/natives/Native.java
@@ -23,5 +23,6 @@ import com.velocitypowered.natives.util.BufferPreference;
  * Generic interface for any Velocity native.
  */
 public interface Native {
+
   BufferPreference preferredBufferType();
 }

--- a/native/src/main/java/com/velocitypowered/natives/compression/CompressorUtils.java
+++ b/native/src/main/java/com/velocitypowered/natives/compression/CompressorUtils.java
@@ -18,6 +18,7 @@
 package com.velocitypowered.natives.compression;
 
 class CompressorUtils {
+
   /**
    * The default preferred output buffer size for zlib.
    */

--- a/native/src/main/java/com/velocitypowered/natives/compression/VelocityCompressor.java
+++ b/native/src/main/java/com/velocitypowered/natives/compression/VelocityCompressor.java
@@ -27,6 +27,7 @@ import java.util.zip.DataFormatException;
  * implementation.
  */
 public interface VelocityCompressor extends Disposable, Native {
+
   void inflate(ByteBuf source, ByteBuf destination, int uncompressedSize)
       throws DataFormatException;
 

--- a/native/src/main/java/com/velocitypowered/natives/util/BufferPreference.java
+++ b/native/src/main/java/com/velocitypowered/natives/util/BufferPreference.java
@@ -21,6 +21,7 @@ package com.velocitypowered.natives.util;
  * Emumerates Netty buffer preferences and requirements for use with Netty.
  */
 public enum BufferPreference {
+
   /**
    * A heap buffer is required.
    */

--- a/native/src/main/java/com/velocitypowered/natives/util/MoreByteBufUtils.java
+++ b/native/src/main/java/com/velocitypowered/natives/util/MoreByteBufUtils.java
@@ -25,6 +25,7 @@ import io.netty.buffer.ByteBufAllocator;
  * Additional utilities for {@link ByteBuf}.
  */
 public class MoreByteBufUtils {
+
   private MoreByteBufUtils() {
     throw new AssertionError();
   }

--- a/native/src/main/java/com/velocitypowered/natives/util/NativeCodeLoader.java
+++ b/native/src/main/java/com/velocitypowered/natives/util/NativeCodeLoader.java
@@ -97,6 +97,7 @@ public final class NativeCodeLoader<T> implements Supplier<T> {
   }
 
   private enum Status {
+
     NOT_AVAILABLE,
     POSSIBLY_AVAILABLE,
     SETUP,

--- a/native/src/main/java/com/velocitypowered/natives/util/NativeConstraints.java
+++ b/native/src/main/java/com/velocitypowered/natives/util/NativeConstraints.java
@@ -26,6 +26,7 @@ import java.util.function.BooleanSupplier;
  * Statically-computed constraints for native code.
  */
 public class NativeConstraints {
+
   private static final boolean NATIVES_ENABLED = !Boolean.getBoolean("velocity.natives-disabled");
   private static final boolean IS_AMD64;
   private static final boolean IS_AARCH64;

--- a/proxy/src/main/java/com/velocitypowered/proxy/adventure/BossBarImplementationProvider.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/adventure/BossBarImplementationProvider.java
@@ -24,6 +24,7 @@ import net.kyori.adventure.bossbar.BossBarImplementation;
 @AutoService(BossBarImplementation.Provider.class)
 @SuppressWarnings("MissingJavadocType")
 public class BossBarImplementationProvider implements BossBarImplementation.Provider {
+
   @Override
   public BossBarImplementation create(final BossBar bar) {
     final VelocityBossBarImplementation impl = new VelocityBossBarImplementation(bar);

--- a/proxy/src/main/java/com/velocitypowered/proxy/adventure/ClickCallbackManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/adventure/ClickCallbackManager.java
@@ -31,6 +31,7 @@ import org.checkerframework.checker.index.qual.NonNegative;
  * Click callback manager.
  */
 public class ClickCallbackManager {
+
   public static final ClickCallbackManager INSTANCE = new ClickCallbackManager();
 
   static final String COMMAND = "/velocity:callback ";

--- a/proxy/src/main/java/com/velocitypowered/proxy/adventure/ClickCallbackProviderImpl.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/adventure/ClickCallbackProviderImpl.java
@@ -29,6 +29,7 @@ import net.kyori.adventure.text.event.ClickEvent;
 @AutoService(ClickCallback.Provider.class)
 @SuppressWarnings("UnstableApiUsage") // permitted provider
 public class ClickCallbackProviderImpl implements ClickCallback.Provider {
+
   @Override
   public  ClickEvent create(
       final ClickCallback<Audience> callback,

--- a/proxy/src/main/java/com/velocitypowered/proxy/adventure/ComponentLoggerProviderImpl.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/adventure/ComponentLoggerProviderImpl.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 @AutoService(ComponentLoggerProvider.class)
 @SuppressWarnings("UnstableApiUsage")
 public final class ComponentLoggerProviderImpl implements ComponentLoggerProvider {
+
   private static final ANSIComponentSerializer SERIALIZER = ANSIComponentSerializer.builder()
           .flattener(TranslatableMapper.FLATTENER)
           .build();

--- a/proxy/src/main/java/com/velocitypowered/proxy/adventure/RegisteredCallback.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/adventure/RegisteredCallback.java
@@ -30,6 +30,7 @@ record RegisteredCallback(
     @Nullable AtomicInteger remainingUses,
     ClickCallback<Audience> callback
 ) {
+
   RegisteredCallback(
       final Duration duration,
       final int maxUses,

--- a/proxy/src/main/java/com/velocitypowered/proxy/adventure/VelocityBossBarImplementation.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/adventure/VelocityBossBarImplementation.java
@@ -34,6 +34,7 @@ import net.kyori.adventure.text.Component;
 @SuppressWarnings("MissingJavadocMethod")
 public final class VelocityBossBarImplementation implements BossBar.Listener,
     BossBarImplementation {
+
   private final Set<ConnectedPlayer> viewers = Collections.newSetFromMap(
       new MapMaker().weakKeys().makeMap());
   private final UUID id = UUID.randomUUID();

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/SendCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/SendCommand.java
@@ -41,6 +41,7 @@ import net.kyori.adventure.text.minimessage.translation.Argument;
  * Implements the Velocity default {@code /send} command.
  */
 public class SendCommand {
+
   private final ProxyServer server;
   private static final String SERVER_ARG = "server";
   private static final String PLAYER_ARG = "player";

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/ServerCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/ServerCommand.java
@@ -43,6 +43,7 @@ import net.kyori.adventure.text.minimessage.translation.Argument;
  * Implements Velocity's {@code /server} command.
  */
 public final class ServerCommand {
+
   private static final String SERVER_ARG = "server";
   public static final int MAX_SERVERS_TO_LIST = 50;
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/VelocityCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/VelocityCommand.java
@@ -70,6 +70,7 @@ import org.apache.logging.log4j.Logger;
  * Implements the {@code /velocity} command and friends.
  */
 public final class VelocityCommand {
+
   private static final String USAGE = "/velocity <%s>";
 
   @SuppressWarnings("checkstyle:MissingJavadocMethod")
@@ -267,6 +268,7 @@ public final class VelocityCommand {
   }
 
   private record Dump(ProxyServer server) implements Command<CommandSource> {
+
     private static final Logger logger = LogManager.getLogger(Dump.class);
 
 
@@ -326,6 +328,7 @@ public final class VelocityCommand {
    * Heap SubCommand.
    */
   public static final class Heap implements Command<CommandSource> {
+
     private static final Logger logger = LogManager.getLogger(Heap.class);
     private MethodHandle heapGenerator;
     private Consumer<CommandSource> heapConsumer;

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/PingPassthroughMode.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/PingPassthroughMode.java
@@ -21,6 +21,7 @@ package com.velocitypowered.proxy.config;
  * Supported passthrough modes for ping passthrough.
  */
 public enum PingPassthroughMode {
+
   DISABLED,
   MODS,
   DESCRIPTION,

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/PlayerInfoForwarding.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/PlayerInfoForwarding.java
@@ -21,6 +21,7 @@ package com.velocitypowered.proxy.config;
  * Supported player info forwarding methods.
  */
 public enum PlayerInfoForwarding {
+
   NONE,
   LEGACY,
   BUNGEEGUARD,

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -1012,6 +1012,7 @@ public class VelocityConfiguration implements ProxyConfig {
    * @param bytesAfterDecompression the maximum number of decompressed bytes per second allowed
    */
   public record PacketLimiterConfig(int interval, int pps, int bytes, int bytesAfterDecompression) {
+
     public static PacketLimiterConfig DEFAULT = new PacketLimiterConfig(7, -1, -1, 5242880);
 
     /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/migration/ConfigurationMigration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/migration/ConfigurationMigration.java
@@ -31,6 +31,7 @@ public sealed interface ConfigurationMigration
                 MiniMessageTranslationsMigration,
                 TransferIntegrationMigration,
                 PacketLimiterMigration {
+
   boolean shouldMigrate(CommentedFileConfig config);
 
   void migrate(CommentedFileConfig config, Logger logger) throws IOException;

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/migration/ForwardingMigration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/migration/ForwardingMigration.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
  * Migrate old forwarding secret settings to modern version using an external file.
  */
 public final class ForwardingMigration implements ConfigurationMigration {
+
   @Override
   public boolean shouldMigrate(final CommentedFileConfig config) {
     return configVersion(config) < 2.0;

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/migration/KeyAuthenticationMigration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/migration/KeyAuthenticationMigration.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
  * Creation of the configuration option "force-key-authentication".
  */
 public final class KeyAuthenticationMigration implements ConfigurationMigration {
+
   @Override
   public boolean shouldMigrate(final CommentedFileConfig config) {
     final double version = configVersion(config);

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/migration/MiniMessageTranslationsMigration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/migration/MiniMessageTranslationsMigration.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.Logger;
  * Also migrates possible use of legacy colors to MiniMessage format.
  */
 public final class MiniMessageTranslationsMigration implements ConfigurationMigration {
+
   @Override
   public boolean shouldMigrate(final CommentedFileConfig config) {
     // Checking whether translations should be migrated would be just as costly as attempting to migrate them directly.

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/migration/MotdMigration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/migration/MotdMigration.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.Logger;
  * Migrates MOTD builtin configuration from legacy or json format to MiniMessage.
  */
 public final class MotdMigration implements ConfigurationMigration {
+
   @Override
   public boolean shouldMigrate(final CommentedFileConfig config) {
     return configVersion(config) < 2.6;

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/migration/TransferIntegrationMigration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/migration/TransferIntegrationMigration.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
  * Creation of the configuration option "accepts-transfers".
  */
 public final class TransferIntegrationMigration implements ConfigurationMigration {
+
   @Override
   public boolean shouldMigrate(final CommentedFileConfig config) {
     return configVersion(config) < 2.7;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/PlayerDataForwarding.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/PlayerDataForwarding.java
@@ -37,6 +37,7 @@ import org.jspecify.annotations.Nullable;
 
 @SuppressWarnings({"MissingJavadocMethod", "MissingJavadocType"})
 public final class PlayerDataForwarding {
+
   private static final String ALGORITHM = "HmacSHA256";
 
   public static final String CHANNEL = "velocity:player_info";

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/ConfigSessionHandler.java
@@ -72,6 +72,7 @@ import org.apache.logging.log4j.Logger;
  * 1.20.2+ switching. Yes, some of this is exceptionally stupid.
  */
 public class ConfigSessionHandler implements MinecraftSessionHandler {
+
   private static final boolean BACKPRESSURE_LOG =
       Boolean.getBoolean("velocity.log-server-backpressure");
 
@@ -412,6 +413,7 @@ public class ConfigSessionHandler implements MinecraftSessionHandler {
    * Represents the state of the configuration stage.
    */
   public enum State {
+
     START, NEGOTIATING, PLUGIN_MESSAGE_INTERRUPT, RESOURCE_PACK_INTERRUPT, COMPLETE
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
@@ -290,6 +290,7 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
   }
 
   enum State {
+
     START, SUCCESS_SENT, ACKNOWLEDGED
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientConfigSessionHandler.java
@@ -61,6 +61,7 @@ import org.apache.logging.log4j.Logger;
  * Handles the client config stage.
  */
 public class ClientConfigSessionHandler implements MinecraftSessionHandler {
+
   private static final boolean BACKPRESSURE_LOG =
       Boolean.getBoolean("velocity.log-server-backpressure");
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -101,6 +101,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * center that joins backend servers with players.
  */
 public class ClientPlaySessionHandler implements MinecraftSessionHandler {
+
   private static final boolean BACKPRESSURE_LOG =
       Boolean.getBoolean("velocity.log-server-backpressure");
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -310,6 +310,7 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
   }
 
   private enum LoginState {
+
     LOGIN_PACKET_EXPECTED,
     LOGIN_PACKET_RECEIVED,
     ENCRYPTION_REQUEST_SENT,

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/StatusSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/StatusSessionHandler.java
@@ -123,6 +123,7 @@ public class StatusSessionHandler implements MinecraftSessionHandler {
   }
 
   private enum State {
+
     AWAITING_REQUEST,
     RECEIVED_REQUEST
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/forge/modern/ModernForgeConstants.java
@@ -21,5 +21,6 @@ package com.velocitypowered.proxy.connection.forge.modern;
  * Constants for use with Modern Forge systems.
  */
 public class ModernForgeConstants {
+
   public static final String MODERN_FORGE_TOKEN = "FORGE";
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/bundle/BundleDelimiterHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/bundle/BundleDelimiterHandler.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
  * BundleDelimiterHandler.
  */
 public final class BundleDelimiterHandler {
+
   private final ConnectedPlayer player;
   private boolean inBundleSession = false;
   private CompletableFuture<Void> finishedBundleSessionFuture;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackResponseBundle.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/ResourcePackResponseBundle.java
@@ -23,4 +23,5 @@ import java.util.UUID;
 @SuppressWarnings("checkstyle:MissingJavadocType")
 public record ResourcePackResponseBundle(UUID uuid, String hash,
                                          PlayerResourcePackStatusEvent.Status status) {
+
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/Legacy117ResourcePackHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/Legacy117ResourcePackHandler.java
@@ -25,6 +25,7 @@ import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
  * Legacy (Minecraft 1.17-1.20.2) ResourcePackHandler.
  */
 public final class Legacy117ResourcePackHandler extends LegacyResourcePackHandler {
+
   Legacy117ResourcePackHandler(final ConnectedPlayer player, final VelocityServer server) {
     super(player, server);
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/LegacyResourcePackHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/LegacyResourcePackHandler.java
@@ -39,6 +39,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public sealed class LegacyResourcePackHandler extends ResourcePackHandler
         permits Legacy117ResourcePackHandler {
+
   protected @MonotonicNonNull Boolean previousResourceResponse;
   protected final Queue<ResourcePackInfo> outstandingResourcePacks = new ArrayDeque<>();
   private @Nullable ResourcePackInfo pendingResourcePack;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/ModernResourcePackHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/ModernResourcePackHandler.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.Nullable;
  * Modern (Minecraft 1.20.3+) ResourcePackHandler
  */
 public final class ModernResourcePackHandler extends ResourcePackHandler {
+
   private final ListMultimap<UUID, ResourcePackInfo> outstandingResourcePacks =
       Multimaps.newListMultimap(new ConcurrentHashMap<>(), LinkedList::new);
   private final Map<UUID, ResourcePackInfo> pendingResourcePacks = new ConcurrentHashMap<>();

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/ResourcePackHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/player/resourcepack/handler/ResourcePackHandler.java
@@ -39,6 +39,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public abstract sealed class ResourcePackHandler
         permits LegacyResourcePackHandler, ModernResourcePackHandler {
+
   protected final ConnectedPlayer player;
   protected final VelocityServer server;
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/crypto/EncryptionUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/crypto/EncryptionUtils.java
@@ -43,6 +43,7 @@ import javax.crypto.Cipher;
  * Generic utilities for dealing with encryption operations in Minecraft.
  */
 public enum EncryptionUtils {
+
   ;
 
   public static final Pair<String, String> PEM_RSA_PUBLIC_KEY_DESCRIPTOR =

--- a/proxy/src/main/java/com/velocitypowered/proxy/event/VelocityEventManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/event/VelocityEventManager.java
@@ -161,6 +161,7 @@ public class VelocityEventManager implements EventManager {
   }
 
   enum AsyncType {
+
     /**
      * The event will never run async, everything is handled on the netty thread.
      */

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/TransportType.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/TransportType.java
@@ -51,6 +51,7 @@ import java.util.function.Supplier;
  * Enumerates the supported transports for Velocity.
  */
 public enum TransportType {
+
   NIO("NIO", NioServerSocketChannel::new,
       NioSocketChannel::new,
       NioDatagramChannel::new,
@@ -135,6 +136,7 @@ public enum TransportType {
    * Event loop group types.
    */
   public enum Type {
+
     /**
      * Accepts connections and distributes them to workers.
      */

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/limiter/PacketLimiter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/limiter/PacketLimiter.java
@@ -22,6 +22,7 @@ package com.velocitypowered.proxy.network.limiter;
  * Implementations should be thread-safe.
  */
 public interface PacketLimiter {
+
   /**
    * Attempts to record the specified number of bytes within the current window.
    *

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/limiter/SimpleBytesPerSecondLimiter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/limiter/SimpleBytesPerSecondLimiter.java
@@ -26,6 +26,7 @@ import org.jspecify.annotations.Nullable;
  * The effective cap over the full window equals limitPerSecond * windowSeconds.
  */
 public final class SimpleBytesPerSecondLimiter implements PacketLimiter {
+
   @Nullable
   private final IntervalledCounter bytesCounter;
   @Nullable

--- a/proxy/src/main/java/com/velocitypowered/proxy/plugin/util/PluginDependencyUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/plugin/util/PluginDependencyUtils.java
@@ -122,6 +122,7 @@ public class PluginDependencyUtils {
   }
 
   private enum Mark {
+
     NOT_VISITED,
     VISITING,
     VISITED

--- a/proxy/src/main/java/com/velocitypowered/proxy/plugin/virtual/VelocityVirtualPlugin.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/plugin/virtual/VelocityVirtualPlugin.java
@@ -21,6 +21,7 @@ package com.velocitypowered.proxy.plugin.virtual;
  * A singleton plugin object that represents the Velocity proxy itself.
  */
 public class VelocityVirtualPlugin {
+
   @SuppressWarnings("InstantiationOfUtilityClass")
   public static final VelocityVirtualPlugin INSTANCE = new VelocityVirtualPlugin();
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolUtils.java
@@ -56,6 +56,7 @@ import net.kyori.option.OptionSchema;
  * Utilities for writing and reading data in the Minecraft protocol.
  */
 public enum ProtocolUtils {
+
   ;
 
   private static final GsonComponentSerializer PRE_1_16_SERIALIZER =
@@ -885,6 +886,7 @@ public enum ProtocolUtils {
    * Represents the direction in which a packet flows.
    */
   public enum Direction {
+
     SERVERBOUND,
     CLIENTBOUND
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/VelocityConnectionEvent.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/VelocityConnectionEvent.java
@@ -21,6 +21,7 @@ package com.velocitypowered.proxy.protocol;
  * Describes various events fired during the course of a connection.
  */
 public enum VelocityConnectionEvent {
+
   COMPRESSION_ENABLED,
   COMPRESSION_DISABLED,
   ENCRYPTION_ENABLED,

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/BundleDelimiterPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/BundleDelimiterPacket.java
@@ -24,6 +24,7 @@ import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import io.netty.buffer.ByteBuf;
 
 public final class BundleDelimiterPacket implements MinecraftPacket {
+
   public static final BundleDelimiterPacket INSTANCE = new BundleDelimiterPacket();
 
   private BundleDelimiterPacket() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientSettingsPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientSettingsPacket.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ClientSettingsPacket implements MinecraftPacket {
+
   private @Nullable String locale;
   private byte viewDistance;
   private int chatVisibility;

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/TransferPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/TransferPacket.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import org.jetbrains.annotations.Nullable;
 
 public class TransferPacket implements MinecraftPacket {
+
   private String host;
   private int port;
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/UpsertPlayerInfoPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/UpsertPlayerInfoPacket.java
@@ -134,6 +134,7 @@ public class UpsertPlayerInfoPacket implements MinecraftPacket {
   }
 
   public enum Action {
+
     ADD_PLAYER((ignored, buf, info) -> { // read
       info.profile = new GameProfile(
           info.profileId,

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatAcknowledgementPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatAcknowledgementPacket.java
@@ -24,6 +24,7 @@ import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import io.netty.buffer.ByteBuf;
 
 public class ChatAcknowledgementPacket implements MinecraftPacket {
+
     int offset;
 
     public ChatAcknowledgementPacket(int offset) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatQueue.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatQueue.java
@@ -127,6 +127,7 @@ public class ChatQueue implements AutoCloseable {
   }
 
   private interface Task {
+
     CompletableFuture<Void> update(ChatState chatState, MinecraftConnection smc);
   }
 
@@ -150,6 +151,7 @@ public class ChatQueue implements AutoCloseable {
    * updates.
    */
   public static class ChatState {
+
     private static final int MINIMUM_DELAYED_ACK_COUNT = LastSeenMessages.WINDOW_SIZE;
     private static final BitSet DUMMY_LAST_SEEN_MESSAGES = new BitSet();
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatType.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ChatType.java
@@ -18,6 +18,7 @@
 package com.velocitypowered.proxy.protocol.packet.chat;
 
 public enum ChatType {
+
   CHAT((byte) 0),
   SYSTEM((byte) 1),
   GAME_INFO((byte) 2);

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ComponentHolder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/ComponentHolder.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 
 public class ComponentHolder {
+
   private static final Logger logger = LogManager.getLogger(ComponentHolder.class);
   public static final int DEFAULT_MAX_STRING_SIZE = 262143;
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/PlayerChatCompletionPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/chat/PlayerChatCompletionPacket.java
@@ -72,6 +72,7 @@ public class PlayerChatCompletionPacket implements MinecraftPacket {
   }
 
   public enum Action {
+
     ADD,
     REMOVE,
     SET

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/FinishedUpdatePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/FinishedUpdatePacket.java
@@ -24,6 +24,7 @@ import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import io.netty.buffer.ByteBuf;
 
 public class FinishedUpdatePacket implements MinecraftPacket {
+
   public static final FinishedUpdatePacket INSTANCE = new FinishedUpdatePacket();
 
   private FinishedUpdatePacket() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/KnownPacksPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/KnownPacksPacket.java
@@ -66,6 +66,7 @@ public class KnownPacksPacket implements MinecraftPacket {
     }
 
     public record KnownPack(String namespace, String id, String version) {
+
         private static KnownPack read(ByteBuf buf) {
             return new KnownPack(ProtocolUtils.readString(buf), ProtocolUtils.readString(buf), ProtocolUtils.readString(buf));
         }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/StartUpdatePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/config/StartUpdatePacket.java
@@ -24,6 +24,7 @@ import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import io.netty.buffer.ByteBuf;
 
 public class StartUpdatePacket implements MinecraftPacket {
+
   public static final StartUpdatePacket INSTANCE = new StartUpdatePacket();
 
   private StartUpdatePacket() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/legacyping/LegacyMinecraftPingVersion.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/legacyping/LegacyMinecraftPingVersion.java
@@ -18,6 +18,7 @@
 package com.velocitypowered.proxy.protocol.packet.legacyping;
 
 public enum LegacyMinecraftPingVersion {
+
   MINECRAFT_1_3,
   MINECRAFT_1_4,
   MINECRAFT_1_6

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/GenericTitlePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/title/GenericTitlePacket.java
@@ -26,6 +26,7 @@ import io.netty.buffer.ByteBuf;
 public abstract class GenericTitlePacket implements MinecraftPacket {
 
   public enum ActionType {
+
     SET_TITLE(0),
     SET_SUBTITLE(1),
     SET_ACTION_BAR(2),

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/InformationUtils.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/InformationUtils.java
@@ -45,6 +45,7 @@ import java.util.Map;
  * Helper class for {@code /velocity dump}.
  */
 public enum InformationUtils {
+
   ;
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/StripAnsiConverter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/StripAnsiConverter.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.core.pattern.PatternParser;
 @Plugin(name = "stripAnsi", category = PatternConverter.CATEGORY)
 @ConverterKeys("stripAnsi")
 public class StripAnsiConverter extends LogEventPatternConverter {
+
   private static final Pattern ANSI_PATTERN = Pattern.compile("\u001B\\[[;\\d]*m");
   private final List<PatternFormatter> formatters;
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/TranslatableMapper.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/TranslatableMapper.java
@@ -29,6 +29,7 @@ import net.kyori.adventure.translation.GlobalTranslator;
  * Velocity Translation Mapper.
  */
 public enum TranslatableMapper implements BiConsumer<TranslatableComponent, Consumer<Component>> {
+
   INSTANCE;
 
   public static final ComponentFlattener FLATTENER = ComponentFlattener.basic().toBuilder()

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/VelocityProperties.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/VelocityProperties.java
@@ -25,6 +25,7 @@ import static java.util.Objects.requireNonNull;
  * @since 3.3.0
  */
 public final class VelocityProperties {
+
   /**
    * Attempts to read a system property as boolean.
    *

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/NoopCacheRatelimiter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/ratelimit/NoopCacheRatelimiter.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
  * A {@link Ratelimiter} that does no rate-limiting.
  */
 enum NoopCacheRatelimiter implements Ratelimiter<Object> {
+
   INSTANCE;
 
   @Override


### PR DESCRIPTION
Introduces a custom spotless `FormatterFunc` that enforces blank lines after type declarations, and fixes them.