### PR TITLE
Create a HTTP Client per worker thread instead of per connection

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -676,8 +676,8 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     this.cm.closeEndpoints(false);
   }
 
-  public HttpClient createHttpClient() {
-    return cm.createHttpClient();
+  public HttpClient getHttpClient() {
+    return cm.getHttpClient();
   }
 
   public @MonotonicNonNull Ratelimiter<InetAddress> getIpAttemptLimiter() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/InitialLoginSessionHandler.java
@@ -44,7 +44,6 @@ import com.velocitypowered.proxy.util.VelocityProperties;
 import io.netty.buffer.ByteBuf;
 import java.net.InetSocketAddress;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.security.GeneralSecurityException;
@@ -220,8 +219,7 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
               .uri(URI.create(url))
               .build();
       //noinspection resource
-      final HttpClient httpClient = server.createHttpClient();
-      httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString())
+      server.getHttpClient().sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString())
           .whenCompleteAsync((response, throwable) -> {
             if (mcConnection.isClosed()) {
               // The player disconnected after we authenticated them.
@@ -260,10 +258,7 @@ public class InitialLoginSessionHandler implements MinecraftSessionHandler {
                   response.statusCode(), login.getUsername(), playerIp);
               inbound.disconnect(Component.translatable("multiplayer.disconnect.authservers_down"));
             }
-          }, mcConnection.eventLoop())
-          .whenComplete((ignored, throwable) -> {
-            httpClient.close();
-          });
+          }, mcConnection.eventLoop());
     } catch (GeneralSecurityException e) {
       logger.error("Unable to enable encryption", e);
       mcConnection.close(true);

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
@@ -36,6 +36,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.unix.UnixChannelOption;
+import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.MultithreadEventExecutorGroup;
 import java.net.InetSocketAddress;
@@ -67,6 +68,14 @@ public final class ConnectionManager {
   public final BackendChannelInitializerHolder backendChannelInitializer;
 
   private final SeparatePoolInetNameResolver resolver;
+  private final FastThreadLocal<HttpClient> httpClient = new FastThreadLocal<>() {
+    @Override
+    protected HttpClient initialValue() {
+      return HttpClient.newBuilder()
+          .executor(workerGroup)
+          .build();
+    }
+  };
 
   /**
    * Initializes the {@code ConnectionManager}.
@@ -275,11 +284,8 @@ public final class ConnectionManager {
     return this.serverChannelInitializer;
   }
 
-  @SuppressWarnings("checkstyle:MissingJavadocMethod")
-  public HttpClient createHttpClient() {
-    return HttpClient.newBuilder()
-            .executor(this.workerGroup)
-            .build();
+  public HttpClient getHttpClient() {
+    return httpClient.get();
   }
 
   public BackendChannelInitializerHolder getBackendChannelInitializer() {


### PR DESCRIPTION
This uses one HttpClient per worker thread instead of creating one for every connection or sharing a single client globally.

This should still avoid the concurrent stream issue from #1243, since requests are distributed across the worker threads. At the same time, each worker can reuse its client and connections, which reduces overhead and avoids repeatedly setting up new TCP connections and TLS handshakes. This saves some network round trips to Mojang and should reduce login times.