### PR TITLE
Forward player loaded packets to the backend server

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -254,7 +254,7 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
       serverConnection.setClientLoaded(true);
       server.getEventManager().fireAndForget(new PlayerClientLoadedWorldEvent(player));
     }
-    return true;
+    return false;
   }
 
   @Override


### PR DESCRIPTION
The `ServerboundPlayerLoadedPacket` handler introduced by #1541 marks the current server connection as client-loaded and fires the `PlayerClientLoadedWorldEvent`.

However, the handler then returns `true`, which indicates that the packet has been fully handled by Velocity. As a result, the packet does not pass through the normal forwarding path and never reaches the connected backend server.

Paper therefore does not receive the client's confirmation that the world has finished loading and has to rely on its timeout fallback. This causes a short desynchronization after initially joining a backend server and after switching servers. During this period, players can move and appear to break blocks before being moved back and seeing the blocks reappear.

This change returns `false` after updating the connection state and firing the event, allowing the packet to continue through Velocity's normal forwarding path. The packet is still consumed when no server connection is available.
