### PR TITLE
Resolve backend DNS on a bounded thread pool to avoid head-of-line blocking

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/network/netty/SeparatePoolInetNameResolver.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/netty/SeparatePoolInetNameResolver.java
@@ -32,16 +32,19 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
  * An implementation of {@code InetNameResolver} that performs blocking DNS name lookups
- * in a separate thread, avoiding blocking the Netty threads for an extended period of time
- * and without the downsides of Netty's native DNS resolver.
+ * on a small bounded pool of separate threads, avoiding blocking the Netty threads for an
+ * extended period of time and without the downsides of Netty's native DNS resolver.
  */
 public final class SeparatePoolInetNameResolver extends InetNameResolver {
+
+  private static final int MAX_RESOLVE_THREADS = 8;
 
   private final ExecutorService resolveExecutor;
   private final InetNameResolver delegate;
@@ -56,9 +59,10 @@ public final class SeparatePoolInetNameResolver extends InetNameResolver {
    */
   public SeparatePoolInetNameResolver(EventExecutor executor) {
     super(executor);
-    this.resolveExecutor = Executors.newSingleThreadExecutor(
+    this.resolveExecutor = new ThreadPoolExecutor(0, MAX_RESOLVE_THREADS,
+        60L, TimeUnit.SECONDS, new SynchronousQueue<>(),
         new ThreadFactoryBuilder()
-            .setNameFormat("Velocity DNS Resolver")
+            .setNameFormat("Velocity DNS Resolver #%d")
             .setDaemon(true)
             .build());
     this.delegate = new DefaultNameResolver(executor);

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/netty/SeparatePoolInetNameResolver.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/netty/SeparatePoolInetNameResolver.java
@@ -32,8 +32,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -59,12 +59,15 @@ public final class SeparatePoolInetNameResolver extends InetNameResolver {
    */
   public SeparatePoolInetNameResolver(EventExecutor executor) {
     super(executor);
-    this.resolveExecutor = new ThreadPoolExecutor(0, MAX_RESOLVE_THREADS,
-        60L, TimeUnit.SECONDS, new SynchronousQueue<>(),
+    ThreadPoolExecutor resolveExecutor = new ThreadPoolExecutor(
+        MAX_RESOLVE_THREADS, MAX_RESOLVE_THREADS,
+        60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(),
         new ThreadFactoryBuilder()
             .setNameFormat("Velocity DNS Resolver #%d")
             .setDaemon(true)
             .build());
+    resolveExecutor.allowCoreThreadTimeOut(true);
+    this.resolveExecutor = resolveExecutor;
     this.delegate = new DefaultNameResolver(executor);
     this.cache = Caffeine.newBuilder()
         .expireAfterWrite(30, TimeUnit.SECONDS)


### PR DESCRIPTION
Fixes #1833.

`SeparatePoolInetNameResolver` runs every backend hostname lookup on a single thread (`Executors.newSingleThreadExecutor`). Because the lookups are blocking, one slow resolve serializes all the others behind it: an unrelated stalled DNS query delays connecting players to otherwise-healthy servers until it returns or the JDK resolver times out. We saw fallback connections to a hostname-defined server hang for 10–18s while the same name resolved instantly on another thread.

This swaps the single-thread executor for a small bounded pool (`ThreadPoolExecutor`, 0–8 threads, 60s keep-alive, `SynchronousQueue`), so a slow lookup only ties up one thread instead of blocking all resolution. Threads are created on demand and reaped when idle, so it costs nothing at rest.