### PR TITLE
chore: drop adventure-platform-facet

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ spotless = "com.diffplug.spotless:8.2.0"
 [libraries]
 adventure-bom = "net.kyori:adventure-bom:5.2.0"
 adventure-text-serializer-json-legacy-impl = "net.kyori:adventure-text-serializer-json-legacy-impl:5.2.0"
-adventure-facet = "net.kyori:adventure-platform-facet:4.4.1"
 asm = "org.ow2.asm:asm:9.9.1"
 auto-service = "com.google.auto.service:auto-service:1.1.1"
 auto-service-annotations = "com.google.auto.service:auto-service-annotations:1.1.1"

--- a/proxy/build.gradle.kts
+++ b/proxy/build.gradle.kts
@@ -159,7 +159,6 @@ dependencies {
     implementation(libs.fastutil)
     implementation(platform(libs.adventure.bom))
     implementation(libs.adventure.text.serializer.json.legacy.impl)
-    implementation(libs.adventure.facet)
     implementation(libs.completablefutures)
     implementation(libs.nightconfig)
     implementation(libs.bstats)

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -122,8 +122,6 @@ import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.permission.PermissionChecker;
-import net.kyori.adventure.platform.facet.FacetPointers;
-import net.kyori.adventure.platform.facet.FacetPointers.Type;
 import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.pointer.PointersSupplier;
 import net.kyori.adventure.resource.ResourcePackInfoLike;
@@ -165,7 +163,6 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
                   .resolving(Identity.DISPLAY_NAME, player -> Component.text(player.getUsername()))
                   .resolving(Identity.LOCALE, Player::getEffectiveLocale)
                   .resolving(PermissionChecker.POINTER, Player::getPermissionChecker)
-                  .resolving(FacetPointers.TYPE, player -> Type.PLAYER)
                   .build();
 
   /**

--- a/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.Locale;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.permission.PermissionChecker;
-import net.kyori.adventure.platform.facet.FacetPointers;
-import net.kyori.adventure.platform.facet.FacetPointers.Type;
 import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.pointer.PointersSupplier;
 import net.kyori.adventure.text.Component;
@@ -64,7 +62,6 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
       .resolving(PermissionChecker.POINTER, VelocityConsole::getPermissionChecker)
       .resolving(Identity.LOCALE, (console) -> ClosestLocaleMatcher.INSTANCE
           .lookupClosest(Locale.getDefault()))
-      .resolving(FacetPointers.TYPE, (console) -> Type.CONSOLE)
       .build();
 
   public VelocityConsole(VelocityServer server) {


### PR DESCRIPTION
adventure-platform is no longer maintained, and there has been some discussion in the original adventure 5 PR on what to do with adventure-platform-facet (see https://github.com/PaperMC/Velocity/pull/1774#issuecomment-4500943734 and replies).

We were only providing some internal pointers that, to my understanding, didn't do anything anyways since there is no adventure-platform for velocity. This PR drops adventure-platform-facet entirely.