### PR TITLE
refactor: remove outdated messages + fix \! randomly appearing in som…

### DIFF
--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages.properties
@@ -55,13 +55,6 @@ velocity.command.no-plugins=There are no plugins currently installed.
 velocity.command.plugins-list=Plugins: <arg:0>
 velocity.command.plugin-tooltip-website=Website: <arg:0>
 velocity.command.plugin-tooltip-author=Author: <arg:0>
-velocity.command.plugin-tooltip-authors=Authors: <arg:0>
-velocity.command.dump-uploading=Uploading gathered information...
-velocity.command.dump-send-error=An error occurred while communicating with the Velocity servers. The servers may be temporarily unavailable or there is an issue with your network settings. You can find more information in the log or console of your Velocity server.
-velocity.command.dump-success=Created an anonymised report containing useful information about this proxy. If a developer requested it, you may share the following link with them:
-velocity.command.dump-will-expire=This link will expire in a few days.
-velocity.command.dump-server-error=An error occurred on the Velocity servers and the dump could not be completed. Please contact the Velocity staff about this problem and provide the details about this error from the Velocity console or server log.
-velocity.command.dump-offline=Likely cause: Invalid system DNS settings or no internet connection
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy shutting down.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_ar_SA.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_ar_SA.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=أنت بالفعل متصل بهذا السيرفر\!
-velocity.error.already-connected-proxy=أنت بالفعل متصل بهذا الوكيل\!
-velocity.error.already-connecting=أنت بالفعل تحاول الاتصال بأحد السيرفرات\!
+velocity.error.already-connected=أنت بالفعل متصل بهذا السيرفر!
+velocity.error.already-connected-proxy=أنت بالفعل متصل بهذا الوكيل!
+velocity.error.already-connecting=أنت بالفعل تحاول الاتصال بأحد السيرفرات!
 velocity.error.cant-connect=فشل الاتصال بـ<arg:0>\: <arg:1>
 velocity.error.connecting-server-error=فشل الاتصال بـ<arg:0>، حاول في وقتٍ لاحق.
 velocity.error.connected-server-error=واجه اتصالك بـ<arg:0> مشكلة.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=لا توجد إضافات مثبتة على Velocit
 velocity.command.plugins-list=الإضافات\: <arg:0>
 velocity.command.plugin-tooltip-website=موقعها\: <arg:0>
 velocity.command.plugin-tooltip-author=تصميم\: <arg:0>
-velocity.command.plugin-tooltip-authors=تصميم\: <arg:0>
-velocity.command.dump-uploading=جاري تجميع و رفع معلومات نظامك...
-velocity.command.dump-send-error=حدث خطأ أثناء الاتصال بسيرفر Velocity. قد يكون السيرفر غير متاح مؤقتاً أو هناك مشكلة في إعدادات الشبكة الخاصة بك. يمكنك العثور على مزيد من المعلومات في log أو console وكيل Velocity الخاص بك.
-velocity.command.dump-success=تم إنشاء تقرير مفصل يحتوي على معلومات مفيدة عن الوكيل الخاص بك. إذا طلبه المطور، يمكنك مشاركة الرابط التالي معه\:
-velocity.command.dump-will-expire=تنتهي صلاحية هذا الرابط خلال بضعة أيام.
-velocity.command.dump-server-error=حدث خطأ في سيرفر Velocity و تعذر إكمال مشاركة البيانات. الرجاء الاتصال بطاقم Velocity حيال هذه المشكلة وتقديم التفاصيل الخطأ من الـconsole أو log السيرفر.
-velocity.command.dump-offline=السبب المحتمل\: إعدادات الـDNS غير صالحة أو لا يوجد اتصال بالإنترنت
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy shutting down.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_bg_BG.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_bg_BG.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Вече сте свързани към този сървър\!
-velocity.error.already-connected-proxy=Вече сте свързани към това прокси\!
-velocity.error.already-connecting=Вече се опитвате да се свържете към сървър\!
+velocity.error.already-connected=Вече сте свързани към този сървър!
+velocity.error.already-connected-proxy=Вече сте свързани към това прокси!
+velocity.error.already-connecting=Вече се опитвате да се свържете към сървър!
 velocity.error.cant-connect=Не успяхме да Ви свържем към <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Не успяхме да Ви свържем към <arg:0>. Моля, опитайте по-късно.
 velocity.error.connected-server-error=Възникна грешка, докато бяхте свързан към <arg:0>.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=За момента няма инсталирани 
 velocity.command.plugins-list=Добавки\: <arg:0>
 velocity.command.plugin-tooltip-website=Уебсайт\: <arg:0>
 velocity.command.plugin-tooltip-author=Автор\: <arg:0>
-velocity.command.plugin-tooltip-authors=Автори\: <arg:0>
-velocity.command.dump-uploading=Качваме събраната информация...
-velocity.command.dump-send-error=Възникна грешка при комуникацията със сървърите на Velocity. Сървърите може временно да не са налични, или да имате проблем с мрежовите настройки. Ще откриете повече информация в логовете или конзолата на Вашето Velocity прокси.
-velocity.command.dump-success=Създадохме анонимен доклад, съдържащ полезна информация относно това прокси. Ако разработчик Ви го е поискал, може да споделите този линк с тях\:
-velocity.command.dump-will-expire=Този линк ще изтече след няколко дена.
-velocity.command.dump-server-error=Възникна грешка при сървърите на Velocity и доклада не може да бъде завършен. Моля, уведомете разработващия екип на Velocity относно този проблем и осигурете детайли за грешката от конзолата или логовете.
-velocity.command.dump-offline=Вероятна причина\: Невалидни системни DNS настройки или липса на Интернет връзка
 velocity.command.send-usage=/изпрати <играч> <сървър>
 # Kick
 velocity.kick.shutdown=Проксито се изключва.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_cs_CZ.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_cs_CZ.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=K tomuto serveru jsi již připojen\!
-velocity.error.already-connected-proxy=K tomuto proxy serveru jsi již připojen\!
-velocity.error.already-connecting=Již se pokoušíš o připojení k serveru\!
+velocity.error.already-connected=K tomuto serveru jsi již připojen!
+velocity.error.already-connected-proxy=K tomuto proxy serveru jsi již připojen!
+velocity.error.already-connecting=Již se pokoušíš o připojení k serveru!
 velocity.error.cant-connect=Nepodařilo se připojit k serveru <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Nepodařilo se tě připojit k serveru <arg:0>. Zkus to prosím později.
 velocity.error.connected-server-error=Nastala chyba ve tvém připojení k serveru <arg:0>.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=V tuto chvíli nejsou nainstalovány žádné zásuv
 velocity.command.plugins-list=Zásuvné moduly\: <arg:0>
 velocity.command.plugin-tooltip-website=Webová stránka\: <arg:0>
 velocity.command.plugin-tooltip-author=Autor\: <arg:0>
-velocity.command.plugin-tooltip-authors=Autoři\: <arg:0>
-velocity.command.dump-uploading=Nahrávání získaných informací...
-velocity.command.dump-send-error=Nastala chyba při komunikaci s Velocity servery. Servery mohou být dočasně nedostupné nebo je chyba v přístupu na internet. Podrobnosti jsou v logu a na konzoli Velocity serveru.
-velocity.command.dump-success=Byla vytvořena anonymizovaná zpráva obsahující užitečné informace o tomto serveru. Vyžádal-li si je vývojář, můžeš mu poslat nasledující odkaz\:
-velocity.command.dump-will-expire=Za několik dnů tento odkaz vyprší.
-velocity.command.dump-server-error=Na Velocity serverech se vyskytla chyba a výpis nebylo možné vytvořit. Prosím kontaktuj Velocity tým o tomto problému a poskytni mu o této chybě podrobnosti z Velocity konzole nebo z logu na serveru.
-velocity.command.dump-offline=Pravděpodobná příčina\: Neplatné systémové DNS nastavení nebo není připojení k internetu
 velocity.command.send-usage=/send <hráč> <server>
 # Kick
 velocity.kick.shutdown=Proxy se vypíná.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_da_DK.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_da_DK.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Du er allerede tilsluttet til den server\!
-velocity.error.already-connected-proxy=Du er allerede tilsluttet til proxyen\!
-velocity.error.already-connecting=Du forsøger allerede at oprette forbindelse til en server\!
+velocity.error.already-connected=Du er allerede tilsluttet til den server!
+velocity.error.already-connected-proxy=Du er allerede tilsluttet til proxyen!
+velocity.error.already-connecting=Du forsøger allerede at oprette forbindelse til en server!
 velocity.error.cant-connect=Kan ikke forbinde til <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Kan ikke forbinde dig til <arg:0>. Prøv igen senere.
 velocity.error.connected-server-error=Din forbindelse til <arg:0> stødte på et problem.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Der er ingen plugins installeret i øjeblikket.
 velocity.command.plugins-list=Plugins\: <arg:0>
 velocity.command.plugin-tooltip-website=Hjemmeside\: <arg:0>
 velocity.command.plugin-tooltip-author=Forfatter\: <arg:0>
-velocity.command.plugin-tooltip-authors=Skabere\: <arg:0>
-velocity.command.dump-uploading=Uploader indsamlet information...
-velocity.command.dump-send-error=Der opstod en fejl under kommunikation med Velocity serverne. Serverne kan være midlertidigt utilgængelige, eller der er et problem med dine netværksindstillinger. Du kan finde mere information i loggen eller konsollen på din Velocity server.
-velocity.command.dump-success=Oprettet en anonymiseret rapport med nyttige oplysninger om denne proxy. Hvis en udvikler anmodede om det, kan du dele følgende link med dem\:
-velocity.command.dump-will-expire=Dette link udløber om et par dage.
-velocity.command.dump-server-error=Der opstod en fejl på Velocity serverne og udskrivningen af fejl logbogen kunne ikke fuldføres. Kontakt venligst Velocity personalet om dette problem og giv oplysninger om denne fejl fra Velocity konsollen eller server loggen.
-velocity.command.dump-offline=Sandsynlig årsag\: Ugyldig system DNS indstillinger eller ingen internetforbindelse
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy lukker ned.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_de_DE.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_de_DE.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Du bist bereits mit diesem Server verbunden\!
-velocity.error.already-connected-proxy=Du bist bereits mit diesem Proxy verbunden\!
-velocity.error.already-connecting=Du versuchst dich bereits mit einem Server zu verbinden\!
+velocity.error.already-connected=Du bist bereits mit diesem Server verbunden!
+velocity.error.already-connected-proxy=Du bist bereits mit diesem Proxy verbunden!
+velocity.error.already-connecting=Du versuchst dich bereits mit einem Server zu verbinden!
 velocity.error.cant-connect=Kein Verbindungsaufbau zu <arg:0> möglich\: <arg:1>
 velocity.error.connecting-server-error=Kein Verbindungsaufbau zu <arg:0> möglich. Bitte versuche es später erneut.
 velocity.error.connected-server-error=Bei der Verbindung zu <arg:0> ist ein Problem aufgetreten.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Es sind derzeit keine Plugins installiert.
 velocity.command.plugins-list=Plugins\: <arg:0>
 velocity.command.plugin-tooltip-website=Webseite\: <arg:0>
 velocity.command.plugin-tooltip-author=Entwickler\: <arg:0>
-velocity.command.plugin-tooltip-authors=Entwickler\: <arg:0>
-velocity.command.dump-uploading=Erfasste Daten werden hochgeladen...
-velocity.command.dump-send-error=Bei der Kommunikation mit den Velocity-Servern ist ein Fehler aufgetreten. Diese Server sind möglicherweise vorübergehend nicht verfügbar oder es gibt ein Problem mit deinen Netzwerkeinstellungen. Weitere Informationen findest du in der Log-Datei oder in der Konsole deines Velocity-Servers.
-velocity.command.dump-success=Ein anonymisierter Bericht mit nützlichen Informationen über diesen Proxy wurde erstellt. Wenn ein Entwickler den Bericht angefordert hat, kannst du diesen über folgenden Link mit ihm teilen\:
-velocity.command.dump-will-expire=Dieser Link wird in ein paar Tagen ablaufen.
-velocity.command.dump-server-error=Auf den Velocity-Servern ist ein Fehler aufgetreten und der Dump konnte nicht abgeschlossen werden. Bitte kontaktiere die Velocity-Mitarbeiter über das Problem mit Details zu diesem Fehler aus der Velocity-Konsole oder dem Serverprotokoll.
-velocity.command.dump-offline=Wahrscheinliche Ursache\: Ungültige System-DNS-Einstellungen oder keine Internetverbindung
 velocity.command.send-usage=/send <spieler> <server>
 # Kick
 velocity.kick.shutdown=Proxy fährt herunter.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_es_ES.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_es_ES.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=¡Ya estás conectado a este servidor\!
-velocity.error.already-connected-proxy=¡Ya estás conectado a este proxy\!
-velocity.error.already-connecting=¡Ya estás intentando conectarte a un servidor\!
+velocity.error.already-connected=¡Ya estás conectado a este servidor!
+velocity.error.already-connected-proxy=¡Ya estás conectado a este proxy!
+velocity.error.already-connecting=¡Ya estás intentando conectarte a un servidor!
 velocity.error.cant-connect=No se ha podido conectar a <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=No hemos podido conectarte a <arg:0>. Por favor, inténtalo de nuevo más tarde.
 velocity.error.connected-server-error=Tu conexión a <arg:0> ha sufrido un problema.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Actualmente no hay plugins instalados.
 velocity.command.plugins-list=Complementos\: <arg:0>
 velocity.command.plugin-tooltip-website=Página web\: <arg:0>
 velocity.command.plugin-tooltip-author=Autor\: <arg:0>
-velocity.command.plugin-tooltip-authors=Autores\: <arg:0>
-velocity.command.dump-uploading=Subiendo la información recopilada...
-velocity.command.dump-send-error=Se ha producido un error al comunicarse con los servidores de Velocity. Es posible que los servidores no estén disponibles temporalmente o que exista un problema en tu configuración de red. Puedes encontrar más información en el archivo de registro o la consola de tu servidor Velocity.
-velocity.command.dump-success=Se ha creado un informe anónimo que contiene información útil sobre este proxy. Si un desarrollador lo solicita, puedes compartir el siguiente enlace con él\:
-velocity.command.dump-will-expire=Este enlace caducará en unos días.
-velocity.command.dump-server-error=Se ha producido un error en los servidores de Velocity y la subida no se ha podido completar. Notifica al equipo de Velocity sobre este problema y proporciona los detalles sobre este error disponibles en el archivo de registro o la consola de tu servidor Velocity.
-velocity.command.dump-offline=Causa probable\: la configuración DNS del sistema no es válida o no hay conexión a internet
 velocity.command.send-usage=/send <jugador> <servidor>
 # Kick
 velocity.kick.shutdown=El proxy se ha apagado.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_et_EE.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_et_EE.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Sa oled juba antud serveriga ühendatud\!
-velocity.error.already-connected-proxy=Sa oled juba antud proksiga ühendatud\!
-velocity.error.already-connecting=Sa juba ühendad severiga\!
+velocity.error.already-connected=Sa oled juba antud serveriga ühendatud!
+velocity.error.already-connected-proxy=Sa oled juba antud proksiga ühendatud!
+velocity.error.already-connecting=Sa juba ühendad severiga!
 velocity.error.cant-connect=Unable to connect to <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Unable to connect you to <arg:0>. Please try again later.
 velocity.error.connected-server-error=Your connection to <arg:0> encountered a problem.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=There are no plugins currently installed.
 velocity.command.plugins-list=Pluginad\: <arg:0>
 velocity.command.plugin-tooltip-website=Veebileht\: <arg:0>
 velocity.command.plugin-tooltip-author=Autor\: <arg:0>
-velocity.command.plugin-tooltip-authors=Autorid\: <arg:0>
-velocity.command.dump-uploading=Kogutud informatsiooni üleslaadimine...
-velocity.command.dump-send-error=An error occurred while communicating with the Velocity servers. The servers may be temporarily unavailable or there is an issue with your network settings. You can find more information in the log or console of your Velocity server.
-velocity.command.dump-success=Created an anonymised report containing useful information about this proxy. If a developer requested it, you may share the following link with them\:
-velocity.command.dump-will-expire=Link aegub paari päeva pärast.
-velocity.command.dump-server-error=An error occurred on the Velocity servers and the dump could not be completed. Please contact the Velocity staff about this problem and provide the details about this error from the Velocity console or server log.
-velocity.command.dump-offline=Likely cause\: Invalid system DNS settings or no internet connection
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy shutting down.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_fi_FI.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_fi_FI.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Olet jo yhteydessä tälle palvelimelle\!
-velocity.error.already-connected-proxy=Olet jo yhteydessä tälle välityspalvelimelle\!
-velocity.error.already-connecting=Yrität jo yhdistää palvelimeen\!
+velocity.error.already-connected=Olet jo yhteydessä tälle palvelimelle!
+velocity.error.already-connected-proxy=Olet jo yhteydessä tälle välityspalvelimelle!
+velocity.error.already-connecting=Yrität jo yhdistää palvelimeen!
 velocity.error.cant-connect=<arg:0> ei saatu yhteyttä\: <arg:1>
 velocity.error.connecting-server-error=Yhteyttä palvelimeen <arg:0> ei voitu muodostaa. Yritä myöhemmin uudelleen.
 velocity.error.connected-server-error=Yhteydessäsi palvelimeen <arg:0> tapahtui virhe.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Yhtäkään pluginia ei ole asennettu.
 velocity.command.plugins-list=Pluginit\: <arg:0>
 velocity.command.plugin-tooltip-website=Verkkosivu\: <arg:0>
 velocity.command.plugin-tooltip-author=Tekijä\: <arg:0>
-velocity.command.plugin-tooltip-authors=Tekijät\: <arg:0>
-velocity.command.dump-uploading=Lähetetään kerättyjä tietoja...
-velocity.command.dump-send-error=Velocity-palvelimien kanssa kommunikoidessa tapahtui virhe. Palvelimet eivät ehkä ole tilapäisesti käytettävissä tai verkkoasetuksissa on ongelma. Löydät lisätietoja Velocity-palvelimesi lokista tai konsolista.
-velocity.command.dump-success=Luotiin anonyymi raportti, joka sisältää hyödyllistä tietoa tästä välityspalvelimesta. Jos jokin kehittäjä on pyytänyt sitä, voit jakaa seuraavan linkin heidän kanssaan\:
-velocity.command.dump-will-expire=Tämä linkki vanhenee muutaman päivän kuluttua.
-velocity.command.dump-server-error=Virhe tapahtui Velocity-palvelimissa ja tiedonkeruuta ei voitu suorittaa loppuun. Ota yhteyttä Velocityn henkilökuntaan liittyen tästä ongelmasta, ja lisää yksityiskohdat virheestä Velocityn konsolista tai palvelimen lokista.
-velocity.command.dump-offline=Todennäköinen syy\: DNS-asetukset ovat virheelliset tai internet-yhteyttä ei ole
 velocity.command.send-usage=/send <pelaaja> <palvelin>
 # Kick
 velocity.kick.shutdown=Sammutetaan välityspalvelinta.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_fr_FR.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_fr_FR.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Vous êtes déjà connecté(e) à ce serveur \!
-velocity.error.already-connected-proxy=Vous êtes déjà connecté(e) à ce proxy \!
-velocity.error.already-connecting=Vous êtes déjà en train d'essayer de vous connecter à un serveur \!
+velocity.error.already-connected=Vous êtes déjà connecté(e) à ce serveur !
+velocity.error.already-connected-proxy=Vous êtes déjà connecté(e) à ce proxy !
+velocity.error.already-connecting=Vous êtes déjà en train d'essayer de vous connecter à un serveur !
 velocity.error.cant-connect=Impossible de se connecter à <arg:0> \: <arg:1>
 velocity.error.connecting-server-error=Impossible de vous connecter à <arg:0>. Veuillez réessayer ultérieurement.
 velocity.error.connected-server-error=Votre connexion à <arg:0> a rencontré un problème.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Il n'y a aucun plugin actuellement installé.
 velocity.command.plugins-list=Plugins \: <arg:0>
 velocity.command.plugin-tooltip-website=Site Internet \: <arg:0>
 velocity.command.plugin-tooltip-author=Auteur \: <arg:0>
-velocity.command.plugin-tooltip-authors=Auteurs \: <arg:0>
-velocity.command.dump-uploading=Envoi des informations collectées...
-velocity.command.dump-send-error=Une erreur est survenue lors de la communication avec les serveurs Velocity. Soit les serveurs sont temporairement indisponibles, soit il y a un problème avec les paramètres de votre réseau. Vous trouverez plus d'informations dans le journal ou la console de votre serveur Velocity.
-velocity.command.dump-success=Un rapport anonyme contenant des informations utiles sur ce proxy a été créé. Si un développeur vous le demande, vous pouvez le partager avec le lien suivant \:
-velocity.command.dump-will-expire=Ce lien expirera dans quelques jours.
-velocity.command.dump-server-error=Une erreur s'est produite sur les serveurs Velocity et le dump n'a pas pu être terminé. Veuillez contacter l'équipe de Velocity et leur communiquer les détails sur cette erreur à partir de la console de Velocity ou du journal du serveur.
-velocity.command.dump-offline=Cause probable \: paramètres DNS non valides ou aucune connexion Internet
 velocity.command.send-usage=/send <joueur> <serveur>
 # Kick
 velocity.kick.shutdown=Arrêt du proxy.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_he_IL.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_he_IL.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=אתה כבר מחובר לשרת זה\!
-velocity.error.already-connected-proxy=אתה כבר מחובר ל- proxy זה\!
-velocity.error.already-connecting=אתה כבר מנסה להתחבר לשרת\!
+velocity.error.already-connected=אתה כבר מחובר לשרת זה!
+velocity.error.already-connected-proxy=אתה כבר מחובר ל- proxy זה!
+velocity.error.already-connecting=אתה כבר מנסה להתחבר לשרת!
 velocity.error.cant-connect=לא ניתן להתחבר ל- <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=לא ניתן לחבר אותך ל- <arg:0>. אנא נסה שנית מאוחר יותר.
 velocity.error.connected-server-error=החיבור שלך ל- <arg:0> נתקל בבעיה.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=לא מותקנים כעת תוספים.
 velocity.command.plugins-list=תוספים\: <arg:0>
 velocity.command.plugin-tooltip-website=אתר אינטרנט\: <arg:0>
 velocity.command.plugin-tooltip-author=יוצר\: <arg:0>
-velocity.command.plugin-tooltip-authors=יוצרים\: <arg:0>
-velocity.command.dump-uploading=מעלה מידע שנאסף...
-velocity.command.dump-send-error=התרחשה שגיאה בעת קיום תקשורת עם שרתי ה- Velocity. ייתכן שהשרתים אינם זמינים באופן זמני או שקיימת בעיה בהגדרות הרשת שלך. באפשרותך למצוא מידע נוסף ביומן הרישום או בקונסולה של שרת ה- Velocity שלך.
-velocity.command.dump-success=נוצר דוח אנונימיות המכיל מידע שימושי אודות proxy זה. אם מפתח ביקש זאת, באפשרותך לשתף איתם את הקישור הבא\:
-velocity.command.dump-will-expire=קישור זה יפוג בעוד מספר ימים.
-velocity.command.dump-server-error=התרחשה שגיאה בשרתי ה- Velocity ולא הייתה אפשרות להשלים את קובץ ה- dump. אנא צור קשר עם צוות ה- Velocity בנוגע לבעיה זו ולספק את הפרטים אודות שגיאה זו מקונסולה ה- Velocity או מיומן השרת.
-velocity.command.dump-offline=סביר להניח\: הגדרות DNS לא חוקיות של המערכת או ללא חיבור לאינטרנט
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy בתהליך כיבוי.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_hu_HU.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_hu_HU.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Már csatlakozva vagy ehhez a szerverhez\!
-velocity.error.already-connected-proxy=Már csatlakozva vagy ehhez a proxyhoz\!
-velocity.error.already-connecting=Jelenleg is csatlakozol egy szerverre\!
+velocity.error.already-connected=Már csatlakozva vagy ehhez a szerverhez!
+velocity.error.already-connected-proxy=Már csatlakozva vagy ehhez a proxyhoz!
+velocity.error.already-connecting=Jelenleg is csatlakozol egy szerverre!
 velocity.error.cant-connect=Nem lehet csatlakozni a(z) <arg:0> szerverhez\: <arg:1>
 velocity.error.connecting-server-error=Nem tudunk csatlakoztatni a(z) <arg:0> szerverhez. Kérlek próbáld újra később.
 velocity.error.connected-server-error=A kapcsolatod a(z) <arg:0> szerverhez hibába ütközött.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Jelenleg egyetlen plugin sincs telepítve.
 velocity.command.plugins-list=Pluginok\: <arg:0>
 velocity.command.plugin-tooltip-website=Weboldal\: <arg:0>
 velocity.command.plugin-tooltip-author=Készítő\: <arg:0>
-velocity.command.plugin-tooltip-authors=Készítők\: <arg:0>
-velocity.command.dump-uploading=Az összegyűjtött információ feltöltése...
-velocity.command.dump-send-error=Egy hiba lépett fel miközben kommunikálni próbáltunk a Velocity szerverekkel. Lehetséges, hogy a szerver(ek) ideiglenesen elérhetetlenek, vagy ez egy hiba a te hálózati beállításaiddal. Több információt a logban, vagy a Velocity konzoljában találsz.
-velocity.command.dump-success=Egy anonimizált jelentés sikeresen el lett készítve erről a proxyról. Ha egy fejlesztő kérte, akkor innen kimásolhatod a linket, és megoszthatod velük\: 
-velocity.command.dump-will-expire=Ez a link egy pár napon belül le fog járni.
-velocity.command.dump-server-error=Egy hiba lépett fel a Velocity szervereken, és a jelentést nem tudtuk elkészíteni. Kérlek lépj kapcsolatba egy Velocity személyzeti taggal ezzel a problémával kapcsolatban, és adj információt ezzel a hibával kapcsolatban a Velocity logokból, vagy a szerver konzolból.
-velocity.command.dump-offline=Valószínűleg a következő a hiba okozója\: Hibás DNS beállítások, vagy nincs internetkapcsolat.
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy shutting down.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_it_IT.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_it_IT.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Sei già connesso a questo server\!
-velocity.error.already-connected-proxy=Sei già connesso a questo proxy\!
-velocity.error.already-connecting=Stai già cercando di connetterti a un server\!
+velocity.error.already-connected=Sei già connesso a questo server!
+velocity.error.already-connected-proxy=Sei già connesso a questo proxy!
+velocity.error.already-connecting=Stai già cercando di connetterti a un server!
 velocity.error.cant-connect=Impossibile connettersi a <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Impossibile connetterti a <arg:0>. Prova più tardi.
 velocity.error.connected-server-error=La tua connessione a <arg:0> ha incontrato un problema.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Non ci sono plugin installati.
 velocity.command.plugins-list=Plugins\: <arg:0>
 velocity.command.plugin-tooltip-website=Sito web\: <arg:0>
 velocity.command.plugin-tooltip-author=Autore\: <arg:0>
-velocity.command.plugin-tooltip-authors=Autori\: <arg:0>
-velocity.command.dump-uploading=Caricamento informazioni raccolte...
-velocity.command.dump-send-error=Si è verificato un errore durante la comunicazione con i server Velocity. I server potrebbero essere temporaneamente non disponibili o c'è un problema con le impostazioni di rete. Puoi trovare maggiori informazioni nel log o nella console del tuo server Velocity.
-velocity.command.dump-success=Creato un report anonimo contenente informazioni utili su questo proxy. Se uno sviluppatore lo richiede, è possibile condividere con loro il seguente link\:
-velocity.command.dump-will-expire=Questo link scadrà tra pochi giorni.
-velocity.command.dump-server-error=Si è verificato un errore sui server Velocity e il dump non può essere completato. Contattare lo staff di Velocity per questo problema e fornire i dettagli relativi a questo errore dalla console di Velocity o dai log del server.
-velocity.command.dump-offline=Probabile causa\: Impostazioni DNS di sistema non valide o nessuna connessione internet
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Il server è in fase di arresto.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_ja_JP.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_ja_JP.properties
@@ -53,13 +53,6 @@ velocity.command.no-plugins=現在インストールされているプラグイ�
 velocity.command.plugins-list=プラグイン\: <arg:0>
 velocity.command.plugin-tooltip-website=ウェブサイト\: <arg:0>
 velocity.command.plugin-tooltip-author=作者\: <arg:0>
-velocity.command.plugin-tooltip-authors=作者\: <arg:0>
-velocity.command.dump-uploading=収集した情報をアップロードしています...
-velocity.command.dump-send-error=Velocityサーバーとの通信中にエラーが発生しました。サーバーが一時的に利用できないか、ネットワーク設定に問題がある可能性があります。詳細はコンソールまたはサーバーログで確認できます。
-velocity.command.dump-success=このプロキシに関する有用な情報を含む匿名化されたレポートを作成しました。開発者が要求した場合は、次のリンクを共有してください\:
-velocity.command.dump-will-expire=このリンクは数日後に期限切れになります。
-velocity.command.dump-server-error=Velocityサーバーでエラーが発生し、ダンプが完了できませんでした。 この問題についてはVelocityスタッフに連絡し、コンソールまたはサーバーログからこのエラーの詳細を提供してください。
-velocity.command.dump-offline=考えられる原因\: システムのDNS設定が無効であるか、インターネットに接続されていません
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=プロキシをシャットダウンしています。

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_ko_KR.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_ko_KR.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=이미 이 서버에 연결되어 있습니다\!
-velocity.error.already-connected-proxy=이미 이 프록시에 연결되어 있습니다\!
-velocity.error.already-connecting=이미 이 서버에 연결하는 중입니다\!
+velocity.error.already-connected=이미 이 서버에 연결되어 있습니다!
+velocity.error.already-connected-proxy=이미 이 프록시에 연결되어 있습니다!
+velocity.error.already-connecting=이미 이 서버에 연결하는 중입니다!
 velocity.error.cant-connect=<arg:0>에 연결할 수 없습니다\: <arg:1>
 velocity.error.connecting-server-error=<arg:0>에 연결할 수 없습니다. 나중에 다시 시도하세요.
 velocity.error.connected-server-error=<arg:0>에 연결하던 도중 문제가 발생했습니다.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=설치된 플러그인이 없습니다.
 velocity.command.plugins-list=플러그인\: <arg:0>
 velocity.command.plugin-tooltip-website=웹사이트\: <arg:0>
 velocity.command.plugin-tooltip-author=제작자\: <arg:0>
-velocity.command.plugin-tooltip-authors=제작자\: <arg:0>
-velocity.command.dump-uploading=수집된 정보를 업로드하는 중...
-velocity.command.dump-send-error=Velocity 서버와 통신하는 동안 오류가 발생했습니다. 서버를 일시적으로 사용할 수 없거나 네트워크 설정에 문제가 있을 수 있습니다. Velocity 서버의 로그 또는 콘솔에서 자세한 정보를 찾아볼 수 있습니다.
-velocity.command.dump-success=이 프록시와 관련된 유용한 정보를 담은 익명 보고서를 만들었습니다. 만약 개발자가 요청한다면, 다음 링크를 그들에게 공유해보세요\:
-velocity.command.dump-will-expire=이 링크는 며칠 후에 만료됩니다.
-velocity.command.dump-server-error=Velocity 서버에 문제가 발생했으며 덤프가 완료되지 않았습니다. Velocity 스태프에게 연락해 이 문제에 대해 설명하고 Velocity 콘솔 또는 서버 로그를 제공해주세요.
-velocity.command.dump-offline=가능성 높은 원인\: 잘못된 DNS 설정 또는 인터넷 연결 없음
 velocity.command.send-usage=/send <플레이어> <서버>
 # Kick
 velocity.kick.shutdown=프록시가 종료됩니다.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_nb_NO.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_nb_NO.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Du er allerede tilkoblet denne serveren\!
-velocity.error.already-connected-proxy=Du er allerede tilkoblet denne proxyen\!
-velocity.error.already-connecting=Du tilkobles allerede en server\!
+velocity.error.already-connected=Du er allerede tilkoblet denne serveren!
+velocity.error.already-connected-proxy=Du er allerede tilkoblet denne proxyen!
+velocity.error.already-connecting=Du tilkobles allerede en server!
 velocity.error.cant-connect=Kan ikke koble til <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Kan ikke koble deg til <arg:0>. Vennligst prøv igjen senere.
 velocity.error.connected-server-error=Din oppkobling mot <arg:0> traff et uventet problem.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Ingen plugin er installert.
 velocity.command.plugins-list=Plugins\: <arg:0>
 velocity.command.plugin-tooltip-website=Hjemmeside\: <arg:0>
 velocity.command.plugin-tooltip-author=Skaper\: <arg:0>
-velocity.command.plugin-tooltip-authors=Skapere\: <arg:0>
-velocity.command.dump-uploading=Laster opp diagnostisk informasjon...
-velocity.command.dump-send-error=En feil oppstod under kommunikasjon med Velocityserverne. Enten er disse serverne midlertidig utilgjengelige, ellers er det noe galt med dine nettverksinnstillinger. Du kan finne mer informasjon i din logg eller i konsollen på Velocityservern.
-velocity.command.dump-success=Skapte en anonymisert rapport med utfyllende informasjon om denne proxyen. Om en utvikler forespurte den, kan du dele følgende lenke med dem\:
-velocity.command.dump-will-expire=Denne lenken kommer til å fjernes om noen dager.
-velocity.command.dump-server-error=En feil oppstod på Velocityserverne og en diagnostisk informasjonsinnsamling kunne ikke gennomføres. Vennligst kontakt organisasjonen bak Velocity om problemet og oppgi alle detaljene du kan finne i Velocitykonsollen eller loggen.
-velocity.command.dump-offline=Sannsynlig årsak\: Ugyldige DNS innstillinger eller manglende internettforbindelse
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy slår seg av.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_nl_NL.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_nl_NL.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Je bent al met deze server verbonden\!
-velocity.error.already-connected-proxy=Je bent al met deze proxy verbonden\!
-velocity.error.already-connecting=Je probeert al verbinding te maken met een server\!
+velocity.error.already-connected=Je bent al met deze server verbonden!
+velocity.error.already-connected-proxy=Je bent al met deze proxy verbonden!
+velocity.error.already-connecting=Je probeert al verbinding te maken met een server!
 velocity.error.cant-connect=Kan geen verbinding maken met <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Kan je niet verbinden met <arg:0>. Probeer het later opnieuw.
 velocity.error.connected-server-error=Er is een probleem opgetreden bij je verbinding met <arg:0>.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Er zijn momenteel geen plugins geïnstalleerd.
 velocity.command.plugins-list=Plugins\: <arg:0>
 velocity.command.plugin-tooltip-website=Website\: <arg:0>
 velocity.command.plugin-tooltip-author=Auteur\: <arg:0>
-velocity.command.plugin-tooltip-authors=Auteurs\: <arg:0>
-velocity.command.dump-uploading=Verzamelde informatie uploaden...
-velocity.command.dump-send-error=Er is een fout opgetreden tijdens de communicatie met de Velocity-servers. De servers zijn mogelijk tijdelijk niet beschikbaar of er is een probleem met je netwerkinstellingen. Je kunt meer informatie vinden in de logs of de console van je Velocity-server.
-velocity.command.dump-success=Een anoniem rapport is gemaakt met nuttige informatie over deze proxy. Als een ontwikkelaar dit heeft verzocht, kun je de volgende link delen\:
-velocity.command.dump-will-expire=Deze link verloopt over een paar dagen.
-velocity.command.dump-server-error=Er is een fout opgetreden op de Velocity-servers en de dump kan niet worden voltooid. Neem contact op met het Velocity team over dit probleem en geef de details over deze fout op vanuit de Velocity-console of de logs.
-velocity.command.dump-offline=Waarschijnlijke oorzaak\: ongeldige DNS-instellingen van het systeem of geen internetverbinding
 velocity.command.send-usage=/send <speler> <server>
 # Kick
 velocity.kick.shutdown=Proxy wordt afgesloten.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_nn_NO.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_nn_NO.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Du er allereie tilkopla denne sørvaren\!
-velocity.error.already-connected-proxy=Du er allereie tilkopla denne proxyen\!
-velocity.error.already-connecting=Du tilkoplas allereie ein sørvar\!
+velocity.error.already-connected=Du er allereie tilkopla denne sørvaren!
+velocity.error.already-connected-proxy=Du er allereie tilkopla denne proxyen!
+velocity.error.already-connecting=Du tilkoplas allereie ein sørvar!
 velocity.error.cant-connect=Kan ikkje kopla til <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Kan ikkje kopla deg til <arg:0>. Prøv gjerne igjen seinare.
 velocity.error.connected-server-error=Din oppkopling mot <arg:0> trefte eit uventa problem.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Det er ingen plugins installert.
 velocity.command.plugins-list=Plugins\: <arg:0>
 velocity.command.plugin-tooltip-website=Heimeside\: <arg:0>
 velocity.command.plugin-tooltip-author=Skapar\: <arg:0>
-velocity.command.plugin-tooltip-authors=Skaparar\: <arg:0>
-velocity.command.dump-uploading=Uploading gathered information...
-velocity.command.dump-send-error=An error occurred while communicating with the Velocity servers. The servers may be temporarily unavailable or there is an issue with your network settings. You can find more information in the log or console of your Velocity server.
-velocity.command.dump-success=Created an anonymised report containing useful information about this proxy. If a developer requested it, you may share the following link with them\:
-velocity.command.dump-will-expire=This link will expire in a few days.
-velocity.command.dump-server-error=An error occurred on the Velocity servers and the dump could not be completed. Please contact the Velocity staff about this problem and provide the details about this error from the Velocity console or server log.
-velocity.command.dump-offline=Likely cause\: Invalid system DNS settings or no internet connection
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy shutting down.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_pl_PL.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_pl_PL.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Jesteś już połączony z tym serwerem\!
-velocity.error.already-connected-proxy=Jesteś już połączony z tym proxy\!
-velocity.error.already-connecting=Jesteś już w trakcie łączenia się do serwera\!
+velocity.error.already-connected=Jesteś już połączony z tym serwerem!
+velocity.error.already-connected-proxy=Jesteś już połączony z tym proxy!
+velocity.error.already-connecting=Jesteś już w trakcie łączenia się do serwera!
 velocity.error.cant-connect=Nie udało się połączyć z serwerem <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Nie udało się połączyć cię z serwerem <arg:0>. Spróbuj ponownie później.
 velocity.error.connected-server-error=Podczas łączenia cię z serwerem <arg:0> wystąpił problem.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Obecnie nie ma zainstalowanych żadnych pluginów.
 velocity.command.plugins-list=Pluginy\: <arg:0>
 velocity.command.plugin-tooltip-website=Strona internetowa\: <arg:0>
 velocity.command.plugin-tooltip-author=Autor\: <arg:0>
-velocity.command.plugin-tooltip-authors=Autorzy\: <arg:0>
-velocity.command.dump-uploading=Przesyłanie zebranych informacji…
-velocity.command.dump-send-error=Wystąpił błąd podczas komunikacji z serwerami Velocity. Serwery mogą być chwilowo niedostępne lub wystąpił problem z ustawieniami sieci. Możesz znaleźć więcej informacji w logach lub konsoli swojego serwera Velocity.
-velocity.command.dump-success=Utworzono anonimowy raport zawierający przydatne informacje o tym proxy. Możesz udostępnić deweloperowi następujący odnośnik, jeśli o niego poprosił\:
-velocity.command.dump-will-expire=Ten odnośnik wygaśnie za kilka dni.
-velocity.command.dump-server-error=Wystąpił błąd na serwerach Velocity i nie udało się przesłać raportu. Skontaktuj się z zespołem Velocity w sprawie tego problemu i podaj szczegółowe informacje o tym błędzie z konsoli Velocity lub logów serwera.
-velocity.command.dump-offline=Prawdopodobna przyczyna\: nieprawidłowe ustawienia DNS lub brak połączenia internetowego
 velocity.command.send-usage=/send <gracz> <serwer>
 # Kick
 velocity.kick.shutdown=Wyłączanie serwera proxy.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_pt_BR.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_pt_BR.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Você já está conectado a esse servidor\!
-velocity.error.already-connected-proxy=Você já está conectado a esse proxy\!
-velocity.error.already-connecting=Você já está tentando se conectar a um servidor\!
+velocity.error.already-connected=Você já está conectado a esse servidor!
+velocity.error.already-connected-proxy=Você já está conectado a esse proxy!
+velocity.error.already-connecting=Você já está tentando se conectar a um servidor!
 velocity.error.cant-connect=Não foi possível se conectar a <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Não foi possível conectar você a <arg:0>. Tente novamente mais tarde.
 velocity.error.connected-server-error=Sua conexão com o servidor <arg:0> encontrou um problema.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Não há plugins instalados atualmente.
 velocity.command.plugins-list=Plugins\: <arg:0>
 velocity.command.plugin-tooltip-website=Site\: <arg:0>
 velocity.command.plugin-tooltip-author=Autor\: <arg:0>
-velocity.command.plugin-tooltip-authors=Autores\: <arg:0>
-velocity.command.dump-uploading=Enviando informações coletadas...
-velocity.command.dump-send-error=Ocorreu um erro ao se comunicar com os servidores Velocity. Os servidores podem estar temporariamente indisponíveis ou há um problema com suas configurações de rede. Você pode encontrar mais informações no log ou no console de seu servidor Velocity.
-velocity.command.dump-success=Foi criado um relatório anônimo contendo informações úteis sobre este proxy. Se um desenvolvedor o solicitou, você pode compartilhar o seguinte link com eles\:
-velocity.command.dump-will-expire=Este link irá expirar em alguns dias.
-velocity.command.dump-server-error=Ocorreu um erro nos servidores Velocity e o dump não pôde ser concluído. Por favor, entre em contato com a staff do Velocity sobre este problema e forneça detalhes sobre esse erro a partir do log do console Velocity ou do servidor.
-velocity.command.dump-offline=Causa provável\: configurações de DNS do sistema inválidas ou sem conexão de internet
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy desligando.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_ro_RO.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_ro_RO.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=You are already connected to this server\!
-velocity.error.already-connected-proxy=You are already connected to this proxy\!
-velocity.error.already-connecting=You are already trying to connect to a server\!
+velocity.error.already-connected=You are already connected to this server!
+velocity.error.already-connected-proxy=You are already connected to this proxy!
+velocity.error.already-connecting=You are already trying to connect to a server!
 velocity.error.cant-connect=Unable to connect to <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Unable to connect you to <arg:0>. Please try again later.
 velocity.error.connected-server-error=Your connection to <arg:0> encountered a problem.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=There are no plugins currently installed.
 velocity.command.plugins-list=Plugins\: <arg:0>
 velocity.command.plugin-tooltip-website=Website\: <arg:0>
 velocity.command.plugin-tooltip-author=Author\: <arg:0>
-velocity.command.plugin-tooltip-authors=Authors\: <arg:0>
-velocity.command.dump-uploading=Uploading gathered information...
-velocity.command.dump-send-error=An error occurred while communicating with the Velocity servers. The servers may be temporarily unavailable or there is an issue with your network settings. You can find more information in the log or console of your Velocity server.
-velocity.command.dump-success=Created an anonymised report containing useful information about this proxy. If a developer requested it, you may share the following link with them\:
-velocity.command.dump-will-expire=This link will expire in a few days.
-velocity.command.dump-server-error=An error occurred on the Velocity servers and the dump could not be completed. Please contact the Velocity staff about this problem and provide the details about this error from the Velocity console or server log.
-velocity.command.dump-offline=Likely cause\: Invalid system DNS settings or no internet connection
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy se închide.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_ru_RU.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_ru_RU.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Вы уже подключены к этому серверу\!
-velocity.error.already-connected-proxy=Игрок с таким ником уже играет на сервере\!
-velocity.error.already-connecting=Вы уже подключаетесь к серверу\!
+velocity.error.already-connected=Вы уже подключены к этому серверу!
+velocity.error.already-connected-proxy=Игрок с таким ником уже играет на сервере!
+velocity.error.already-connecting=Вы уже подключаетесь к серверу!
 velocity.error.cant-connect=Не удалось подключиться к серверу <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Не удалось подключить вас к серверу <arg:0>. Пожалуйста, попробуйте снова через некоторое время.
 velocity.error.connected-server-error=С вашим подключением к серверу <arg:0> возникла проблема.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Ни одного плагина не установ
 velocity.command.plugins-list=Плагины\: <arg:0>
 velocity.command.plugin-tooltip-website=Веб-сайт\: <arg:0>
 velocity.command.plugin-tooltip-author=Автор\: <arg:0>
-velocity.command.plugin-tooltip-authors=Авторы\: <arg:0>
-velocity.command.dump-uploading=Загрузка полученной информации...
-velocity.command.dump-send-error=Произошла ошибка при попытке связаться с серверами Velocity. Возможно, серверы временно недоступны или ваша сеть настроена неправильно. Более подробную информацию можно найти в логах или консоли вашего сервера Velocity.
-velocity.command.dump-success=Создан анонимный отчет, содержащий полезную информацию об этом прокси. Если этот отчёт запросил разработчик, вы можете поделиться с ним следующей ссылкой\:
-velocity.command.dump-will-expire=Срок действия этой ссылки истечёт через несколько дней.
-velocity.command.dump-server-error=Не удалось завершить дамп, так как на серверах Velocity произошла ошибка. Пожалуйста, свяжитесь с командой Velocity по поводу этой проблемы и сообщите подробности, а также предоставьте подробную информацию об этой ошибке из консоли Velocity или логов сервера.
-velocity.command.dump-offline=Вероятная причина\: Неверные настройки DNS или отсутствие подключения к интернету
 velocity.command.send-usage=/send <никнейм> <сервер>
 # Kick
 velocity.kick.shutdown=Прокси-сервер выключается.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_sk_SK.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_sk_SK.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Na tento server si už pripojený\!
-velocity.error.already-connected-proxy=Na tento proxy server si už pripojený\!
-velocity.error.already-connecting=Už sa pokúšaš o pripojenie na server\!
+velocity.error.already-connected=Na tento server si už pripojený!
+velocity.error.already-connected-proxy=Na tento proxy server si už pripojený!
+velocity.error.already-connecting=Už sa pokúšaš o pripojenie na server!
 velocity.error.cant-connect=Nepodarilo sa pripojiť na <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Nepodarilo sa pripojiť ťa na <arg:0>. Skús to prosím neskôr.
 velocity.error.connected-server-error=V tvojom pripojení na <arg:0> sa vyskytla chyba.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Aktuálne nie sú nainštalované žiadne pluginy.
 velocity.command.plugins-list=Pluginy\: <arg:0>
 velocity.command.plugin-tooltip-website=Webstránka\: <arg:0>
 velocity.command.plugin-tooltip-author=Autor\: <arg:0>
-velocity.command.plugin-tooltip-authors=Autori\: <arg:0>
-velocity.command.dump-uploading=Nahrávanie získaných informácií...
-velocity.command.dump-send-error=Nastala chyba pri komunikácii s Velocity servermi. Servery môžu byť dočasne nedostupné alebo je chyba v prístupe na internet. Viac informácií je v logu a v konzole tvojho Velocity servera.
-velocity.command.dump-success=Bol vytvorený anonymný záznam o tomto serveri. Ak si ho vyžiadal developer, môžeš mu poslať nasledujúci odkaz\:
-velocity.command.dump-will-expire=Tento odkaz vyprší za niekoľko dní.
-velocity.command.dump-server-error=Nastala chyba vo Velocity serveroch a záznam nebolo možné vytvoriť. Prosím kontaktuj tím Velocity a poskytni detaily o tejto chybe z konzoly Velocity alebo z logu servera.
-velocity.command.dump-offline=Pravdepodobná príčina\: Neplatné systémové nastavenie DNS alebo chýbajúce pripojenie na internet
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy shutting down.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_sq_AL.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_sq_AL.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Ju tashmë jeni lidhur me këtë server\!
-velocity.error.already-connected-proxy=Ju jeni lidhur tashmë me këtë përfaqësues\!
-velocity.error.already-connecting=Ju tashmë po përpiqeni të lidheni me një server\!
+velocity.error.already-connected=Ju tashmë jeni lidhur me këtë server!
+velocity.error.already-connected-proxy=Ju jeni lidhur tashmë me këtë përfaqësues!
+velocity.error.already-connecting=Ju tashmë po përpiqeni të lidheni me një server!
 velocity.error.cant-connect=Nuk mund të lidhet me <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Nuk mund të të lidh me <arg:0>. Ju lutemi provoni përsëri më vonë.
 velocity.error.connected-server-error=Lidhja juaj me <arg:0> hasi një problem.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=There are no plugins currently installed.
 velocity.command.plugins-list=Plugins\: <arg:0>
 velocity.command.plugin-tooltip-website=Website\: <arg:0>
 velocity.command.plugin-tooltip-author=Author\: <arg:0>
-velocity.command.plugin-tooltip-authors=Authors\: <arg:0>
-velocity.command.dump-uploading=Uploading gathered information...
-velocity.command.dump-send-error=An error occurred while communicating with the Velocity servers. The servers may be temporarily unavailable or there is an issue with your network settings. You can find more information in the log or console of your Velocity server.
-velocity.command.dump-success=Created an anonymised report containing useful information about this proxy. If a developer requested it, you may share the following link with them\:
-velocity.command.dump-will-expire=This link will expire in a few days.
-velocity.command.dump-server-error=An error occurred on the Velocity servers and the dump could not be completed. Please contact the Velocity staff about this problem and provide the details about this error from the Velocity console or server log.
-velocity.command.dump-offline=Likely cause\: Invalid system DNS settings or no internet connection
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy shutting down.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_sr_CS.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_sr_CS.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Već ste povezani na ovaj server\!
-velocity.error.already-connected-proxy=Već ste povezani na ovaj proxy\!
-velocity.error.already-connecting=Već pokušavate da se povežete na server\!
+velocity.error.already-connected=Već ste povezani na ovaj server!
+velocity.error.already-connected-proxy=Već ste povezani na ovaj proxy!
+velocity.error.already-connecting=Već pokušavate da se povežete na server!
 velocity.error.cant-connect=Nije moguće povezati se na <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Nije moguće povezati Vas na <arg:0>. Molimo pokušajte ponovo kasnije.
 velocity.error.connected-server-error=Došlo je do problema sa Vašom vezom sa <arg:0>.
@@ -51,10 +51,3 @@ velocity.command.no-plugins=Trenutno nema instaliranih plugin-a.
 velocity.command.plugins-list=Plugin-i\: <arg:0>
 velocity.command.plugin-tooltip-website=Web stranica\: <arg:0>
 velocity.command.plugin-tooltip-author=Autor\: <arg:0>
-velocity.command.plugin-tooltip-authors=Autori\: <arg:0>
-velocity.command.dump-uploading=Otpremanje prikupljenih informacija...
-velocity.command.dump-send-error=Dogodila se greška pri komunikaciji sa Velocity serverima. Serveri su ili trenutno nedostupni, ili postoji problem sa Vašim mrežnim podešavanjima. Možete saznati više informacija u log-u ili konzoli Vašeg Velocity servera.
-velocity.command.dump-success=Kreiran anonimiziran izveštaj koji sadrži korisne informacije o ovom proxy-u. Ako ga developer zatraži, možete mu poslati ovaj link\:
-velocity.command.dump-will-expire=Ovaj link će isteći za nekoliko dana.
-velocity.command.dump-server-error=Dogodila se greška na Velocity serverima i nije moguće završiti dump. Molimo kontaktirajte Velocity staff u pitanju ovog problema i pružite detalje o ovoj grešci iz Velocity konzole ili server log-a.
-velocity.command.dump-offline=Verovatan uzrok\: Nevalidan sistem DNS podešavanja ili nema internet konekcije

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_sr_Latn.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_sr_Latn.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Već ste povezani na ovaj server\!
-velocity.error.already-connected-proxy=Već ste povezani na ovaj proxy\!
-velocity.error.already-connecting=Već pokušavate da se povežete na server\!
+velocity.error.already-connected=Već ste povezani na ovaj server!
+velocity.error.already-connected-proxy=Već ste povezani na ovaj proxy!
+velocity.error.already-connecting=Već pokušavate da se povežete na server!
 velocity.error.cant-connect=Nije moguće povezati se na <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Nije moguće povezati Vas na <arg:0>. Molimo pokušajte ponovo kasnije.
 velocity.error.connected-server-error=Došlo je do problema sa Vašom vezom sa <arg:0>.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Trenutno nema instaliranih plugin-a.
 velocity.command.plugins-list=Plugin-i\: <arg:0>
 velocity.command.plugin-tooltip-website=Web stranica\: <arg:0>
 velocity.command.plugin-tooltip-author=Autor\: <arg:0>
-velocity.command.plugin-tooltip-authors=Autori\: <arg:0>
-velocity.command.dump-uploading=Otpremanje prikupljenih informacija...
-velocity.command.dump-send-error=Dogodila se greška pri komunikaciji sa Velocity serverima. Serveri su ili trenutno nedostupni, ili postoji problem sa Vašim mrežnim podešavanjima. Možete saznati više informacija u log-u ili konzoli Vašeg Velocity servera.
-velocity.command.dump-success=Kreiran anonimiziran izveštaj koji sadrži korisne informacije o ovom proxy-u. Ako ga developer zatraži, možete mu poslati ovaj link\:
-velocity.command.dump-will-expire=Ovaj link će isteći za nekoliko dana.
-velocity.command.dump-server-error=Dogodila se greška na Velocity serverima i nije moguće završiti dump. Molimo kontaktirajte Velocity staff u pitanju ovog problema i pružite detalje o ovoj grešci iz Velocity konzole ili server log-a.
-velocity.command.dump-offline=Verovatan uzrok\: Nevalidan sistem DNS podešavanja ili nema internet konekcije
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy shutting down.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_sv_SE.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_sv_SE.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Du är redan ansluten till den här servern\!
-velocity.error.already-connected-proxy=Du är redan ansluten till den här proxyn\!
-velocity.error.already-connecting=Du försöker redan ansluta till en server\!
+velocity.error.already-connected=Du är redan ansluten till den här servern!
+velocity.error.already-connected-proxy=Du är redan ansluten till den här proxyn!
+velocity.error.already-connecting=Du försöker redan ansluta till en server!
 velocity.error.cant-connect=Det går inte att ansluta till <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Det går inte att ansluta dig till <arg:0>. Snälla försök igen senare.
 velocity.error.connected-server-error=Din anslutning till <arg:0> stötte på ett problem.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Det finns inga tillägg installerade.
 velocity.command.plugins-list=Tillägg\: <arg:0>
 velocity.command.plugin-tooltip-website=Webbsida\: <arg:0>
 velocity.command.plugin-tooltip-author=Utgivare\: <arg:0>
-velocity.command.plugin-tooltip-authors=Utgivare\: <arg:0>
-velocity.command.dump-uploading=Laddar upp insamlad information...
-velocity.command.dump-send-error=Ett fel uppstod under kommunikationen med Velocity servrarna. Servrarna kan vara tillfälligt otillgängliga eller så finns det ett problem med dina nätverksinställningar. Du kan hitta mer information i loggen eller konsolen på din Velocity server.
-velocity.command.dump-success=Skapade en anonymiserad rapport med användbar information om denna proxy. Om en utvecklare begärde det, kan du dela följande länk med dem\:
-velocity.command.dump-will-expire=Denna länk kommer att gå ut om några dagar.
-velocity.command.dump-server-error=Ett fel uppstod på Velocity servrarna och dumpen kunde inte slutföras. Vänligen kontakta Velocity personalen om detta problem och ge dem information om detta fel från Velocity konsolen eller serverloggen.
-velocity.command.dump-offline=Sannolik orsak\: Ogiltiga system DNS inställningar eller ingen internetanslutning
 velocity.command.send-usage=/send <spelare> <server>
 # Kick
 velocity.kick.shutdown=Proxy stänger ner.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_tl_PH.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_tl_PH.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Nakakonekta ka na sa serbidor na ito\!
-velocity.error.already-connected-proxy=Nakakonekta ka na sa proxy na ito\!
-velocity.error.already-connecting=Sinusubukan mo na makakonekta sa isang serbidor\!
+velocity.error.already-connected=Nakakonekta ka na sa serbidor na ito!
+velocity.error.already-connected-proxy=Nakakonekta ka na sa proxy na ito!
+velocity.error.already-connecting=Sinusubukan mo na makakonekta sa isang serbidor!
 velocity.error.cant-connect=Hindi makakonekta sa <arg:0> dahil <arg:1>
 velocity.error.connecting-server-error=Hindi ka makakonekta sa <arg:0>. Paki-ulitin mo ulit na mamaya.
 velocity.error.connected-server-error=Maencounter isang problema ang koneksyon mo sa <arg:0>.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Walang plugin nang naka-install.
 velocity.command.plugins-list=Mga plugin\: <arg:0>
 velocity.command.plugin-tooltip-website=Website\: <arg:0>
 velocity.command.plugin-tooltip-author=Autor\: <arg:0>
-velocity.command.plugin-tooltip-authors=Mga autor\: <arg:0>
-velocity.command.dump-uploading=Inu-upload ang ipong impormasyon...
-velocity.command.dump-send-error=Nangyari isang pagkakamali sa panahon ng koneksiyon kasama ang mga serbidor ng Velocity. Baka hindi magagamit na pansamantalang ang mga serbidor o may isang isyu sa mga network settings mo. Hinapin mo mas impormasyon sa log o console sa serbidor ng Velocity mo.
-velocity.command.dump-success=Lumikha isang report ng hindi nagpapakilala ng may impormasyon mahalaga tungkol sa proxy ng ito. Kung hingin ito ng developer, makashare ka ang link na ito kasama siya\:
-velocity.command.dump-will-expire=Magwakas ang link na ito sa ilang araw.
-velocity.command.dump-server-error=Nangyari isang pagkakamali sa mga serbidor ng Velocity at hindi nakakumpleto ang dump. Paki-kumontak ka ng staff ng Velocity tungkol sa problema ng ito at ka maglaan ang mga detalye ng pagkakamali ng ito mula sa konsole ng Velocity o log ng serbidor.
-velocity.command.dump-offline=Ang malamang sanhi\: Hindi wasto ang mga setting ng DNS sa system mo o wala koneksiyon ka sa Internet
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy shutting down.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_tr_TR.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_tr_TR.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Bu sunucuya zaten bağlısın\!
-velocity.error.already-connected-proxy=Bu sunucuya zaten bağlısın\!
-velocity.error.already-connecting=Bu sunucuya zaten bağlanmaya çalışıyorsun\!
+velocity.error.already-connected=Bu sunucuya zaten bağlısın!
+velocity.error.already-connected-proxy=Bu sunucuya zaten bağlısın!
+velocity.error.already-connecting=Bu sunucuya zaten bağlanmaya çalışıyorsun!
 velocity.error.cant-connect=<arg:0>\:<arg:1> ile bağlantı kurulamadı
 velocity.error.connecting-server-error=Seni <arg:0>'ye bağlayamadık. Lütfen daha sonra tekrar deneyiniz.
 velocity.error.connected-server-error=<arg:0> ile bağlantında bir problem meydana geldi.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Yüklenmiş herhangi bir eklenti yok.
 velocity.command.plugins-list=Eklentiler\: <arg:0>
 velocity.command.plugin-tooltip-website=Website\: <arg:0>
 velocity.command.plugin-tooltip-author=Yapımcı\: <arg:0>
-velocity.command.plugin-tooltip-authors=Yapımcılar\: <arg:0>
-velocity.command.dump-uploading=Toplanılan bilgiler yükleniyor...
-velocity.command.dump-send-error=Velocity sunucuları ile iletişim sırasında bir hata oluştu. Sunucular geçici olarak kullanılamıyor olabilir veya ağ ayarlarınızla ilgili bir sorun olabilir. Velocity sunucunuzun logunda veya konsolunda daha fazla bilgi bulabilirsiniz.
-velocity.command.dump-success=Bu proxy hakkında faydalı bilgiler içeren anonim bir rapor oluşturdu. Bir geliştirici talep ettiyse, aşağıdaki bağlantıyı onlarla paylaşabilirsiniz\:
-velocity.command.dump-will-expire=Bu bağlantı birkaç gün içinde geçersiz olacak.
-velocity.command.dump-server-error=Velocity sunucularında bir hata oluştu ve döküm tamamlanamadı. Lütfen bu sorunla ilgili olarak Velocity ekibiyle iletişime geçin ve bu hatayla ilgili ayrıntıları Velocity konsolundan veya sunucu logundan sağlayın.
-velocity.command.dump-offline=Olası neden\: Geçersiz sistem DNS ayarları veya internet bağlantısı yok
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy kapatılıyor.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_uk_UA.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_uk_UA.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Ви вже підключені до цього серверу\!
-velocity.error.already-connected-proxy=Ви вже приєднані до даного проксі\!
-velocity.error.already-connecting=Ви вже приєднуєтесь до сервера\!
+velocity.error.already-connected=Ви вже підключені до цього серверу!
+velocity.error.already-connected-proxy=Ви вже приєднані до даного проксі!
+velocity.error.already-connecting=Ви вже приєднуєтесь до сервера!
 velocity.error.cant-connect=Не вдалося приєднатись до сервера <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Не вдалося приєднати вас до сервера <arg:0>. Будь ласка, спробуйте пізніше.
 velocity.error.connected-server-error=З вашим приєднанням до сервера <arg:0> виникла проблема.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Плагіни відсутні.
 velocity.command.plugins-list=Плагіни\: <arg:0>
 velocity.command.plugin-tooltip-website=Веб-сайт\: <arg:0>
 velocity.command.plugin-tooltip-author=Автор\: <arg:0>
-velocity.command.plugin-tooltip-authors=Автори\: <arg:0>
-velocity.command.dump-uploading=Завантаження отриманої інформації...
-velocity.command.dump-send-error=Під час зв'язку з серверами Velocity виникла помилка. Можливо, сервери тимчасово недоступні або проблема з налаштування ми вашої мережі. Більше інформації ви можете знайти в журнвлі або консолі вашого серверу Velocity.
-velocity.command.dump-success=Створено анонімний звіт, що містить корисну інформацію про проксі. Якщо цей звіт запросив розробник, ви можете поділитися з ним наступним посиланням\:
-velocity.command.dump-will-expire=Термін дії цього посилання спливе за кілька днів.
-velocity.command.dump-server-error=На серверах Velocity сталася помилка і дамп не вдалося завершити. Будь ласка, зв'яжіться зі співробітниками Velocity з приводу цієї проблеми та повідомте подробиці, а також надайте детальну інформацію про цю помилку з консолі Velocity чи журналу сервера.
-velocity.command.dump-offline=Ймовірна причина\: Неправильні налаштування DNS або відсутність підключення до Інтернету
 velocity.command.send-usage=/send <гравець> <сервер>
 # Kick
 velocity.kick.shutdown=Проксі вимкнено.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_vi_VN.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_vi_VN.properties
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=Bạn đã kết nối đến máy chủ này\!
-velocity.error.already-connected-proxy=Bạn đã kết nối đến proxy này\!
-velocity.error.already-connecting=Bạn đang kết nối đến một máy chủ\!
+velocity.error.already-connected=Bạn đã kết nối đến máy chủ này!
+velocity.error.already-connected-proxy=Bạn đã kết nối đến proxy này!
+velocity.error.already-connecting=Bạn đang kết nối đến một máy chủ!
 velocity.error.cant-connect=Không thể kết nối đến <arg:0>\: <arg:1>
 velocity.error.connecting-server-error=Không thể kết nối bạn đến <arg:0>. Vui lòng thử lại sau.
 velocity.error.connected-server-error=Kết nối của bạn đến <arg:0> đã gặp một vấn đề.
@@ -53,13 +53,6 @@ velocity.command.no-plugins=Hiện tại không có plugin được cài đặt.
 velocity.command.plugins-list=Plugins\: <arg:0>
 velocity.command.plugin-tooltip-website=Website\: <arg:0>
 velocity.command.plugin-tooltip-author=Tác giả\: <arg:0>
-velocity.command.plugin-tooltip-authors=Các tác giả\: <arg:0>
-velocity.command.dump-uploading=Đang tải lên thông tin đã thu thập...
-velocity.command.dump-send-error=Đã xảy ra lỗi khi giao tiếp với máy chủ Velocity. Các máy chủ có thể tạm thời không khả dụng hoặc có sự cố với cài đặt mạng của bạn. Bạn có thể tìm thêm thông tin trong nhật ký hoặc bảng điều khiển của máy chủ Velocity của mình.
-velocity.command.dump-success=Đã tạo một báo cáo ẩn danh chứa thông tin hữu ích về proxy này. Nếu một nhà phát triển yêu cầu nó, bạn có thể chia sẻ liên kết sau với họ\:
-velocity.command.dump-will-expire=Đường dẫn sẽ hết hạn trong vài ngày.
-velocity.command.dump-server-error=Một sự cố đã xảy ra trên những máy chủ Velocity và dump không thể hoàn tất. Vui lòng liên lạc quản trị viên của Velocity về sự cố này và đưa thông tin chi tiết về lỗi này từ console của Velocity hoặc log của máy chủ.
-velocity.command.dump-offline=Nguyên nhân có thể\: Cài đặt DNS không hợp lệ hoặc không có kết nối internet
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy đang tắt.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_zh_CN.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_zh_CN.properties
@@ -53,13 +53,6 @@ velocity.command.no-plugins=当前没有安装任何插件。
 velocity.command.plugins-list=插件：<arg:0>
 velocity.command.plugin-tooltip-website=网站：<arg:0>
 velocity.command.plugin-tooltip-author=作者：<arg:0>
-velocity.command.plugin-tooltip-authors=作者：<arg:0>
-velocity.command.dump-uploading=正在上传已收集的信息...
-velocity.command.dump-send-error=与 Velocity 服务器通信时发生错误，服务器可能暂不可用或您的网络设置存在问题。您可在 Velocity 服务器日志或控制台中了解详情。
-velocity.command.dump-success=已创建关于此代理的匿名反馈数据。若开发者需要，您可与其分享以下链接：
-velocity.command.dump-will-expire=此链接将于几天后过期。
-velocity.command.dump-server-error=Velocity 服务器发生错误，无法完成内存转储。请联系 Velocity 开发者并从 Velocity 控制台或日志中提供详细错误信息。
-velocity.command.dump-offline=可能原因：系统 DNS 设置无效或无网络连接
 velocity.command.send-usage=/send <玩家> <服务器>
 # Kick
 velocity.kick.shutdown=正在关闭代理。

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_zh_HK.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_zh_HK.properties
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-velocity.error.already-connected=你已經連接到這個伺服器\!
+velocity.error.already-connected=你已經連接到這個伺服器!
 velocity.error.already-connected-proxy=您已經連接到此代理伺服器了！
 velocity.error.already-connecting=您已經在嘗試連接伺服器了！
 velocity.error.cant-connect=無法法連接至 <arg:0>：<arg:1>
@@ -53,13 +53,6 @@ velocity.command.no-plugins=目前未有安裝任何 Velocity 插件。
 velocity.command.plugins-list=插件： <arg:0>
 velocity.command.plugin-tooltip-website=網站： <arg:0>
 velocity.command.plugin-tooltip-author=作者： <arg:0>
-velocity.command.plugin-tooltip-authors=作者： <arg:0>
-velocity.command.dump-uploading=正在收集並上載 Velocity 設定資料...
-velocity.command.dump-send-error=與 Velocity 伺服器通信時發生錯誤，伺服器可能暫時不可用或您的網路設置存在問題。您可在 Velocity 伺服器日志或控制台中了解詳情。
-velocity.command.dump-success=已創建關於此代理的匿名反饋數據。若開發人員需要，您可與其分享以下鏈接：
-velocity.command.dump-will-expire=此鏈接將於幾天後后過期。
-velocity.command.dump-server-error=Velocity 伺服器發生錯誤，無法完成轉儲數據。請聯繫 Velocity 開發人員並從 Velocity 控制台或日志中提供詳細的錯誤信息。
-velocity.command.dump-offline=可能原因：系统 DNS 設置無效或無網絡連接
 velocity.command.send-usage=/send <player> <server>
 # Kick
 velocity.kick.shutdown=Proxy shutting down.

--- a/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_zh_TW.properties
+++ b/proxy/src/main/resources/com/velocitypowered/proxy/l10n/messages_zh_TW.properties
@@ -53,13 +53,6 @@ velocity.command.no-plugins=當前沒有安裝任何插件。
 velocity.command.plugins-list=插件：<arg:0>
 velocity.command.plugin-tooltip-website=網站：<arg:0>
 velocity.command.plugin-tooltip-author=作者：<arg:0>
-velocity.command.plugin-tooltip-authors=作者：<arg:0>
-velocity.command.dump-uploading=正在上傳已收集的訊息...
-velocity.command.dump-send-error=與 Velocity 伺服器通訊時發生錯誤，伺服器可能暫不可用或您的網路設置存在問題。您可在 Velocity 伺服器日誌或控制台中了解詳情。
-velocity.command.dump-success=已創建關於此代理的匿名反饋資料。若開發者需要，您可與其分享以下連結：
-velocity.command.dump-will-expire=此連結將於幾天後過期。
-velocity.command.dump-server-error=Velocity 伺服器發生錯誤，無法完成記憶體轉存。請聯絡 Velocity 開發者並從 Velocity 控制台或日誌中提供詳細錯誤訊息。
-velocity.command.dump-offline=可能原因：系統 DNS 設置無效或無網路連線
 velocity.command.send-usage=/send <玩家> <伺服器>
 # Kick
 velocity.kick.shutdown=正在關閉代理伺服器。


### PR DESCRIPTION
This just fixes an annoying bug in the Finnish language, and almost all other languages where \! would appear in a specific language. The messages.properties for localization does not even have \! for the English language, which was weird.
My IDE was also complaining about some unused variables in other languages, so I just removed them.

I just also realized there's a crowdin for velocitypowered, my bad, but this seems faster.

before:
<img width="410" height="104" alt="image" src="https://github.com/user-attachments/assets/f0d3f4c3-4ad4-451f-96d5-d132e5e5d925" />
after:
<img width="416" height="104" alt="image" src="https://github.com/user-attachments/assets/c2662d20-b1f0-463d-99a1-d091964482bd" />
