### PR TITLE
Fix negative ID Dimension in JoinGamePacket

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
@@ -245,17 +245,7 @@ public class JoinGamePacket implements MinecraftPacket {
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_9_1)) {
       this.dimension = buf.readInt();
     } else {
-      // Vanilla 1.7.10 uses a signed byte for dimension (-1 Nether, 0 Overworld, 1 End).
-      // Modded servers hack this to an unsigned byte to allow dim IDs up to 255.
-      // We must store the canonical int here because RespawnPacket.fromJoinGame copies this
-      // value into a packet that encodes dimension as a 4-byte int (RespawnPacket.encode,
-      // pre-1.16 logic). Sign-extending a modded byte like 0xB4 to int -76 sends an
-      // illegal dimension ID to the client and crashes it.
-      //
-      // The wire byte is ambiguous: 0xFF could be vanilla Nether (-1) or modded dim 255.
-      // We resolve in Nether's favor since vanilla 1.7.10 only ever uses -1/0/1.
-      short raw = buf.readUnsignedByte();
-      this.dimension = raw == 0xFF ? -1 : raw;
+      this.dimension = buf.readByte();
     }
     if (version.noGreaterThan(ProtocolVersion.MINECRAFT_1_13_2)) {
       this.difficulty = buf.readUnsignedByte();

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGamePacket.java
@@ -264,6 +264,12 @@ public class JoinGamePacket implements MinecraftPacket {
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_15)) {
       this.showRespawnScreen = buf.readBoolean();
     }
+
+    // Hodgepodge
+    if (version.lessThan(ProtocolVersion.MINECRAFT_1_9_1)
+        && buf.readableBytes() >= 4) {
+      this.dimension = buf.readInt();
+    }
   }
 
   private void decode116Up(ByteBuf buf, ProtocolVersion version) {
@@ -418,6 +424,12 @@ public class JoinGamePacket implements MinecraftPacket {
     }
     if (version.noLessThan(ProtocolVersion.MINECRAFT_1_15)) {
       buf.writeBoolean(showRespawnScreen);
+    }
+
+    // Hodgepodge
+    if (version.lessThan(ProtocolVersion.MINECRAFT_1_9_1)
+        && (dimension < Byte.MIN_VALUE || dimension > Byte.MAX_VALUE)) {
+      buf.writeInt(dimension);
     }
   }
 


### PR DESCRIPTION
This fix negative ID bug by #1734 (https://github.com/PaperMC/Velocity/commit/2676520c6a54bac0529544793c982dd701b338d9) and completly support GTNH (hodgepodge with B:fixLoginDimensionIDOverflow=true)

> I can confirm that after https://github.com/PaperMC/Velocity/commit/2676520c6a54bac0529544793c982dd701b338d9, login in a negative number world (-2 ~ -128) it crash client
> Test with dimension id -7 (and it was map to 249 by that commit):
> ```
> java.lang.IllegalArgumentException: Could not get provider type for dimension 249, does not exist
> 	at Launch//net.minecraftforge.common.DimensionManager.getProviderType(DimensionManager.java:148)
> 	at Launch//net.minecraftforge.common.DimensionManager.createProviderFor(DimensionManager.java:302)
> 	at Launch//net.minecraft.world.WorldProvider.func_76570_a(WorldProvider.java:160)
> 	at Launch//net.minecraft.client.multiplayer.WorldClient.<init>(WorldClient.java:54)
> 	at Launch//net.minecraft.client.network.NetHandlerPlayClient.func_147280_a(NetHandlerPlayClient.java:871)
> 	at Launch//net.minecraft.network.play.server.S07PacketRespawn.func_148833_a(SourceFile:32)
> 	at Launch//net.minecraft.network.play.server.S07PacketRespawn.func_148833_a(SourceFile:13)
> 	at Launch//net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:212)
> 	at Launch//net.minecraft.client.multiplayer.PlayerControllerMP.func_78765_e(PlayerControllerMP.java:273)
> 	at Launch//net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:1602)
> 	at Launch//net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:973)
> 	at Launch//net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:898)
> 	at Launch//net.minecraft.client.main.Main.main(SourceFile:148)
> 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
> 	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
> 	at System//net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250)
> 	at System//net.minecraft.launchwrapper.Launch.launch(Launch.java:35)
> 	at System//net.minecraft.launchwrapper.Launch.main(Launch.java:60)
> 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
> 	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
> 	at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207)
> 	at com.gtnewhorizons.retrofuturabootstrap.MainStartOnFirstThread.lambda$main$1(MainStartOnFirstThread.java:47)
> 	at java.base/java.lang.Thread.run(Thread.java:1474)
> ```
https://github.com/PaperMC/Velocity/pull/1734#issuecomment-5163023103