### PR TITLE
feat: add stable session UUID to MinecraftConnection

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/InboundConnection.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/InboundConnection.java
@@ -74,7 +74,7 @@ public interface InboundConnection {
    * Returns the unique, stable session UUID for this connection, generated when
    * the client initially connects to the proxy. The session id remains consistent
    * across all login-phase events and all proxy-to-backend connections for the
-   * same player session.
+   * same player session. This should not be confused with Mojang's server-wide play session ID introduced in Minecraft 26.2.
    *
    * @return the session UUID, never {@code null}
    */

--- a/api/src/main/java/com/velocitypowered/api/proxy/InboundConnection.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/InboundConnection.java
@@ -12,6 +12,7 @@ import com.velocitypowered.api.network.ProtocolState;
 import com.velocitypowered.api.network.ProtocolVersion;
 import java.net.InetSocketAddress;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Represents an incoming connection to the proxy.
@@ -70,11 +71,13 @@ public interface InboundConnection {
   HandshakeIntent getHandshakeIntent();
 
   /**
-   * Returns a unique, stable identifier for this connection.
+   * Returns a unique, stable UUID for this connection, generated at
+   * connection creation time. The UUID remains consistent across all
+   * login-phase events for the same TCP connection.
    *
-   * @return the connection id
+   * @return the connection UUID, or {@code null} if not supported
    */
-  default long getConnectionId() {
-    return -1;
+  default UUID getConnectionId() {
+    return null;
   }
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/InboundConnection.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/InboundConnection.java
@@ -68,4 +68,13 @@ public interface InboundConnection {
    * @return the intent of the connection
    */
   HandshakeIntent getHandshakeIntent();
+
+  /**
+   * Returns a unique, stable identifier for this connection.
+   *
+   * @return the connection id
+   */
+  default long getConnectionId() {
+    return -1;
+  }
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/InboundConnection.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/InboundConnection.java
@@ -71,13 +71,12 @@ public interface InboundConnection {
   HandshakeIntent getHandshakeIntent();
 
   /**
-   * Returns a unique, stable UUID for this connection, generated at
-   * connection creation time. The UUID remains consistent across all
-   * login-phase events for the same TCP connection.
+   * Returns the unique, stable session UUID for this connection, generated when
+   * the client initially connects to the proxy. The session id remains consistent
+   * across all login-phase events and all proxy-to-backend connections for the
+   * same player session.
    *
-   * @return the connection UUID, or {@code null} if not supported
+   * @return the session UUID, never {@code null}
    */
-  default UUID getConnectionId() {
-    return null;
-  }
+  UUID getSessionId();
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -88,7 +88,7 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
 
   private static final Logger logger = LogManager.getLogger(MinecraftConnection.class);
 
-  private final UUID connectionId = UUID.randomUUID();
+  private final @Nullable UUID sessionId;
   private final Channel channel;
   public boolean pendingConfigurationSwitch = false;
   private SocketAddress remoteAddress;
@@ -107,10 +107,11 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
    * @param channel the channel on the connection
    * @param server  the Velocity instance
    */
-  public MinecraftConnection(Channel channel, VelocityServer server) {
+  public MinecraftConnection(Channel channel, VelocityServer server, @Nullable UUID sessionId) {
     this.channel = channel;
     this.remoteAddress = channel.remoteAddress();
     this.server = server;
+    this.sessionId = sessionId;
     this.state = StateRegistry.HANDSHAKE;
 
     this.sessionHandlers = new EnumMap<>(StateRegistry.class);
@@ -325,13 +326,14 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
   }
 
   /**
-   * Returns a unique, stable UUID for this connection, generated at
-   * connection creation time.
+   * Returns the session UUID for this connection. Client connections have a
+   * unique session UUID; backend connections share the client's session UUID;
+   * ping connections have {@code null}.
    *
-   * @return the connection UUID
+   * @return the session UUID, or {@code null} for ping connections
    */
-  public UUID getConnectionId() {
-    return connectionId;
+  public @Nullable UUID getSessionId() {
+    return sessionId;
   }
 
   public boolean isClosed() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -86,7 +86,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class MinecraftConnection extends ChannelInboundHandlerAdapter {
 
   private static final Logger logger = LogManager.getLogger(MinecraftConnection.class);
+  private static final java.util.concurrent.atomic.AtomicLong CONNECTION_ID_COUNTER =
+      new java.util.concurrent.atomic.AtomicLong();
 
+  private final long connectionId = CONNECTION_ID_COUNTER.incrementAndGet();
   private final Channel channel;
   public boolean pendingConfigurationSwitch = false;
   private SocketAddress remoteAddress;
@@ -320,6 +323,15 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
 
   public Channel getChannel() {
     return channel;
+  }
+
+  /**
+   * Returns a unique, stable identifier for this connection.
+   *
+   * @return the connection id
+   */
+  public long getConnectionId() {
+    return connectionId;
   }
 
   public boolean isClosed() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -325,13 +325,7 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
     return channel;
   }
 
-  /**
-   * Returns the session UUID for this connection. Client connections have a
-   * unique session UUID; backend connections share the client's session UUID;
-   * ping connections have {@code null}.
-   *
-   * @return the session UUID, or {@code null} for ping connections
-   */
+
   public @Nullable UUID getSessionId() {
     return sessionId;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -72,6 +72,7 @@ import java.security.GeneralSecurityException;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -86,10 +87,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class MinecraftConnection extends ChannelInboundHandlerAdapter {
 
   private static final Logger logger = LogManager.getLogger(MinecraftConnection.class);
-  private static final java.util.concurrent.atomic.AtomicLong CONNECTION_ID_COUNTER =
-      new java.util.concurrent.atomic.AtomicLong();
 
-  private final long connectionId = CONNECTION_ID_COUNTER.incrementAndGet();
+  private final UUID connectionId = UUID.randomUUID();
   private final Channel channel;
   public boolean pendingConfigurationSwitch = false;
   private SocketAddress remoteAddress;
@@ -326,11 +325,12 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
   }
 
   /**
-   * Returns a unique, stable identifier for this connection.
+   * Returns a unique, stable UUID for this connection, generated at
+   * connection creation time.
    *
-   * @return the connection id
+   * @return the connection UUID
    */
-  public long getConnectionId() {
+  public UUID getConnectionId() {
     return connectionId;
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -105,7 +105,8 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
         .connect(registeredServer.getServerInfo().getAddress())
         .addListener((ChannelFutureListener) future -> {
           if (future.isSuccess()) {
-            connection = new MinecraftConnection(future.channel(), server);
+            connection = new MinecraftConnection(future.channel(), server,
+                proxyPlayer.getConnection().getSessionId());
             connection.setAssociation(VelocityServerConnection.this);
             future.channel().pipeline().addLast(HANDLER, connection);
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -322,8 +322,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   }
 
   @Override
-  public UUID getConnectionId() {
-    return connection.getConnectionId();
+  public UUID getSessionId() {
+    return connection.getSessionId();
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -322,6 +322,11 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   }
 
   @Override
+  public long getConnectionId() {
+    return connection.getConnectionId();
+  }
+
+  @Override
   public long getPing() {
     return this.ping;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -322,7 +322,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   }
 
   @Override
-  public long getConnectionId() {
+  public UUID getConnectionId() {
     return connection.getConnectionId();
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginInboundConnection.java
@@ -183,4 +183,9 @@ public class LoginInboundConnection implements LoginPhaseConnection, KeyIdentifi
   public HandshakeIntent getHandshakeIntent() {
     return delegate.getHandshakeIntent();
   }
+
+  @Override
+  public long getConnectionId() {
+    return delegate.getConnectionId();
+  }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginInboundConnection.java
@@ -33,6 +33,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import java.net.InetSocketAddress;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import net.kyori.adventure.text.Component;
@@ -185,7 +186,7 @@ public class LoginInboundConnection implements LoginPhaseConnection, KeyIdentifi
   }
 
   @Override
-  public long getConnectionId() {
+  public UUID getConnectionId() {
     return delegate.getConnectionId();
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginInboundConnection.java
@@ -186,7 +186,7 @@ public class LoginInboundConnection implements LoginPhaseConnection, KeyIdentifi
   }
 
   @Override
-  public UUID getConnectionId() {
-    return delegate.getConnectionId();
+  public UUID getSessionId() {
+    return delegate.getSessionId();
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/VelocityInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/VelocityInboundConnection.java
@@ -29,7 +29,7 @@ public interface VelocityInboundConnection extends InboundConnection {
   MinecraftConnection getConnection();
 
   @Override
-  default UUID getConnectionId() {
-    return getConnection().getConnectionId();
+  default UUID getSessionId() {
+    return getConnection().getSessionId();
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/VelocityInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/VelocityInboundConnection.java
@@ -19,6 +19,7 @@ package com.velocitypowered.proxy.connection.util;
 
 import com.velocitypowered.api.proxy.InboundConnection;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
+import java.util.UUID;
 
 /**
  * Base internal interface for a {@link InboundConnection}.
@@ -28,7 +29,7 @@ public interface VelocityInboundConnection extends InboundConnection {
   MinecraftConnection getConnection();
 
   @Override
-  default long getConnectionId() {
+  default UUID getConnectionId() {
     return getConnection().getConnectionId();
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/VelocityInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/VelocityInboundConnection.java
@@ -19,6 +19,7 @@ package com.velocitypowered.proxy.connection.util;
 
 import com.velocitypowered.api.proxy.InboundConnection;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -30,6 +31,6 @@ public interface VelocityInboundConnection extends InboundConnection {
 
   @Override
   default UUID getSessionId() {
-    return getConnection().getSessionId();
+    return Objects.requireNonNull(getConnection().getSessionId(), "sessionId");
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/util/VelocityInboundConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/util/VelocityInboundConnection.java
@@ -26,4 +26,9 @@ import com.velocitypowered.proxy.connection.MinecraftConnection;
 public interface VelocityInboundConnection extends InboundConnection {
 
   MinecraftConnection getConnection();
+
+  @Override
+  default long getConnectionId() {
+    return getConnection().getConnectionId();
+  }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ServerChannelInitializer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ServerChannelInitializer.java
@@ -42,6 +42,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.netty.handler.timeout.ReadTimeoutHandler;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -69,7 +70,7 @@ public class ServerChannelInitializer extends ChannelInitializer<Channel> {
         .addLast(MINECRAFT_DECODER, new MinecraftDecoder(ProtocolUtils.Direction.SERVERBOUND))
         .addLast(MINECRAFT_ENCODER, new MinecraftEncoder(ProtocolUtils.Direction.CLIENTBOUND));
 
-    final MinecraftConnection connection = new MinecraftConnection(ch, this.server);
+    final MinecraftConnection connection = new MinecraftConnection(ch, this.server, UUID.randomUUID());
     connection.setActiveSessionHandler(StateRegistry.HANDSHAKE,
         new HandshakeSessionHandler(connection, this.server));
     ch.pipeline().addLast(Connections.HANDLER, connection);

--- a/proxy/src/main/java/com/velocitypowered/proxy/server/VelocityRegisteredServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/server/VelocityRegisteredServer.java
@@ -123,7 +123,7 @@ public class VelocityRegisteredServer implements RegisteredServer, ForwardingAud
             .addLast(MINECRAFT_DECODER, new MinecraftDecoder(ProtocolUtils.Direction.CLIENTBOUND))
             .addLast(MINECRAFT_ENCODER, new MinecraftEncoder(ProtocolUtils.Direction.SERVERBOUND));
 
-        ch.pipeline().addLast(HANDLER, new MinecraftConnection(ch, server));
+        ch.pipeline().addLast(HANDLER, new MinecraftConnection(ch, server, null));
       }
     }).connect(serverInfo.getAddress()).addListener((ChannelFutureListener) future -> {
       if (future.isSuccess()) {


### PR DESCRIPTION
Add a stable connection identifier to MinecraftConnection

A unique connectionId (AtomicLong) is held in MinecraftConnection,
the shared underlying instance across all InboundConnection wrappers,
surfaced via InboundConnection.getSessionId().

This allows plugins to reliably track the same TCP connection across
PreLoginEvent, GameProfileRequestEvent, and LoginEvent, even when
the InboundConnection wrapper object differs between events.

Tested with both online-mode and offline-mode connections:
- [x] Same connection across all login-phase events: same connId
- [x] Different players: different connId
- [x] Premium (Mojang-authenticated) connections: connId stable