### PR TITLE
Export JSpecify annotations at runtime

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -18,7 +18,7 @@ java {
 }
 
 dependencies {
-    compileOnlyApi(libs.jspecify)
+    api(libs.jspecify)
 
     api(libs.gson)
     api(libs.guava)


### PR DESCRIPTION
## Summary

Expose `org.jspecify:jspecify` through the API variant using the JSpecify-recommended `api` scope. JSpecify annotations have runtime retention, so `compileOnlyApi` does not model the runtime contract correctly.

## Validation

- `./gradlew check`