### PR TITLE
Add opt-in client-online-mode-requires-matching-uuid option

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -444,6 +444,10 @@ public class VelocityConfiguration implements ProxyConfig {
     return this.advanced.isAcceptTransfers();
   }
 
+  public boolean isClientOnlineModeRequiresMatchingUuid() {
+    return this.advanced.isClientOnlineModeRequiresMatchingUuid();
+  }
+
   public boolean isForceKeyAuthentication() {
     return forceKeyAuthentication;
   }
@@ -777,6 +781,8 @@ public class VelocityConfiguration implements ProxyConfig {
     @Expose
     private boolean acceptTransfers = false;
     @Expose
+    private boolean clientOnlineModeRequiresMatchingUuid = false;
+    @Expose
     private boolean enableReusePort = false;
     @Expose
     private int commandRateLimit = 50;
@@ -813,6 +819,8 @@ public class VelocityConfiguration implements ProxyConfig {
         this.logCommandExecutions = config.getOrElse("log-command-executions", false);
         this.logPlayerConnections = config.getOrElse("log-player-connections", true);
         this.acceptTransfers = config.getOrElse("accepts-transfers", false);
+        this.clientOnlineModeRequiresMatchingUuid = config.getOrElse(
+            "client-online-mode-requires-matching-uuid", false);
         this.enableReusePort = config.getOrElse("enable-reuse-port", false);
         this.commandRateLimit = config.getIntOrElse("command-rate-limit", 25);
         this.forwardCommandsIfRateLimited = config.getOrElse("forward-commands-if-rate-limited", true);
@@ -882,6 +890,10 @@ public class VelocityConfiguration implements ProxyConfig {
       return this.acceptTransfers;
     }
 
+    public boolean isClientOnlineModeRequiresMatchingUuid() {
+      return this.clientOnlineModeRequiresMatchingUuid;
+    }
+
     public boolean isEnableReusePort() {
       return enableReusePort;
     }
@@ -923,6 +935,7 @@ public class VelocityConfiguration implements ProxyConfig {
           + ", logCommandExecutions=" + logCommandExecutions
           + ", logPlayerConnections=" + logPlayerConnections
           + ", acceptTransfers=" + acceptTransfers
+          + ", clientOnlineModeRequiresMatchingUuid=" + clientOnlineModeRequiresMatchingUuid
           + ", enableReusePort=" + enableReusePort
           + '}';
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/TransitionSessionHandler.java
@@ -107,7 +107,7 @@ public class TransitionSessionHandler implements MinecraftSessionHandler {
     player.clearPlayerListHeaderAndFooter();
 
     // Override online mode
-    packet.setOnlineMode(player.isOnlineMode());
+    packet.setOnlineMode(player.isClientOnlineMode());
 
     // The goods are in hand! We got JoinGame. Let's transition completely to the new state.
     smc.setAutoReading(false);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/AuthSessionHandler.java
@@ -99,6 +99,7 @@ public class AuthSessionHandler implements MinecraftSessionHandler {
       // Initiate a regular connection and move over to it.
       ConnectedPlayer player = new ConnectedPlayer(server, profileEvent.getGameProfile(),
           mcConnection, inbound.getVirtualHost().orElse(null), inbound.getRawVirtualHost().orElse(null), onlineMode,
+          onlineMode ? finalProfile.getId() : null,
           inbound.getHandshakeIntent(), inbound.getIdentifiedKey());
       this.connectedPlayer = player;
       if (!server.canRegisterConnection(player)) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -57,8 +57,11 @@ import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.util.GameProfile;
 import com.velocitypowered.api.util.ModInfo;
 import com.velocitypowered.api.util.ServerLink;
+import com.velocitypowered.api.util.UuidUtils;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.adventure.VelocityBossBarImplementation;
+import com.velocitypowered.proxy.config.PlayerInfoForwarding;
+import com.velocitypowered.proxy.config.VelocityConfiguration;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftConnectionAssociation;
 import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
@@ -178,6 +181,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   private int tryIndex = 0;
   private long ping = -1;
   private final boolean onlineMode;
+  private final @Nullable UUID authenticatedId;
   private @Nullable VelocityServerConnection connectedServer;
   private @Nullable VelocityServerConnection connectionInFlight;
   private @Nullable PlayerSettings settings;
@@ -204,6 +208,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
 
   ConnectedPlayer(VelocityServer server, GameProfile profile, MinecraftConnection connection,
                   @Nullable InetSocketAddress virtualHost, @Nullable String rawVirtualHost, boolean onlineMode,
+                  @Nullable UUID authenticatedId,
                   HandshakeIntent handshakeIntent, @Nullable IdentifiedKey playerKey) {
     this.server = server;
     this.profile = profile;
@@ -214,6 +219,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
     this.permissionFunction = PermissionFunction.ALWAYS_UNDEFINED;
     this.connectionPhase = connection.getType().getInitialClientPhase();
     this.onlineMode = onlineMode;
+    this.authenticatedId = authenticatedId;
     this.clientsideChannels = CappedSet.create(MAX_CLIENTSIDE_PLUGIN_CHANNELS);
 
     if (connection.getProtocolVersion().noLessThan(ProtocolVersion.MINECRAFT_1_19_3)) {
@@ -329,6 +335,31 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player, 
   @Override
   public boolean isOnlineMode() {
     return onlineMode;
+  }
+
+  /**
+   * Returns whether the client is told that it plays on an online-mode server. This equals
+   * {@link #isOnlineMode()} unless {@code client-online-mode-requires-matching-uuid} is enabled and
+   * the UUID the backend sees no longer matches the Mojang session the client authenticated with,
+   * because a plugin rewrote the profile or because player info forwarding is disabled.
+   *
+   * @return whether the client should treat this connection as online-mode
+   */
+  public boolean isClientOnlineMode() {
+    VelocityConfiguration configuration = server.getConfiguration();
+    return isClientOnlineMode(onlineMode, configuration.isClientOnlineModeRequiresMatchingUuid(),
+        configuration.getPlayerInfoForwardingMode(), getUsername(), getUniqueId(), authenticatedId);
+  }
+
+  static boolean isClientOnlineMode(boolean onlineMode, boolean requireMatchingUuid,
+      PlayerInfoForwarding forwardingMode, String username, UUID uniqueId,
+      @Nullable UUID authenticatedId) {
+    if (!onlineMode || !requireMatchingUuid) {
+      return onlineMode;
+    }
+    UUID effectiveId = forwardingMode == PlayerInfoForwarding.NONE
+        ? UuidUtils.generateOfflinePlayerUuid(username) : uniqueId;
+    return effectiveId.equals(authenticatedId);
   }
 
   @Override

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -160,6 +160,14 @@ log-player-connections = true
 # Transfer packet (Minecraft 1.20.5) to be received.
 accepts-transfers = false
 
+# Since Minecraft 26.2 the client is told whether it plays on an online-mode server and bases its
+# identity handling on that (chat signing keys, tab list heads, Mojang lookups). By default Velocity
+# reports the connection's real online-mode state. Enable this to report "offline" instead whenever
+# the UUID the backend sees no longer matches the Mojang session the client authenticated with,
+# i.e. a plugin rewrote the profile UUID (premium auto-login keeping offline UUIDs) or player info
+# forwarding is disabled. Players who logged in offline are not affected.
+client-online-mode-requires-matching-uuid = false
+
 # Enables support for SO_REUSEPORT. This may help the proxy scale better on multicore systems
 # with a lot of incoming connections, and provide better CPU utilization than the existing
 # strategy of having a single thread accepting connections and distributing them to worker

--- a/proxy/src/test/java/com/velocitypowered/proxy/connection/client/ConnectedPlayerClientOnlineModeTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/connection/client/ConnectedPlayerClientOnlineModeTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018-2026 Velocity Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.velocitypowered.proxy.connection.client;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.velocitypowered.api.util.UuidUtils;
+import com.velocitypowered.proxy.config.PlayerInfoForwarding;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ConnectedPlayerClientOnlineModeTest {
+
+  private static final UUID MOJANG_ID = UUID.fromString("8d6d0684-d8b4-4d40-8d2d-0dd4df5555c8");
+  private static final UUID OFFLINE_ID = UuidUtils.generateOfflinePlayerUuid("Alice");
+
+  @Test
+  void offlinePlayerIsNeverReportedOnline() {
+    assertFalse(clientOnlineMode(false, true, PlayerInfoForwarding.MODERN, OFFLINE_ID, null));
+    assertFalse(clientOnlineMode(false, false, PlayerInfoForwarding.MODERN, OFFLINE_ID, null));
+  }
+
+  @Test
+  void reportsRealOnlineModeWhenOptionIsDisabled() {
+    assertTrue(clientOnlineMode(true, false, PlayerInfoForwarding.MODERN, OFFLINE_ID, MOJANG_ID));
+    assertTrue(clientOnlineMode(true, false, PlayerInfoForwarding.NONE, MOJANG_ID, MOJANG_ID));
+  }
+
+  @Test
+  void staysOnlineWhenProfileUuidMatchesSession() {
+    assertTrue(clientOnlineMode(true, true, PlayerInfoForwarding.MODERN, MOJANG_ID, MOJANG_ID));
+  }
+
+  @Test
+  void reportsOfflineWhenPluginRewroteUuid() {
+    assertFalse(clientOnlineMode(true, true, PlayerInfoForwarding.MODERN, OFFLINE_ID, MOJANG_ID));
+  }
+
+  @Test
+  void reportsOfflineWhenForwardingIsDisabled() {
+    // Without forwarding the backend derives the offline UUID itself, whatever the profile says
+    assertFalse(clientOnlineMode(true, true, PlayerInfoForwarding.NONE, MOJANG_ID, MOJANG_ID));
+  }
+
+  private static boolean clientOnlineMode(boolean onlineMode, boolean requireMatchingUuid,
+      PlayerInfoForwarding forwarding, UUID uniqueId, UUID authenticatedId) {
+    return ConnectedPlayer.isClientOnlineMode(onlineMode, requireMatchingUuid, forwarding, "Alice",
+        uniqueId, authenticatedId);
+  }
+}


### PR DESCRIPTION
Related issue: [#1875](https://github.com/PaperMC/Velocity/issues/1875).

Since 26.2, Velocity sets the client-facing `onlineMode` flag from
`Player#isOnlineMode()`. After a plugin replaces an authenticated player's
UUID with an offline UUID, that flag no longer reflects the in-game
identity. Disabled player info forwarding causes the same mismatch.

Add `advanced.client-online-mode-requires-matching-uuid` (default `false`).
When enabled, report client-facing offline-mode if the effective backend
UUID differs from the authenticated Mojang UUID. Authentication, player
UUIDs, and `Player#isOnlineMode()` remain unchanged.

This works with existing plugins without API changes and also covers
disabled forwarding. A plugin API can follow separately.
