### PR TITLE
Better support for multiple tablist add/remove

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/player/TabList.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/player/TabList.java
@@ -11,7 +11,9 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.crypto.IdentifiedKey;
 import com.velocitypowered.api.util.GameProfile;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -77,6 +79,34 @@ public interface TabList {
    *     {@link Optional#empty()}
    */
   Optional<TabListEntry> removeEntry(UUID uuid);
+
+  /**
+   * Removes a {@link Iterable} of {@link UUID}'s from the {@link Player}'s tab list.
+   *
+   * @param entries to remove from the tab list
+   * @return {@link Optional} containing the {@link Set} of removed {@link TabListEntry}'s
+   */
+  default Set<TabListEntry> removeEntries(Iterable<UUID> entries) {
+    final Set<TabListEntry> removed = new HashSet<>();
+    for (UUID entry : entries) {
+      removeEntry(entry).ifPresent(removed::add);
+    }
+    return removed;
+  }
+
+  /**
+   * Removes an array of {@link UUID}'s from the {@link Player}'s tab list.
+   *
+   * @param entries to remove from the tab list
+   * @return {@link Optional} containing the {@link Set} of removed {@link TabListEntry}'s
+   */
+  default Set<TabListEntry> removeEntries(UUID... entries) {
+    final Set<TabListEntry> removed = new HashSet<>();
+    for (UUID entry : entries) {
+      removeEntry(entry).ifPresent(removed::add);
+    }
+    return removed;
+  }
 
   /**
    * Determines if the specified entry exists in the tab list.

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -18,6 +18,7 @@
 package com.velocitypowered.proxy.tablist;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.Player;
@@ -32,12 +33,16 @@ import com.velocitypowered.proxy.protocol.packet.UpsertPlayerInfoPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import com.velocitypowered.proxy.protocol.packet.chat.RemoteChatSession;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import org.apache.logging.log4j.LogManager;
@@ -83,118 +88,150 @@ public class VelocityTabList implements InternalTabList {
   }
 
   @Override
-  public void addEntry(TabListEntry entry1) {
-    VelocityTabListEntry entry;
-    if (entry1 instanceof VelocityTabListEntry) {
-      entry = (VelocityTabListEntry) entry1;
-    } else {
-      entry = new VelocityTabListEntry(this, entry1.getProfile(),
-          entry1.getDisplayNameComponent().orElse(null),
-          entry1.getLatency(), entry1.getGameMode(), entry1.getChatSession(), entry1.isListed(), entry1.getListOrder(), entry1.isShowHat());
-    }
+  public void addEntry(TabListEntry entry) {
+    addEntries(entry);
+  }
 
-    EnumSet<UpsertPlayerInfoPacket.Action> actions = EnumSet
-            .noneOf(UpsertPlayerInfoPacket.Action.class);
-    UpsertPlayerInfoPacket.Entry playerInfoEntry = new UpsertPlayerInfoPacket
-            .Entry(entry.getProfile().getId());
+  @Override
+  public void addEntries(Iterable<TabListEntry> entries) {
+    Map<EnumSet<UpsertPlayerInfoPacket.Action>, List<UpsertPlayerInfoPacket.Entry>> batches = new HashMap<>();
+    for (TabListEntry e : entries) {
+      VelocityTabListEntry entry;
+      if (e instanceof VelocityTabListEntry) {
+        entry = (VelocityTabListEntry) e;
+      } else {
+        entry = new VelocityTabListEntry(this, e.getProfile(),
+                e.getDisplayNameComponent().orElse(null),
+                e.getLatency(), e.getGameMode(), e.getChatSession(), e.isListed(), e.getListOrder(), e.isShowHat());
+      }
 
-    Preconditions.checkNotNull(entry.getProfile(), "Profile cannot be null");
-    Preconditions.checkNotNull(entry.getProfile().getId(), "Profile ID cannot be null");
+      EnumSet<UpsertPlayerInfoPacket.Action> actions = EnumSet
+              .noneOf(UpsertPlayerInfoPacket.Action.class);
+      UpsertPlayerInfoPacket.Entry playerInfoEntry = new UpsertPlayerInfoPacket
+              .Entry(entry.getProfile().getId());
 
-    this.entries.compute(entry.getProfile().getId(), (uuid, previousEntry) -> {
-      if (previousEntry != null) {
-        // we should merge entries here
-        if (previousEntry.equals(entry)) {
-          return previousEntry; // nothing else to do, this entry is perfect
-        }
-        if (!Objects.equals(previousEntry.getDisplayNameComponent().orElse(null),
-                entry.getDisplayNameComponent().orElse(null))) {
-          actions.add(UpsertPlayerInfoPacket.Action.UPDATE_DISPLAY_NAME);
-          playerInfoEntry.setDisplayName(entry.getDisplayNameComponent().isEmpty()
-                  ?
-                  null :
-                  new ComponentHolder(player.getProtocolVersion(),
-                          entry.getDisplayNameComponent().get())
-          );
-        }
-        if (!Objects.equals(previousEntry.getLatency(), entry.getLatency())) {
-          actions.add(UpsertPlayerInfoPacket.Action.UPDATE_LATENCY);
-          playerInfoEntry.setLatency(entry.getLatency());
-        }
-        if (!Objects.equals(previousEntry.getGameMode(), entry.getGameMode())) {
-          actions.add(UpsertPlayerInfoPacket.Action.UPDATE_GAME_MODE);
-          playerInfoEntry.setGameMode(entry.getGameMode());
-        }
-        if (!Objects.equals(previousEntry.isListed(), entry.isListed())) {
-          actions.add(UpsertPlayerInfoPacket.Action.UPDATE_LISTED);
-          playerInfoEntry.setListed(entry.isListed());
-        }
-        if (!Objects.equals(previousEntry.getListOrder(), entry.getListOrder())
-            && player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
-          actions.add(UpsertPlayerInfoPacket.Action.UPDATE_LIST_ORDER);
-          playerInfoEntry.setListOrder(entry.getListOrder());
-        }
-        if (!Objects.equals(previousEntry.isShowHat(), entry.isShowHat())
-                && player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21_4)) {
-          actions.add(UpsertPlayerInfoPacket.Action.UPDATE_HAT);
-          playerInfoEntry.setShowHat(entry.isShowHat());
-        }
-        if (!Objects.equals(previousEntry.getChatSession(), entry.getChatSession())) {
-          ChatSession from = entry.getChatSession();
-          if (from != null) {
+      Preconditions.checkNotNull(entry.getProfile(), "Profile cannot be null");
+      Preconditions.checkNotNull(entry.getProfile().getId(), "Profile ID cannot be null");
+
+      this.entries.compute(entry.getProfile().getId(), (uuid, previousEntry) -> {
+        if (previousEntry != null) {
+          // we should merge entries here
+          if (previousEntry.equals(entry)) {
+            return previousEntry; // nothing else to do, this entry is perfect
+          }
+          if (!Objects.equals(previousEntry.getDisplayNameComponent().orElse(null),
+                  entry.getDisplayNameComponent().orElse(null))) {
+            actions.add(UpsertPlayerInfoPacket.Action.UPDATE_DISPLAY_NAME);
+            playerInfoEntry.setDisplayName(entry.getDisplayNameComponent().isEmpty()
+                    ?
+                    null :
+                    new ComponentHolder(player.getProtocolVersion(),
+                            entry.getDisplayNameComponent().get())
+            );
+          }
+          if (!Objects.equals(previousEntry.getLatency(), entry.getLatency())) {
+            actions.add(UpsertPlayerInfoPacket.Action.UPDATE_LATENCY);
+            playerInfoEntry.setLatency(entry.getLatency());
+          }
+          if (!Objects.equals(previousEntry.getGameMode(), entry.getGameMode())) {
+            actions.add(UpsertPlayerInfoPacket.Action.UPDATE_GAME_MODE);
+            playerInfoEntry.setGameMode(entry.getGameMode());
+          }
+          if (!Objects.equals(previousEntry.isListed(), entry.isListed())) {
+            actions.add(UpsertPlayerInfoPacket.Action.UPDATE_LISTED);
+            playerInfoEntry.setListed(entry.isListed());
+          }
+          if (!Objects.equals(previousEntry.getListOrder(), entry.getListOrder())
+                  && player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
+            actions.add(UpsertPlayerInfoPacket.Action.UPDATE_LIST_ORDER);
+            playerInfoEntry.setListOrder(entry.getListOrder());
+          }
+          if (!Objects.equals(previousEntry.isShowHat(), entry.isShowHat())
+                  && player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21_4)) {
+            actions.add(UpsertPlayerInfoPacket.Action.UPDATE_HAT);
+            playerInfoEntry.setShowHat(entry.isShowHat());
+          }
+          if (!Objects.equals(previousEntry.getChatSession(), entry.getChatSession())) {
+            ChatSession from = entry.getChatSession();
+            if (from != null) {
+              actions.add(UpsertPlayerInfoPacket.Action.INITIALIZE_CHAT);
+              playerInfoEntry.setChatSession(
+                      new RemoteChatSession(from.getSessionId(), from.getIdentifiedKey()));
+            }
+          }
+        } else {
+          actions.addAll(EnumSet.of(UpsertPlayerInfoPacket.Action.ADD_PLAYER,
+                  UpsertPlayerInfoPacket.Action.UPDATE_LATENCY,
+                  UpsertPlayerInfoPacket.Action.UPDATE_LISTED));
+          playerInfoEntry.setProfile(entry.getProfile());
+          if (entry.getDisplayNameComponent().isPresent()) {
+            actions.add(UpsertPlayerInfoPacket.Action.UPDATE_DISPLAY_NAME);
+            playerInfoEntry.setDisplayName(entry.getDisplayNameComponent().isEmpty()
+                    ?
+                    null :
+                    new ComponentHolder(player.getProtocolVersion(),
+                            entry.getDisplayNameComponent().get())
+            );
+          }
+          if (entry.getChatSession() != null) {
             actions.add(UpsertPlayerInfoPacket.Action.INITIALIZE_CHAT);
+            ChatSession from = entry.getChatSession();
             playerInfoEntry.setChatSession(
                     new RemoteChatSession(from.getSessionId(), from.getIdentifiedKey()));
           }
+          if (entry.getGameMode() != -1 && entry.getGameMode() != 256) {
+            actions.add(UpsertPlayerInfoPacket.Action.UPDATE_GAME_MODE);
+            playerInfoEntry.setGameMode(entry.getGameMode());
+          }
+          playerInfoEntry.setLatency(entry.getLatency());
+          playerInfoEntry.setListed(entry.isListed());
+          if (entry.getListOrder() != 0
+                  && player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
+            actions.add(UpsertPlayerInfoPacket.Action.UPDATE_LIST_ORDER);
+            playerInfoEntry.setListOrder(entry.getListOrder());
+          }
+          if (!entry.isShowHat() && player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21_4)) {
+            actions.add(UpsertPlayerInfoPacket.Action.UPDATE_HAT);
+            playerInfoEntry.setShowHat(entry.isShowHat());
+          }
         }
-      } else {
-        actions.addAll(EnumSet.of(UpsertPlayerInfoPacket.Action.ADD_PLAYER,
-                UpsertPlayerInfoPacket.Action.UPDATE_LATENCY,
-                UpsertPlayerInfoPacket.Action.UPDATE_LISTED));
-        playerInfoEntry.setProfile(entry.getProfile());
-        if (entry.getDisplayNameComponent().isPresent()) {
-          actions.add(UpsertPlayerInfoPacket.Action.UPDATE_DISPLAY_NAME);
-          playerInfoEntry.setDisplayName(entry.getDisplayNameComponent().isEmpty()
-                  ?
-                  null :
-                  new ComponentHolder(player.getProtocolVersion(),
-                          entry.getDisplayNameComponent().get())
-          );
-        }
-        if (entry.getChatSession() != null) {
-          actions.add(UpsertPlayerInfoPacket.Action.INITIALIZE_CHAT);
-          ChatSession from = entry.getChatSession();
-          playerInfoEntry.setChatSession(
-                  new RemoteChatSession(from.getSessionId(), from.getIdentifiedKey()));
-        }
-        if (entry.getGameMode() != -1 && entry.getGameMode() != 256) {
-          actions.add(UpsertPlayerInfoPacket.Action.UPDATE_GAME_MODE);
-          playerInfoEntry.setGameMode(entry.getGameMode());
-        }
-        playerInfoEntry.setLatency(entry.getLatency());
-        playerInfoEntry.setListed(entry.isListed());
-        if (entry.getListOrder() != 0
-            && player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
-          actions.add(UpsertPlayerInfoPacket.Action.UPDATE_LIST_ORDER);
-          playerInfoEntry.setListOrder(entry.getListOrder());
-        }
-        if (!entry.isShowHat() && player.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_21_4)) {
-          actions.add(UpsertPlayerInfoPacket.Action.UPDATE_HAT);
-          playerInfoEntry.setShowHat(entry.isShowHat());
-        }
-      }
-      return entry;
-    });
+        return entry;
+      });
 
-    if (!actions.isEmpty()) {
-      this.connection.write(new UpsertPlayerInfoPacket(actions, List.of(playerInfoEntry)));
+      if (!actions.isEmpty()) {
+        batches.computeIfAbsent(actions, a -> new ArrayList<>()).add(playerInfoEntry);
+      }
     }
+
+    for (Map.Entry<EnumSet<UpsertPlayerInfoPacket.Action>, List<UpsertPlayerInfoPacket.Entry>> batch : batches.entrySet()) {
+      this.connection.write(new UpsertPlayerInfoPacket(batch.getKey(), batch.getValue()));
+    }
+  }
+
+  public void addEntries(TabListEntry... entries) {
+    addEntries(Arrays.asList(entries));
   }
 
   @Override
   public Optional<TabListEntry> removeEntry(UUID uuid) {
     this.connection.write(new RemovePlayerInfoPacket(List.of(uuid)));
     return Optional.ofNullable(this.entries.remove(uuid));
+  }
+
+  public Set<TabListEntry> removeEntries(Iterable<UUID> entries) {
+    this.connection.write(new RemovePlayerInfoPacket(Lists.newArrayList(entries)));
+    final Set<TabListEntry> removed = new HashSet<>();
+    for (UUID entry : entries) {
+      final TabListEntry removedEntry = this.entries.remove(entry);
+      if (removedEntry != null) {
+        removed.add(removedEntry);
+      }
+    }
+    return removed;
+  }
+
+  public Set<TabListEntry> removeEntries(UUID... entries) {
+    return removeEntries(List.of(entries));
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabList.java
@@ -208,6 +208,7 @@ public class VelocityTabList implements InternalTabList {
     }
   }
 
+  @Override
   public void addEntries(TabListEntry... entries) {
     addEntries(Arrays.asList(entries));
   }
@@ -218,6 +219,7 @@ public class VelocityTabList implements InternalTabList {
     return Optional.ofNullable(this.entries.remove(uuid));
   }
 
+  @Override
   public Set<TabListEntry> removeEntries(Iterable<UUID> entries) {
     this.connection.write(new RemovePlayerInfoPacket(Lists.newArrayList(entries)));
     final Set<TabListEntry> removed = new HashSet<>();
@@ -230,6 +232,7 @@ public class VelocityTabList implements InternalTabList {
     return removed;
   }
 
+  @Override
   public Set<TabListEntry> removeEntries(UUID... entries) {
     return removeEntries(List.of(entries));
   }


### PR DESCRIPTION
The Minecraft protocol supports adding/removing multiple entries from the tab list in a single packet (see [Player Info Update](https://minecraft.wiki/w/Java_Edition_protocol/Packets#Player_Info_Update) and [Player Info Remove](https://minecraft.wiki/w/Java_Edition_protocol/Packets#Player_Info_Remove)).

Currently, while Velocity does have an `addEntries` method on its `TabList`, the method currently processes each entry individually regardless of what entries are being updated.
https://github.com/PaperMC/Velocity/blob/a078053e26eff94b106afcaf594f9fde2897c592/api/src/main/java/com/velocitypowered/api/proxy/player/TabList.java#L53-L57

There are no subclasses of `TabList` which override this default behavior, meaning each individual tab list entry sends a separate packet, which is undesirable.

Similarly, `removeEntry` exists, but in this case there are no corresponding `removeEntries` methods, even though removing multiple entries is also supported (and trivial).

This PR attempts to address this by refactoring the existing code from `addEntry` to `addEntries` in `VelocityTabList`, where `addEntries` now handles batching tab list modifications into the least number of packets possible. It is not possible (to my knowledge, I'm happy to be corrected) to combine modifications that contain varying length player actions, as a restriction imposed by the protocol, since the actions must prefix the list of entries being updated. As a result, the existing `addEntry` method can simply delegate to `addEntries` passing only one entry. The `removeEntries` implementation is pretty straightforward, my goal there was simply to mirror the same kinds of overloads as `addEntries` has, and keep the same behavior of returning all of the removed `TabListEntry` instances.