### PR TITLE
Fix login status after backend disconnect

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -178,6 +178,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   private long ping = -1;
   private final boolean onlineMode;
   private @Nullable VelocityServerConnection connectedServer;
+  private boolean hasJoinedServer;
   private @Nullable VelocityServerConnection connectionInFlight;
   private @Nullable PlayerSettings settings;
   private @Nullable ModInfo modInfo;
@@ -910,6 +911,9 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
    */
   public void setConnectedServer(@Nullable VelocityServerConnection serverConnection) {
     this.connectedServer = serverConnection;
+    if (serverConnection != null) {
+      this.hasJoinedServer = true;
+    }
     this.tryIndex = 0; // reset since we got connected to a server
 
     if (serverConnection == connectionInFlight) {
@@ -946,18 +950,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     Optional<Player> connectedPlayer = server.getPlayer(this.getUniqueId());
     server.unregisterConnection(this);
 
-    DisconnectEvent.LoginStatus status;
-    if (connectedPlayer.isPresent()) {
-      if (connectedPlayer.get().getCurrentServer().isEmpty()) {
-        status = LoginStatus.PRE_SERVER_JOIN;
-      } else {
-        status = connectedPlayer.get() == this ? LoginStatus.SUCCESSFUL_LOGIN
-            : LoginStatus.CONFLICTING_LOGIN;
-      }
-    } else {
-      status = connection.isKnownDisconnect() ? LoginStatus.CANCELLED_BY_PROXY :
-          LoginStatus.CANCELLED_BY_USER;
-    }
+    DisconnectEvent.LoginStatus status = determineLoginStatus(connectedPlayer.orElse(null),
+        connection.isKnownDisconnect());
 
     DisconnectEvent event = new DisconnectEvent(this, status);
     server.getEventManager().fire(event).whenComplete((val, ex) -> {
@@ -971,6 +965,18 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
 
   public CompletableFuture<Void> getTeardownFuture() {
     return teardownFuture;
+  }
+
+  DisconnectEvent.LoginStatus determineLoginStatus(@Nullable Player connectedPlayer,
+                                                    boolean knownDisconnect) {
+    if (connectedPlayer == null) {
+      return knownDisconnect ? LoginStatus.CANCELLED_BY_PROXY : LoginStatus.CANCELLED_BY_USER;
+    }
+    if (connectedPlayer == this) {
+      return hasJoinedServer ? LoginStatus.SUCCESSFUL_LOGIN : LoginStatus.PRE_SERVER_JOIN;
+    }
+    return connectedPlayer.getCurrentServer().isEmpty() ? LoginStatus.PRE_SERVER_JOIN
+        : LoginStatus.CONFLICTING_LOGIN;
   }
 
   @Override

--- a/proxy/src/test/java/com/velocitypowered/proxy/connection/client/ConnectedPlayerTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/connection/client/ConnectedPlayerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2018-2026 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.connection.client;
+
+import static com.velocitypowered.api.event.connection.DisconnectEvent.LoginStatus.PRE_SERVER_JOIN;
+import static com.velocitypowered.api.event.connection.DisconnectEvent.LoginStatus.SUCCESSFUL_LOGIN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
+import org.junit.jupiter.api.Test;
+
+class ConnectedPlayerTest {
+
+  @Test
+  void backendDisconnectAfterServerJoinIsSuccessfulLogin() {
+    ConnectedPlayer player = mock(ConnectedPlayer.class, CALLS_REAL_METHODS);
+    player.setConnectedServer(mock(VelocityServerConnection.class));
+    player.setConnectedServer(null);
+
+    assertEquals(SUCCESSFUL_LOGIN, player.determineLoginStatus(player, true));
+  }
+
+  @Test
+  void disconnectBeforeServerJoinIsPreServerJoin() {
+    ConnectedPlayer player = mock(ConnectedPlayer.class, CALLS_REAL_METHODS);
+
+    assertEquals(PRE_SERVER_JOIN, player.determineLoginStatus(player, true));
+  }
+}


### PR DESCRIPTION
## Summary
- track whether a player has successfully joined a backend independently of the current server reference
- report `SUCCESSFUL_LOGIN` after a backend kick clears that reference
- add regression coverage for backend disconnects and pre-server-join disconnects

## Testing
- `./gradlew :velocity-proxy:test --tests com.velocitypowered.proxy.connection.client.ConnectedPlayerTest :velocity-proxy:checkstyleMain :velocity-proxy:checkstyleTest`

Fixes #1696