### PR TITLE
fix: deterministic resolution of colliding argument-type ids

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/AvailableCommandsPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/AvailableCommandsPacket.java
@@ -41,6 +41,7 @@ import com.velocitypowered.proxy.protocol.ProtocolUtils.Direction;
 import com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentPropertyRegistry;
 import com.velocitypowered.proxy.util.collect.IdentityHashStrategy;
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.CorruptedFrameException;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenCustomHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import java.util.ArrayDeque;
@@ -87,6 +88,10 @@ public class AvailableCommandsPacket implements MinecraftPacket {
     int commands = ProtocolUtils.readVarInt(buf);
     List<WireNode> wireNodes = ProtocolUtils.newList(commands);
     for (int i = 0; i < commands; i++) {
+      if (!buf.isReadable()) {
+        throw new CorruptedFrameException("Ran out of bytes while reading command node " + i
+            + " (declared " + commands + " nodes)");
+      }
       wireNodes.add(deserializeNode(buf, i, protocolVersion));
     }
 
@@ -111,6 +116,10 @@ public class AvailableCommandsPacket implements MinecraftPacket {
     }
 
     int rootIdx = ProtocolUtils.readVarInt(buf);
+    if (rootIdx < 0 || rootIdx >= wireNodes.size()) {
+      throw new CorruptedFrameException("Root node index " + rootIdx
+          + " is out of bounds (declared " + commands + " nodes)");
+    }
     rootNode = (RootCommandNode<CommandSource>) wireNodes.get(rootIdx).built;
   }
 
@@ -221,7 +230,8 @@ public class AvailableCommandsPacket implements MinecraftPacket {
         }
         return new WireNode(idx, flags, children, redirectTo, argumentBuilder);
       default:
-        throw new IllegalArgumentException("Unknown node type " + (flags & FLAG_NODE_TYPE));
+        throw new IllegalArgumentException("Unknown node type " + (flags & FLAG_NODE_TYPE)
+            + " for node " + idx);
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentIdentifier.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentIdentifier.java
@@ -59,6 +59,22 @@ public class ArgumentIdentifier {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ArgumentIdentifier that)) {
+      return false;
+    }
+    return identifier.equals(that.identifier);
+  }
+
+  @Override
+  public int hashCode() {
+    return identifier.hashCode();
+  }
+
+  @Override
   public String toString() {
     return "ArgumentIdentifier{" +
         "identifier='" + identifier + '\'' +

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java
@@ -46,9 +46,17 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.CorruptedFrameException;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ArgumentPropertyRegistry {
@@ -58,11 +66,17 @@ public class ArgumentPropertyRegistry {
   }
 
   private static final Map<ArgumentIdentifier, ArgumentPropertySerializer<?>> byIdentifier =
-      new HashMap<>();
+      new LinkedHashMap<>();
   private static final Map<Class<? extends ArgumentType>,
       ArgumentPropertySerializer<?>> byClass = new HashMap<>();
   private static final Map<Class<? extends ArgumentType>, ArgumentIdentifier> classToId =
       new HashMap<>();
+
+  // Per-version numeric id -> identifier lookup. Built once at class init so resolution never
+  // depends on map iteration order again. Collisions are resolved deterministically and reported
+  // in indexCollisions (see buildIndex).
+  private static final Map<ProtocolVersion, Int2ObjectMap<ArgumentIdentifier>> byId;
+  static final List<String> indexCollisions = new ArrayList<>();
 
   private static <T extends ArgumentType<?>> void register(ArgumentIdentifier identifier,
       Class<T> klazz, ArgumentPropertySerializer<T> serializer) {
@@ -159,13 +173,12 @@ public class ArgumentPropertyRegistry {
   public static @NotNull ArgumentIdentifier readIdentifier(ByteBuf buf, ProtocolVersion protocolVersion) {
     if (protocolVersion.noLessThan(MINECRAFT_1_19)) {
       int id = ProtocolUtils.readVarInt(buf);
-      for (ArgumentIdentifier i : byIdentifier.keySet()) {
-        Integer v = i.getIdByProtocolVersion(protocolVersion);
-        if (v != null && v == id) {
-          return i;
-        }
+      Int2ObjectMap<ArgumentIdentifier> versionIndex = byId.get(protocolVersion);
+      ArgumentIdentifier identifier = versionIndex != null ? versionIndex.get(id) : null;
+      if (identifier == null) {
+        throw new CorruptedFrameException("Argument type identifier " + id + " unknown.");
       }
-      throw new IllegalArgumentException("Argument type identifier " + id + " unknown.");
+      return identifier;
     } else {
       String identifier = ProtocolUtils.readString(buf);
       for (ArgumentIdentifier i : byIdentifier.keySet()) {
@@ -173,8 +186,88 @@ public class ArgumentPropertyRegistry {
           return i;
         }
       }
-      throw new IllegalArgumentException("Argument type identifier " + identifier + " unknown.");
+      throw new CorruptedFrameException("Argument type identifier " + identifier + " unknown.");
     }
+  }
+
+  /**
+   * Returns the registered argument identifiers.
+   *
+   * @return the registered argument identifiers
+   */
+  static Collection<ArgumentIdentifier> identifiers() {
+    return byIdentifier.keySet();
+  }
+
+  /**
+   * Builds a per-version index of numeric argument ids to their identifiers. When more than one
+   * identifier claims the same id for a protocol version, the collision is resolved
+   * deterministically: vanilla ({@code minecraft:}/{@code brigadier:}) namespaces win over mod
+   * namespaces, with a lexicographic tie-break for equal priorities. Resolved collisions are
+   * recorded in {@code collisions} so they can be logged and caught by tests.
+   *
+   * @param identifiers the registered identifiers to index
+   * @param collisions  receives a human-readable line per resolved collision
+   * @return the version -> (id -> identifier) index
+   */
+  static Map<ProtocolVersion, Int2ObjectMap<ArgumentIdentifier>> buildIndex(
+      Collection<ArgumentIdentifier> identifiers, List<String> collisions) {
+    Map<ProtocolVersion, Int2ObjectMap<ArgumentIdentifier>> index =
+        new EnumMap<>(ProtocolVersion.class);
+    for (ProtocolVersion version : ProtocolVersion.values()) {
+      if (!version.noLessThan(MINECRAFT_1_19)) {
+        // Pre-1.19 argument types are identified by string, not by numeric id, so there is no
+        // numeric index to build for these versions.
+        continue;
+      }
+      Int2ObjectMap<ArgumentIdentifier> versionIndex = new Int2ObjectOpenHashMap<>();
+      for (ArgumentIdentifier identifier : identifiers) {
+        Integer id = identifier.getIdByProtocolVersion(version);
+        if (id == null) {
+          continue;
+        }
+        ArgumentIdentifier existing = versionIndex.get(id);
+        if (existing == null) {
+          versionIndex.put(id, identifier);
+        } else if (!existing.equals(identifier)) {
+          ArgumentIdentifier winner = prefer(existing, identifier);
+          versionIndex.put(id, winner);
+          // Negative ids are sentinels ("removed in this version" / mod args) that never appear on
+          // the wire, and are expected to overlap. Only positive-id collisions are real regressions
+          // worth flagging.
+          if (id >= 0) {
+            collisions.add(existing + " and " + identifier + " share id " + id
+                + " for " + version + ", resolved to " + winner);
+          }
+        }
+      }
+      index.put(version, versionIndex);
+    }
+    return index;
+  }
+
+  /**
+   * Picks the winner between two identifiers claiming the same id: vanilla namespaces beat mod
+   * namespaces, equal priorities are broken deterministically by identifier string.
+   *
+   * @param a the first identifier
+   * @param b the second identifier
+   * @return the identifier that should win the collision
+   */
+  static ArgumentIdentifier prefer(ArgumentIdentifier a, ArgumentIdentifier b) {
+    int comparison = Integer.compare(namespacePriority(a), namespacePriority(b));
+    if (comparison != 0) {
+      return comparison < 0 ? a : b;
+    }
+    return a.getIdentifier().compareTo(b.getIdentifier()) <= 0 ? a : b;
+  }
+
+  private static int namespacePriority(ArgumentIdentifier identifier) {
+    String name = identifier.getIdentifier();
+    if (name.startsWith("minecraft:") || name.startsWith("brigadier:")) {
+      return 0;
+    }
+    return 1;
   }
 
   static {
@@ -273,7 +366,7 @@ public class ArgumentPropertyRegistry {
     empty(id("minecraft:heightmap", mapSet(MINECRAFT_1_21_6, 51), mapSet(MINECRAFT_1_21_5, 50), mapSet(MINECRAFT_1_20_3, 49),
         mapSet(MINECRAFT_1_19_4, 47))); // 1.19.4
 
-    empty(id("minecraft:uuid", mapSet(MINECRAFT_1_21_6, 56), mapSet(MINECRAFT_1_21_5, 54),mapSet(MINECRAFT_1_20_5, 53), mapSet(MINECRAFT_1_20_3, 48),
+    empty(id("minecraft:uuid", mapSet(MINECRAFT_1_21_6, 56), mapSet(MINECRAFT_1_21_5, 54), mapSet(MINECRAFT_1_20_5, 53), mapSet(MINECRAFT_1_20_3, 48),
         mapSet(MINECRAFT_1_19_4, 48), mapSet(MINECRAFT_1_19, 47))); // added in 1.16
 
     empty(id("minecraft:loot_table", mapSet(MINECRAFT_1_21_6, 52), mapSet(MINECRAFT_1_21_5, 51), mapSet(MINECRAFT_1_20_5, 50)));
@@ -288,5 +381,13 @@ public class ArgumentPropertyRegistry {
     register(id("crossstitch:mod_argument", mapSet(MINECRAFT_1_19, -256)), ModArgumentProperty.class, MOD);
 
     empty(id("minecraft:nbt")); // No longer in 1.19+
+
+    byId = buildIndex(byIdentifier.keySet(), indexCollisions);
+    // Assertions are stripped when running without -ea, so a real (positive-id) collision must fail
+    // fast here rather than silently resolving to a winner in production.
+    if (!indexCollisions.isEmpty()) {
+      throw new IllegalStateException("Colliding argument type identifiers in registry: "
+          + indexCollisions);
+    }
   }
 }

--- a/proxy/src/test/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistryTests.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistryTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2026 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.protocol.packet.brigadier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.velocitypowered.api.network.ProtocolVersion;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ArgumentPropertyRegistry} id resolution.
+ */
+public class ArgumentPropertyRegistryTests {
+
+  @Test
+  void identifierEqualityUsesIdentifierString() {
+    ArgumentIdentifier a = ArgumentIdentifier.id("minecraft:template_rotation",
+        ArgumentIdentifier.mapSet(ProtocolVersion.MINECRAFT_1_19, 46));
+    ArgumentIdentifier b = ArgumentIdentifier.id("minecraft:template_rotation",
+        ArgumentIdentifier.mapSet(ProtocolVersion.MINECRAFT_1_19, 47));
+
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+    assertNotEquals(a, ArgumentIdentifier.id("minecraft:heightmap",
+        ArgumentIdentifier.mapSet(ProtocolVersion.MINECRAFT_1_19_4, 47)));
+  }
+
+  @Test
+  void collisionResolutionIsDeterministicAndPrefersVanilla() {
+    // Simulates the registry state behind the issue: a mod argument reusing a vanilla id.
+    ProtocolVersion version = ProtocolVersion.MINECRAFT_1_21_11;
+    ArgumentIdentifier vanilla = ArgumentIdentifier.id("minecraft:template_rotation",
+        ArgumentIdentifier.mapSet(version, 50));
+    ArgumentIdentifier mod = ArgumentIdentifier.id("forge:enum",
+        ArgumentIdentifier.mapSet(version, 50));
+
+    // Registration order must not change the result.
+    assertResolvesTo(vanilla, Arrays.asList(vanilla, mod), version, 50);
+    assertResolvesTo(vanilla, Arrays.asList(mod, vanilla), version, 50);
+  }
+
+  @Test
+  void collisionTieBreakIsLexicographicForEqualNamespaces() {
+    ProtocolVersion version = ProtocolVersion.MINECRAFT_1_21_11;
+    ArgumentIdentifier earlier = ArgumentIdentifier.id("forge:aaa",
+        ArgumentIdentifier.mapSet(version, 40));
+    ArgumentIdentifier later = ArgumentIdentifier.id("forge:zzz",
+        ArgumentIdentifier.mapSet(version, 40));
+
+    assertResolvesTo(earlier, Arrays.asList(later, earlier), version, 40);
+    assertResolvesTo(earlier, Arrays.asList(earlier, later), version, 40);
+  }
+
+  @Test
+  void readIdentifierRoundTripsAllRegisteredIdentifiers() {
+    // Exercise a spread of protocols including the newest 26.x line.
+    ProtocolVersion[] versions = {
+        ProtocolVersion.MINECRAFT_1_19, ProtocolVersion.MINECRAFT_1_19_3,
+        ProtocolVersion.MINECRAFT_1_19_4, ProtocolVersion.MINECRAFT_1_20_5,
+        ProtocolVersion.MINECRAFT_1_21_6, ProtocolVersion.MINECRAFT_1_21_11,
+        ProtocolVersion.MINECRAFT_26_2
+    };
+    for (ProtocolVersion version : versions) {
+      for (ArgumentIdentifier identifier : ArgumentPropertyRegistry.identifiers()) {
+        Integer id = identifier.getIdByProtocolVersion(version);
+        if (id == null || id < 0) {
+          continue; // not in use for this version (removed types and mod args use negative ids)
+        }
+        ByteBuf buf = Unpooled.buffer();
+        ArgumentPropertyRegistry.writeIdentifier(buf, identifier, version);
+        assertEquals(identifier, ArgumentPropertyRegistry.readIdentifier(buf, version));
+      }
+    }
+  }
+
+  @Test
+  void resolvesTheIdsFromTheIssueToVanillaIdentifiers() {
+    ProtocolVersion version = ProtocolVersion.MINECRAFT_1_21_11;
+    Map<ProtocolVersion, Int2ObjectMap<ArgumentIdentifier>> index =
+        ArgumentPropertyRegistry.buildIndex(ArgumentPropertyRegistry.identifiers(),
+            new ArrayList<>());
+
+    assertEquals("minecraft:template_rotation",
+        index.get(version).get(50).getIdentifier());
+    assertEquals("minecraft:heightmap", index.get(version).get(51).getIdentifier());
+  }
+
+  @Test
+  void readIdentifierRoundTripsPre119StringPath() {
+    // Pre-1.19 argument types are identified by their string, not a numeric id.
+    ProtocolVersion version = ProtocolVersion.MINECRAFT_1_18_2;
+    for (ArgumentIdentifier identifier : ArgumentPropertyRegistry.identifiers()) {
+      ByteBuf buf = Unpooled.buffer();
+      ArgumentPropertyRegistry.writeIdentifier(buf, identifier, version);
+      assertEquals(identifier, ArgumentPropertyRegistry.readIdentifier(buf, version));
+    }
+  }
+
+  @Test
+  void registryHasNoIdCollisions() {
+    assertTrue(ArgumentPropertyRegistry.indexCollisions.isEmpty(),
+        "Unexpected positive-id collisions in registry: "
+            + ArgumentPropertyRegistry.indexCollisions);
+    // Negative ids are "removed in this version" sentinels and are expected to overlap; they must
+    // not be reported as collisions.
+    Map<ProtocolVersion, Int2ObjectMap<ArgumentIdentifier>> index =
+        ArgumentPropertyRegistry.buildIndex(ArgumentPropertyRegistry.identifiers(),
+            new ArrayList<>());
+    assertNotNull(index.get(ProtocolVersion.MINECRAFT_1_19_3).get(-1));
+  }
+
+  private static void assertResolvesTo(ArgumentIdentifier expected,
+      List<ArgumentIdentifier> identifiers, ProtocolVersion version, int id) {
+    List<String> collisions = new ArrayList<>();
+    Map<ProtocolVersion, Int2ObjectMap<ArgumentIdentifier>> index =
+        ArgumentPropertyRegistry.buildIndex(identifiers, collisions);
+
+    assertEquals(expected, index.get(version).get(id));
+    assertTrue(collisions.size() > 0, "expected a collision to be reported");
+  }
+}


### PR DESCRIPTION
Fixes #1868.

`ArgumentPropertyRegistry` resolved a numeric argument id to an `ArgumentIdentifier` by linearly scanning `byIdentifier.keySet()` and returning the first match. For protocol versions where a Forge/CrossStitch identifier reuses a vanilla id (e.g. `forge:enum` and `minecraft:template_rotation` both claim id 50 on 1.21.11), the returned identifier depended on `HashMap` iteration order, which is seeded per JVM start. On unlucky boots the wrong serializer read the argument properties, desyncing the packet parser and surfacing as `Unknown node type 3` for OP players — cured only by a restart.

Changes:
- Give `ArgumentIdentifier` stable `equals`/`hashCode` based on its identifier string, so map behaviour no longer depends on identity hashes
- Build a per-version numeric id → identifier index once at class init instead of scanning the registry on every packet; lookups are O(1) and order-independent
- Resolve id collisions deterministically: vanilla (`minecraft:*`/`brigadier:*`) namespaces win over mod namespaces, with a lexicographic tie-break; collisions are logged and fail fast at startup if a positive id is ever reused
- `readIdentifier` now throws `CorruptedFrameException` for an unknown id, matching the rest of the packet decoder
- Harden `AvailableCommandsPacket` against truncated frames (missing bytes / out-of-bounds root index) and include the node index in the unknown node type message

Added `ArgumentPropertyRegistryTests` covering collision resolution, determinism across registration order, and round-tripping every registered identifier (including the new pre-1.19 string path).

Validation:
- All proxy tests pass
- Checkstyle and Spotless clean
- Full Gradle build successful