### PR TITLE
Fix GS4 query crash and validate login usernames

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/GameSpyQueryHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/GameSpyQueryHandler.java
@@ -109,7 +109,8 @@ public class GameSpyQueryHandler extends SimpleChannelInboundHandler<DatagramPac
     InetAddress senderAddress = msg.sender().getAddress();
 
     // Verify query packet magic
-    if (queryMessage.readUnsignedByte() != QUERY_MAGIC_FIRST
+    if (queryMessage.readableBytes() < 7
+        || queryMessage.readUnsignedByte() != QUERY_MAGIC_FIRST
         || queryMessage.readUnsignedByte() != QUERY_MAGIC_SECOND) {
       return;
     }


### PR DESCRIPTION
## Summary

Two small defensive fixes for the proxy's network layer.

### 1. Guard GameSpyQueryHandler against short datagrams

GameSpyQueryHandler.channelRead0() reads magic bytes, type, and sessionId
without first checking readableBytes(). A malformed UDP datagram shorter
than 7 bytes causes IndexOutOfBoundsException on every packet, spamming
the log at WARNING level.

This adds a readableBytes() >= 7 guard at the start so short datagrams
are silently dropped instead.

### 2. Validate usernames in ServerLoginPacket

In offline mode, ServerLoginPacket.decode() accepts any UTF-8 content
as a username. This username becomes the offline UUID seed and is
forwarded to the backend as-is, enabling log injection and identity
confusion.

This adds a [A-Za-z0-9_]+ regex check (the vanilla Minecraft character
set), rejecting non-conforming usernames with a QuietDecoderException.

## Testing

./gradlew :velocity-proxy:check passes all checks (compile, Checkstyle,
SpotBugs, tests).

Closes #1828
Closes #1827