### PR TITLE
reduce log noise for unreachable backend servers

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -718,8 +718,13 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
       friendlyError = Component.translatable("velocity.error.connected-server-error",
               Argument.string("server", server.getServerInfo().getName()));
     } else {
-      logger.error("{}: unable to connect to server {}", this, server.getServerInfo().getName(),
-          wrapped);
+      if (wrapped instanceof java.net.ConnectException) {
+        logger.warn("{}: unable to connect to server {} ({})", this,
+            server.getServerInfo().getName(), wrapped.getMessage());
+      } else {
+        logger.error("{}: unable to connect to server {}", this,
+            server.getServerInfo().getName(), wrapped);
+      }
       friendlyError = Component.translatable("velocity.error.connecting-server-error",
               Argument.string("server", server.getServerInfo().getName()));
     }


### PR DESCRIPTION
Log ConnectException as WARN instead of ERROR to avoid printing full stack traces when a backend server is simply offline.