### PR TITLE
fix: silently drop short GS4 query datagrams

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/GameSpyQueryHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/GameSpyQueryHandler.java
@@ -57,6 +57,13 @@ public class GameSpyQueryHandler extends SimpleChannelInboundHandler<DatagramPac
   private static final short QUERY_MAGIC_SECOND = 0xFD;
   private static final byte QUERY_TYPE_HANDSHAKE = 0x09;
   private static final byte QUERY_TYPE_STAT = 0x00;
+  /**
+   * Minimum valid query message length: 2 magic bytes + 1 type byte + 4 session id bytes.
+   * The {@link #QUERY_TYPE_HANDSHAKE} branch is the shortest handler — it only reads this
+   * header, so any message shorter than 7 bytes is always malformed.
+   */
+  private static final int MINIMUM_MESSAGE_LENGTH = 7;
+
   private static final byte[] QUERY_RESPONSE_FULL_PADDING = new byte[]{0x73, 0x70, 0x6C, 0x69, 0x74,
       0x6E, 0x75, 0x6D, 0x00, (byte) 0x80, 0x00};
   private static final byte[] QUERY_RESPONSE_FULL_PADDING2 = new byte[]{0x01, 0x70, 0x6C, 0x61,
@@ -108,6 +115,10 @@ public class GameSpyQueryHandler extends SimpleChannelInboundHandler<DatagramPac
     ByteBuf queryMessage = msg.content();
     InetAddress senderAddress = msg.sender().getAddress();
 
+    if (queryMessage.readableBytes() < MINIMUM_MESSAGE_LENGTH) {
+      return;
+    }
+
     // Verify query packet magic
     if (queryMessage.readUnsignedByte() != QUERY_MAGIC_FIRST
         || queryMessage.readUnsignedByte() != QUERY_MAGIC_SECOND) {
@@ -135,6 +146,11 @@ public class GameSpyQueryHandler extends SimpleChannelInboundHandler<DatagramPac
       }
 
       case QUERY_TYPE_STAT -> {
+        // Need at least 4 more bytes for challenge token
+        if (queryMessage.readableBytes() < 4) {
+          return;
+        }
+
         // Check if query was done with session previously generated using a handshake packet
         int challengeToken = queryMessage.readInt();
         Integer session = sessions.getIfPresent(senderAddress);

--- a/proxy/src/test/java/com/velocitypowered/proxy/protocol/netty/GameSpyQueryHandlerTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/protocol/netty/GameSpyQueryHandlerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018-2023 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.protocol.netty;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.velocitypowered.proxy.VelocityServer;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.DatagramPacket;
+import java.net.InetSocketAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class GameSpyQueryHandlerTest {
+
+  @Mock
+  private VelocityServer server;
+  @Mock
+  private ChannelHandlerContext ctx;
+
+  private final InetSocketAddress sender = new InetSocketAddress("127.0.0.1", 12345);
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void emptyBufferDoesNotThrow() {
+    assertDoesNotThrow(() -> handle(Unpooled.EMPTY_BUFFER));
+  }
+
+  @Test
+  void shortBufferDoesNotThrow() {
+    assertDoesNotThrow(() -> handle(Unpooled.buffer().writeBytes(new byte[6])));
+  }
+
+  @Test
+  void statWithoutChallengeTokenDoesNotThrow() {
+    ByteBuf buf = Unpooled.buffer();
+    buf.writeByte(0xFE);
+    buf.writeByte(0xFD);
+    buf.writeByte(0x00);
+    buf.writeInt(42);
+    assertDoesNotThrow(() -> handle(buf));
+  }
+
+  private void handle(ByteBuf buf) throws Exception {
+    GameSpyQueryHandler handler = new GameSpyQueryHandler(server);
+    DatagramPacket packet = new DatagramPacket(buf, sender, sender);
+    handler.channelRead0(ctx, packet);
+  }
+}


### PR DESCRIPTION
Fixes #1828.

`GameSpyQueryHandler.channelRead0` reads magic bytes, type, and sessionId without first checking `readableBytes()`. A malformed UDP datagram shorter than 7 bytes throws `IndexOutOfBoundsException` on every packet, caught and logged at WARNING:

```
Error whilst handling query packet from
```

**Fix:**
- Added `MINIMUM_MESSAGE_LENGTH` (7) — a named constant with javadoc explaining the 2+1+4 byte layout and which handler branch reads the shortest valid message (`QUERY_TYPE_HANDSHAKE`).
- Silently drop any datagram shorter than `MINIMUM_MESSAGE_LENGTH` before touching any byte.
- Also guard the challenge-token read in the `QUERY_TYPE_STAT` branch (4 bytes after the 7-byte header) for defence-in-depth — a 7-byte datagram with type `0x00` would pass the header check but fail on the `readInt()` for the challenge token.

**Test coverage:**
- Short/empty datagrams are silently dropped (no exception)
- 7-byte STAT datagram without challenge token is silently dropped (no exception)

**Validation:**
- `./gradlew :velocity-proxy:check` — checkstyle, spotless, and all tests pass