### PR TITLE
fix: avoid re-fetching connected server in handle(ClientSettingsPacket)

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -237,7 +237,7 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
       // No server connection yet, probably transitioning.
       return true;
     }
-    player.getConnectedServer().ensureConnected().write(packet);
+    serverConnection.ensureConnected().write(packet);
     return true; // will forward onto the server
   }
 


### PR DESCRIPTION
## What
`ClientPlaySessionHandler#handle(ClientSettingsPacket)` fetches
`player.getConnectedServer()`, null-checks it, then discards the local
variable and calls `player.getConnectedServer()` a second time before
calling `.ensureConnected()` on the result.

Between these two calls the player's connected server can change on
another thread (e.g. mid server-switch), so the second call can return
`null` (NPE on `.ensureConnected()`) or a connection whose
`ensureConnected()` throws `IllegalStateException`, crashing/kicking
the session — the same class of bug fixed for the chat/command packet
handlers in f6fbd25 ("Downgrade severity of handling several incoming
user input packet states"), which however did not touch this handler.

## Fix
Reuse the already null-checked local `serverConnection` reference
instead of re-querying `player.getConnectedServer()`.

## Testing
Built locally with `./gradlew build`; no behavioral change for the
non-racy path, since the second `getConnectedServer()` call previously
returned the same object in the common case.