### PR TITLE
Various dependency bumps

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,24 +2,24 @@
 configurate3 = "3.7.3"
 configurate4 = "4.2.0"
 flare = "2.0.1"
-log4j = "2.26.0"
+log4j = "2.26.1"
 netty = "4.2.16.Final"
 
 [plugins]
 fill = "io.papermc.fill.gradle:1.0.12"
-shadow = "com.gradleup.shadow:9.5.1"
-spotless = "com.diffplug.spotless:8.2.0"
+shadow = "com.gradleup.shadow:9.6.1"
+spotless = "com.diffplug.spotless:8.9.0"
 
 [libraries]
 adventure-bom = "net.kyori:adventure-bom:5.2.0"
 adventure-text-serializer-json-legacy-impl = "net.kyori:adventure-text-serializer-json-legacy-impl:5.2.0"
-asm = "org.ow2.asm:asm:9.9.1"
+asm = "org.ow2.asm:asm:9.10.1"
 auto-service = "com.google.auto.service:auto-service:1.1.1"
 auto-service-annotations = "com.google.auto.service:auto-service-annotations:1.1.1"
 brigadier = "com.velocitypowered:velocity-brigadier:1.0.0-SNAPSHOT"
-bstats = "org.bstats:bstats-base:3.1.0"
-caffeine = "com.github.ben-manes.caffeine:caffeine:3.2.3"
-checker-qual = "org.checkerframework:checker-qual:3.53.0"
+bstats = "org.bstats:bstats-base:3.2.1"
+caffeine = "com.github.ben-manes.caffeine:caffeine:3.2.4"
+checker-qual = "org.checkerframework:checker-qual:4.2.1"
 checkstyle = "com.puppycrawl.tools:checkstyle:10.9.3"
 completablefutures = "com.spotify:completable-futures:0.3.6"
 configurate3-hocon = { module = "org.spongepowered:configurate-hocon", version.ref = "configurate3" }
@@ -34,19 +34,19 @@ flare-core = { module = "space.vectrix.flare:flare", version.ref = "flare" }
 flare-fastutil = { module = "space.vectrix.flare:flare-fastutil", version.ref = "flare" }
 jline = "org.jline:jline-terminal-ffm:4.3.1"
 jopt = "net.sf.jopt-simple:jopt-simple:5.0.4"
-junit = "org.junit.jupiter:junit-jupiter:6.0.3"
-jspecify = "org.jspecify:jspecify:1.0.0"
+junit = "org.junit.jupiter:junit-jupiter:6.1.2"
+jspecify = "org.jspecify:jspecify:1.0.1"
 kyori-ansi = "net.kyori:ansi:1.1.1"
 guava = "com.google.guava:guava:33.6.0-jre"
 gson = "com.google.code.gson:gson:2.14.0"
 guice = "com.google.inject:guice:7.0.0"
-lmbda = "org.lanternpowered:lmbda:2.0.0"
+lmbda = "org.lanternpowered:lmbda:3.0.0"
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 log4j-slf4j-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version.ref = "log4j" }
 log4j-iostreams = { module = "org.apache.logging.log4j:log4j-iostreams", version.ref = "log4j" }
 log4j-jul = { module = "org.apache.logging.log4j:log4j-jul", version.ref = "log4j" }
-mockito = "org.mockito:mockito-core:5.22.0"
+mockito = "org.mockito:mockito-core:5.23.0"
 netty-codec = { module = "io.netty:netty-codec", version.ref = "netty" }
 netty-codec-haproxy = { module = "io.netty:netty-codec-haproxy", version.ref = "netty" }
 netty-codec-http = { module = "io.netty:netty-codec-http", version.ref = "netty" }
@@ -54,10 +54,10 @@ netty-handler = { module = "io.netty:netty-handler", version.ref = "netty" }
 netty-transport-native-epoll = { module = "io.netty:netty-transport-native-epoll", version.ref = "netty" }
 netty-transport-native-kqueue = { module = "io.netty:netty-transport-native-kqueue", version.ref = "netty" }
 netty-transport-native-iouring = { module = "io.netty:netty-transport-native-io_uring", version.ref = "netty" }
-nightconfig = "com.electronwill.night-config:toml:3.8.3"
-slf4j = "org.slf4j:slf4j-api:2.0.17"
-snakeyaml = "org.yaml:snakeyaml:2.5"
-spotbugs-annotations = "com.github.spotbugs:spotbugs-annotations:4.9.8"
+nightconfig = "com.electronwill.night-config:toml:3.9.0"
+slf4j = "org.slf4j:slf4j-api:2.0.18"
+snakeyaml = "org.yaml:snakeyaml:2.6"
+spotbugs-annotations = "com.github.spotbugs:spotbugs-annotations:4.10.3"
 terminalconsoleappender = "net.minecrell:terminalconsoleappender:1.3.0"
 
 [bundles]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ configurate4-hocon = { module = "org.spongepowered:configurate-hocon", version.r
 configurate4-yaml = { module = "org.spongepowered:configurate-yaml", version.ref = "configurate4" }
 configurate4-gson = { module = "org.spongepowered:configurate-gson", version.ref = "configurate4" }
 disruptor = "com.lmax:disruptor:4.0.0"
-fastutil = "it.unimi.dsi:fastutil:8.5.18"
+fastutil = "it.unimi.dsi:fastutil:8.5.19"
 flare-core = { module = "space.vectrix.flare:flare", version.ref = "flare" }
 flare-fastutil = { module = "space.vectrix.flare:flare-fastutil", version.ref = "flare" }
 jline = "org.jline:jline-terminal-ffm:4.3.1"

--- a/proxy/build.gradle.kts
+++ b/proxy/build.gradle.kts
@@ -33,65 +33,6 @@ tasks {
 
         transform(Log4j2PluginsCacheFileTransformer::class.java)
 
-        // Exclude all the collection types we don"t intend to use
-        exclude("it/unimi/dsi/fastutil/booleans/**")
-        exclude("it/unimi/dsi/fastutil/bytes/**")
-        exclude("it/unimi/dsi/fastutil/chars/**")
-        exclude("it/unimi/dsi/fastutil/doubles/**")
-        exclude("it/unimi/dsi/fastutil/floats/**")
-        exclude("it/unimi/dsi/fastutil/longs/**")
-        exclude("it/unimi/dsi/fastutil/shorts/**")
-
-        // Exclude the fastutil IO utilities - we don"t use them.
-        exclude("it/unimi/dsi/fastutil/io/**")
-
-        // Exclude most of the int types - Object2IntMap have a values() method that returns an
-        // IntCollection, and we need Int2ObjectMap
-        exclude("it/unimi/dsi/fastutil/ints/*Int2Boolean*")
-        exclude("it/unimi/dsi/fastutil/ints/*Int2Byte*")
-        exclude("it/unimi/dsi/fastutil/ints/*Int2Char*")
-        exclude("it/unimi/dsi/fastutil/ints/*Int2Double*")
-        exclude("it/unimi/dsi/fastutil/ints/*Int2Float*")
-        exclude("it/unimi/dsi/fastutil/ints/*Int2Int*")
-        exclude("it/unimi/dsi/fastutil/ints/*Int2Long*")
-        exclude("it/unimi/dsi/fastutil/ints/*Int2Short*")
-        exclude("it/unimi/dsi/fastutil/ints/*Int2Reference*")
-        exclude("it/unimi/dsi/fastutil/ints/IntAVL*")
-        exclude("it/unimi/dsi/fastutil/ints/IntArrayF*")
-        exclude("it/unimi/dsi/fastutil/ints/IntArrayI*")
-        exclude("it/unimi/dsi/fastutil/ints/IntArrayL*")
-        exclude("it/unimi/dsi/fastutil/ints/IntArrayP*")
-        exclude("it/unimi/dsi/fastutil/ints/IntArraySet*")
-        exclude("it/unimi/dsi/fastutil/ints/*IntBi*")
-        exclude("it/unimi/dsi/fastutil/ints/Int*Pair")
-        exclude("it/unimi/dsi/fastutil/ints/IntLinked*")
-        exclude("it/unimi/dsi/fastutil/ints/IntList*")
-        exclude("it/unimi/dsi/fastutil/ints/IntHeap*")
-        exclude("it/unimi/dsi/fastutil/ints/IntOpen*")
-        exclude("it/unimi/dsi/fastutil/ints/IntRB*")
-        exclude("it/unimi/dsi/fastutil/ints/IntSorted*")
-        exclude("it/unimi/dsi/fastutil/ints/*Priority*")
-        exclude("it/unimi/dsi/fastutil/ints/*BigList*")
-
-        // Try to exclude everything BUT Object2Int{LinkedOpen,Open,CustomOpen}HashMap
-        exclude("it/unimi/dsi/fastutil/objects/*ObjectArray*")
-        exclude("it/unimi/dsi/fastutil/objects/*ObjectAVL*")
-        exclude("it/unimi/dsi/fastutil/objects/*Object*Big*")
-        exclude("it/unimi/dsi/fastutil/objects/*Object2Boolean*")
-        exclude("it/unimi/dsi/fastutil/objects/*Object2Byte*")
-        exclude("it/unimi/dsi/fastutil/objects/*Object2Char*")
-        exclude("it/unimi/dsi/fastutil/objects/*Object2Double*")
-        exclude("it/unimi/dsi/fastutil/objects/*Object2Float*")
-        exclude("it/unimi/dsi/fastutil/objects/*Object2IntArray*")
-        exclude("it/unimi/dsi/fastutil/objects/*Object2IntAVL*")
-        exclude("it/unimi/dsi/fastutil/objects/*Object2IntRB*")
-        exclude("it/unimi/dsi/fastutil/objects/*Object2Long*")
-        exclude("it/unimi/dsi/fastutil/objects/*Object2Object*")
-        exclude("it/unimi/dsi/fastutil/objects/*Object2Reference*")
-        exclude("it/unimi/dsi/fastutil/objects/*Object2Short*")
-        exclude("it/unimi/dsi/fastutil/objects/*ObjectRB*")
-        exclude("it/unimi/dsi/fastutil/objects/*Reference*")
-
         // Exclude Checker Framework annotations
         exclude("org/checkerframework/checker/**")
 


### PR DESCRIPTION
Bumps all dependencies to their latest versions, except for `checkstyle` which either needs accompanying formatting changes in the source or a modification of the config, as solely bumping the version generates some new style violations.

Fastutil's version bump breaks things with NoClassDefFoundError's as its latest release creates some internal references to classes we exclude due to some compilation magic (8.5.19 is compiled using Java 25, the older 8.5.18 using Java 21, both targeting Java 8 but with different outcomes). Getting rid of the `it/unimi/dsi/fastutil/objects/*ObjectArray*` exclusion alone would fix this. Though rather than maintaining a hacky list of exclusions, we will now be shipping the full fastutil library, not excluding any of its classes. This means plugins will now have access to the full fastutil library, and it will also mean that the Velocity jar grows in size roughly twofold, from ~20mb to ~40mb.