### PR TITLE
Store historical console commands in .console_history (enables command history between restarts)

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
@@ -25,6 +25,7 @@ import com.velocitypowered.api.permission.Tristate;
 import com.velocitypowered.api.proxy.ConsoleCommandSource;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.util.ClosestLocaleMatcher;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 import net.kyori.adventure.audience.MessageType;
@@ -111,6 +112,7 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
   protected LineReader buildReader(LineReaderBuilder builder) {
     return super.buildReader(builder
         .appName("Velocity")
+        .variable(LineReader.HISTORY_FILE, Path.of(".console_history"))
         .completer((reader, parsedLine, list) -> {
           try {
             List<String> offers = this.server.getCommandManager()


### PR DESCRIPTION
[Mirrors how Paper does things](https://github.com/PaperMC/Paper/blob/main/paper-server/src/main/java/com/destroystokyo/paper/console/PaperConsole.java#L24). Allows the user to press up to get previously executed commands, now persisting between reboots. Very useful for (plugin) development.