### PR TITLE
Bump netty to 4.2.18.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ configurate3 = "3.7.3"
 configurate4 = "4.2.0"
 flare = "2.0.1"
 log4j = "2.26.1"
-netty = "4.2.16.Final"
+netty = "4.2.17.Final"
 
 [plugins]
 fill = "io.papermc.fill.gradle:1.0.12"


### PR DESCRIPTION
## 📝 Description
This PR upgrades Netty from `4.2.16.Final` to `4.2.17.Final`. 
This is a highly recommended security and bug-fix release by the upstream maintainers. 

## 🚀 Key Highlights for Velocity
* **Security Fixes**: Patches multiple CVEs, including algorithm inefficiency in `netty-handler` and memory exhaustion vulnerabilities, protecting the server from potential network-based attacks.
* **Stability & Performance**: 
  * Fixes a critical direct memory OOM (Out of Memory) issue on low-core containers.
  * Resolves buffer leaks in `SslHandler` and classloader leaks via `GlobalEventExecutor`.
* **Network & Compression**: Fixes an issue where `JdkZlibDecompressor` could lose the tail of highly compressible streams, which is crucial for reliable packet handling.

## 🔗 Related Links
* [Netty 4.2.17.Final Release Notes](https://netty.io/news/2026/08/04/4-2-17-Final.html)